### PR TITLE
geoips#6 geoips - Streamline installation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*diff_test_output_dir*
+*diff_test_output*
+*.pyc
+*.o
+*.log
+*.swp
+.vscode
+geoips.egg-info
+*.simg
+*.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@
     # # # See the included license for more details.
 
 
+NRLMMD-GEOIPS/geoips#6,8,9 - Streamline installation process
+
+### Installation and Test
+* **base_install_and_test.sh**
+    * Exit immediately if GEOIPS_BASEDIR or GEOIPS_REPO_URL are not defined
+    * Comment out several sections of installation, to reduce time and disk space
+        * natural-earth-vector data download (will rely on latest shapefiles during cartopy processing)
+        * natural-earth-vector linking to ~/.local/share/cartopy
+            * Will NOT reinstate this step - cartopy supports CARTOPY_DATA_DIR as of 6 August 2021
+        * vim8 installation (only for use of vim8 plugins to help with following style guides)
+        * vim8 plugin installation
+        * seviri setup
+    * Remove BASECONDAPATH from conda cartopy installation (conda will be in PATH)
+* **README.md**
+    * Update github.com GEOIPS_ACTIVE_BRANCH from dev to main
+
+
 # v1.5.1: 2022-07-13, fix overpass error handling, fix ticklabels error, add area_def_adjuster outputs, update test rm
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ NRLMMD-GEOIPS/geoips#6,8,9 - Streamline installation process
         * vim8 plugin installation
         * seviri setup
     * Remove BASECONDAPATH from conda cartopy installation (conda will be in PATH)
+    * Update default branch from dev to main
 * **README.md**
     * Update github.com GEOIPS_ACTIVE_BRANCH from dev to main
+* **setup.sh**
+    * Update default branches from dev to main
 
 
 # v1.5.1: 2022-07-13, fix overpass error handling, fix ticklabels error, add area_def_adjuster outputs, update test rm

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Setup System Environment Variables
     # This config file must be sourced ANY TIME you want to run geoips
     export GEOIPS_CONFIG_FILE=$GEOIPS_BASEDIR/geoips_packages/geoips/setup/config_geoips
 
-    GEOIPS_ACTIVE_BRANCH=dev
+    GEOIPS_ACTIVE_BRANCH=main
 ```
 
 

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -24,8 +24,6 @@ check_continue() {
         echo ""
         echo ""
         echo "Just completed '$1'"
-        echo "Next run '$2'"
-        echo ""
         echo "Y or y to perform '$2'"
         echo "K or k to skip '$2' but continue to following step"
         echo "Q or q to quit installation altogether?"
@@ -54,6 +52,13 @@ else
     GEOIPS_ACTIVE_BRANCH=$1
 fi
     
+if [[ "$GEOIPS_BASEDIR" == "" ]]; then
+    echo "Must set GEOIPS_BASEDIR environment variable prior to installation"
+    exit 1
+fi
+
+# This checks/sets required environment variables for setup - without requiring sourcing a geoips config in advance
+. $GEOIPS_BASEDIR/geoips_packages/geoips/setup/repo_clone_update_install.sh setup
 
     echo ""
     echo "NOTE Approximately 30GB disk space / 10GB memory required for complete installation and test"
@@ -71,9 +76,9 @@ fi
     echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
     echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
     echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-    echo ""
+    echo "    which conda (should not exist yet): "`which conda`
 
-check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIVE_BRANCH" "clone geoips"
+check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIVE_BRANCH" "update geoips repo to $GEOIPS_ACTIVE_BRANCH"
 
     if [[ "$skip_next" == "no" ]]; then
         # Initial clone of geoips repo, to obtain setup scripts
@@ -95,7 +100,7 @@ check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIV
         echo "    which conda (should not exist yet!): "`which conda`
     fi
 
-check_continue "cloning geoips repo" "install conda"
+check_continue "updating geoips" "install conda"
 
     if [[ "$skip_next" == "no" ]]; then
         # Install conda

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -95,7 +95,7 @@ check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIV
         echo "    which conda (should not exist yet!): "`which conda`
     fi
 
-check_continue "cloning geoip2 repo" "install conda"
+check_continue "cloning geoips repo" "install conda"
 
     if [[ "$skip_next" == "no" ]]; then
         # Install conda
@@ -149,36 +149,46 @@ check_continue "creating geoips_conda_env (should point to $GEOIPS_BASEDIR/geoip
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
     fi
 
-check_continue "install geoips and dependencies" "Download cartopy natural earth data (REQUIRED for successful test returns, but takes ~10min and ~16GB to download)"
+# Only required to ensure shapefiles match for valid cartopy-based test outputs
+# Not required if:
+#   1. We recently updated the test repo outputs to use the latest shapefiles
+#   2. We are comparing test outputs that do *not* incorporate cartopy-based coastlines, gridlines, etc
+# Currently assuming test outputs are up-to-date with the latest shapefiles (updated June 2022)
+## check_continue "install geoips and dependencies" "Download cartopy natural earth data (REQUIRED for successful test returns, but takes ~10min and ~16GB to download)"
+## 
+##     if [[ "$skip_next" == "no" ]]; then
+## 
+##         source $GEOIPS_CONFIG_FILE
+##         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh download_cartopy_natural_earth
+## 
+##         echo ""
+##         echo "Confirm environment variables point to desired installation parameters:"
+##         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+##         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+##         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+##         echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
+##         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+##     fi
 
-    if [[ "$skip_next" == "no" ]]; then
-
-        source $GEOIPS_CONFIG_FILE
-        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh download_cartopy_natural_earth
-
-        echo ""
-        echo "Confirm environment variables point to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-    fi
-
-check_continue "Downloading cartopy natural earth data" "Link cartopy natural earth data to ~/.local/share/cartopy (to ensure cartopy uses the correct shapefiles in order for test outputs to match exactly)"
-
-    if [[ "$skip_next" == "no" ]]; then
-        source $GEOIPS_CONFIG_FILE
-        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh link_cartopy_natural_earth
-
-        echo ""
-        echo "Confirm environment variables point to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-    fi
+# NOTE: This was previously required when cartopy had ~/.local hardcoded in as the primary location to search for shapefiles
+#   https://scitools.org.uk/cartopy/docs/latest/reference/config.html
+# As of August 6, 2021, you can set CARTOPY_DATA_DIR and it will look there for shapefiles, so we will not have to do
+#   the hokey linking to ~/.local anyway!!
+#   https://github.com/SciTools/cartopy/commit/300b8c32d411c25b6c2d2ca3bc73794761fb932b
+## check_continue "Downloading cartopy natural earth data" "Link cartopy natural earth data to ~/.local/share/cartopy (to ensure cartopy uses the correct shapefiles in order for test outputs to match exactly)"
+## 
+##     if [[ "$skip_next" == "no" ]]; then
+##         source $GEOIPS_CONFIG_FILE
+##         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh link_cartopy_natural_earth
+## 
+##         echo ""
+##         echo "Confirm environment variables point to desired installation parameters:"
+##         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+##         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+##         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+##         echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
+##         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+##     fi
 
 check_continue "installing geoips dependencies" "install rclone (REQUIRED for test script)"
     if [[ "$skip_next" == "no" ]]; then
@@ -206,35 +216,35 @@ check_continue "installing rclone" "OPTIONAL install seviri libraries (required 
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
     fi
 
-# check_continue "installing seviri libraries" "OPTIONAL install vim8"
-# 
-#     if [[ "$skip_next" == "no" ]]; then
-#         source $GEOIPS_CONFIG_FILE
-#         $GEOIPS/setup.sh setup_vim8  # vim syntax highlighting
-# 
-#         echo ""
-#         echo "Confirm environment variables point to desired installation parameters:"
-#         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-#         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-#         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-#         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-#         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-#     fi
+## check_continue "installing seviri libraries" "OPTIONAL install vim8"
+## 
+##     if [[ "$skip_next" == "no" ]]; then
+##         source $GEOIPS_CONFIG_FILE
+##         $GEOIPS/setup.sh setup_vim8  # vim syntax highlighting
+## 
+##         echo ""
+##         echo "Confirm environment variables point to desired installation parameters:"
+##         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+##         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+##         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+##         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+##         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+##     fi
 
-# check_continue "installing vim8" "OPTIONAL install vim8 plugins (updates ~/.vim and ~/.vimrc to set up syntax highlighting based on geoips style guide)"
-# 
-#     if [[ "$skip_next" == "no" ]]; then
-#         source $GEOIPS_CONFIG_FILE
-#         $GEOIPS/setup.sh setup_vim8_plugins  # vim syntax highlighting
-# 
-#         echo ""
-#         echo "Confirm environment variables point to desired installation parameters:"
-#         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-#         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-#         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-#         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-#         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-#     fi
+## check_continue "installing vim8" "OPTIONAL install vim8 plugins (updates ~/.vim and ~/.vimrc to set up syntax highlighting based on geoips style guide)"
+## 
+##     if [[ "$skip_next" == "no" ]]; then
+##         source $GEOIPS_CONFIG_FILE
+##         $GEOIPS/setup.sh setup_vim8_plugins  # vim syntax highlighting
+## 
+##         echo ""
+##         echo "Confirm environment variables point to desired installation parameters:"
+##         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+##         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+##         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+##         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+##         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+##     fi
 
 check_continue "installing geoips, cartopy data, dependencies, and external packages" "run basic test script"
 

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -81,6 +81,7 @@ fi
 check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIVE_BRANCH" "update geoips repo to $GEOIPS_ACTIVE_BRANCH"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         # Initial clone of geoips repo, to obtain setup scripts
         mkdir -p $GEOIPS_BASEDIR/geoips_packages
         git clone $GEOIPS_REPO_URL/geoips.git $GEOIPS_BASEDIR/geoips_packages/geoips
@@ -98,11 +99,13 @@ check_continue "verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIV
         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
         echo "    which conda (should not exist yet!): "`which conda`
+        date -u
     fi
 
 check_continue "updating geoips" "install conda"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         # Install conda
         # Do not initialize your shell at the end, to allow switching between versions!!!
         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh conda_install
@@ -120,11 +123,13 @@ check_continue "updating geoips" "install conda"
         echo "    which conda (point to geoips_dependencies/miniconda3): "`which conda`
         echo "    which pip (point to geoips_dependencies/miniconda3):   "`which conda`
         echo "    which python (point to geoips_dependencies/miniconda3):     "`which python`
+        date -u
     fi
 
 check_continue "installing conda (should point to $GEOIPS_BASEDIR/geoips_dependencies/miniconda3)" "create geoips_conda_env"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         # Create geoips conda environment
         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh conda_update  # only for a fresh Miniconda install
         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh create_geoips_conda_env
@@ -137,11 +142,13 @@ check_continue "installing conda (should point to $GEOIPS_BASEDIR/geoips_depende
         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
         echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+        date -u
     fi
 
 check_continue "creating geoips_conda_env (should point to $GEOIPS_BASEDIR/geoips_dependencies/miniconda3/envs/geoips_conda)" "install geoips and dependencies"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         # Actually install geoips and all dependencies (cartopy, etc)
         source $GEOIPS_CONFIG_FILE
         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh install
@@ -152,6 +159,7 @@ check_continue "creating geoips_conda_env (should point to $GEOIPS_BASEDIR/geoip
         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
         echo "    which conda (should point to geoips_dependencies/bin): "`which conda`
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+        date -u
     fi
 
 # Only required to ensure shapefiles match for valid cartopy-based test outputs
@@ -197,6 +205,7 @@ check_continue "creating geoips_conda_env (should point to $GEOIPS_BASEDIR/geoip
 
 check_continue "installing geoips dependencies" "install rclone (REQUIRED for test script)"
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         source $GEOIPS_CONFIG_FILE
         $GEOIPS/setup.sh setup_rclone # abi/ahi ingest
         echo ""
@@ -206,20 +215,21 @@ check_continue "installing geoips dependencies" "install rclone (REQUIRED for te
         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+        date -u
     fi
 
-check_continue "installing rclone" "OPTIONAL install seviri libraries (required for seviri HRIT processing)"
-    if [[ "$skip_next" == "no" ]]; then
-        source $GEOIPS_CONFIG_FILE
-        $GEOIPS/setup.sh setup_seviri
-        echo ""
-        echo "Confirm environment variables point to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-    fi
+## check_continue "installing rclone" "OPTIONAL install seviri libraries (required for seviri HRIT processing)"
+##     if [[ "$skip_next" == "no" ]]; then
+##         source $GEOIPS_CONFIG_FILE
+##         $GEOIPS/setup.sh setup_seviri
+##         echo ""
+##         echo "Confirm environment variables point to desired installation parameters:"
+##         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+##         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+##         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+##         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+##         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+##     fi
 
 ## check_continue "installing seviri libraries" "OPTIONAL install vim8"
 ## 
@@ -254,6 +264,7 @@ check_continue "installing rclone" "OPTIONAL install seviri libraries (required 
 check_continue "installing geoips, cartopy data, dependencies, and external packages" "run basic test script"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         source $GEOIPS_CONFIG_FILE
         $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh setup_abi_test_data
         $GEOIPS/tests/test_base_install.sh
@@ -268,11 +279,13 @@ check_continue "installing geoips, cartopy data, dependencies, and external pack
         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+        date -u
     fi
 
 check_continue "Installing and testing geoips" "Obtain amsr2 test data repository"
 
     if [[ "$skip_next" == "no" ]]; then
+        date -u
         source $GEOIPS_CONFIG_FILE
         mkdir -p $GEOIPS_TESTDATA_DIR
         git clone $GEOIPS_REPO_URL/test_data_amsr2.git $GEOIPS_TESTDATA_DIR/test_data_amsr2
@@ -280,12 +293,13 @@ check_continue "Installing and testing geoips" "Obtain amsr2 test data repositor
         git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 checkout -t origin/$GEOIPS_ACTIVE_BRANCH
         git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 checkout $GEOIPS_ACTIVE_BRANCH
         git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 pull
+        date -u
     fi
 
-        echo "Confirm environment variables pointed to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+echo "Confirm environment variables pointed to desired installation parameters:"
+echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
 check_continue "Installing and testing geoips" "Done with base installation and test!"

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -47,7 +47,7 @@ check_continue() {
 }
 
 if [[ "$1" == "" ]]; then
-    GEOIPS_ACTIVE_BRANCH=dev
+    GEOIPS_ACTIVE_BRANCH=main
 else
     GEOIPS_ACTIVE_BRANCH=$1
 fi

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -261,6 +261,31 @@ check_continue "installing geoips, cartopy data, dependencies, and external pack
 
         echo ""
         echo "full return: $retval"
+        echo ""
+        echo "Confirm environment variables pointed to desired installation parameters:"
+        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
     fi
 
+check_continue "Installing and testing geoips" "Obtain amsr2 test data repository"
+
+    if [[ "$skip_next" == "no" ]]; then
+        source $GEOIPS_CONFIG_FILE
+        mkdir -p $GEOIPS_TESTDATA_DIR
+        git clone $GEOIPS_REPO_URL/test_data_amsr2.git $GEOIPS_TESTDATA_DIR/test_data_amsr2
+        git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 pull
+        git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 checkout -t origin/$GEOIPS_ACTIVE_BRANCH
+        git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 checkout $GEOIPS_ACTIVE_BRANCH
+        git -C $GEOIPS_TESTDATA_DIR/test_data_amsr2 pull
+    fi
+
+        echo "Confirm environment variables pointed to desired installation parameters:"
+        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
 check_continue "Installing and testing geoips" "Done with base installation and test!"

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -180,7 +180,7 @@ check_continue "Downloading cartopy natural earth data" "Link cartopy natural ea
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
     fi
 
-check_continue "installing cartopy data" "install rclone (REQUIRED for test script)"
+check_continue "installing geoips dependencies" "install rclone (REQUIRED for test script)"
     if [[ "$skip_next" == "no" ]]; then
         source $GEOIPS_CONFIG_FILE
         $GEOIPS/setup.sh setup_rclone # abi/ahi ingest
@@ -206,35 +206,35 @@ check_continue "installing rclone" "OPTIONAL install seviri libraries (required 
         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
     fi
 
-check_continue "installing seviri libraries" "OPTIONAL install vim8"
+# check_continue "installing seviri libraries" "OPTIONAL install vim8"
+# 
+#     if [[ "$skip_next" == "no" ]]; then
+#         source $GEOIPS_CONFIG_FILE
+#         $GEOIPS/setup.sh setup_vim8  # vim syntax highlighting
+# 
+#         echo ""
+#         echo "Confirm environment variables point to desired installation parameters:"
+#         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+#         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+#         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+#         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+#         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+#     fi
 
-    if [[ "$skip_next" == "no" ]]; then
-        source $GEOIPS_CONFIG_FILE
-        $GEOIPS/setup.sh setup_vim8  # vim syntax highlighting
-
-        echo ""
-        echo "Confirm environment variables point to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-    fi
-
-check_continue "installing vim8" "OPTIONAL install vim8 plugins (updates ~/.vim and ~/.vimrc to set up syntax highlighting based on geoips style guide)"
-
-    if [[ "$skip_next" == "no" ]]; then
-        source $GEOIPS_CONFIG_FILE
-        $GEOIPS/setup.sh setup_vim8_plugins  # vim syntax highlighting
-
-        echo ""
-        echo "Confirm environment variables point to desired installation parameters:"
-        echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
-        echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
-        echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
-        echo "    which conda (should point geoips_dependencies/bin): "`which conda`
-        echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
-    fi
+# check_continue "installing vim8" "OPTIONAL install vim8 plugins (updates ~/.vim and ~/.vimrc to set up syntax highlighting based on geoips style guide)"
+# 
+#     if [[ "$skip_next" == "no" ]]; then
+#         source $GEOIPS_CONFIG_FILE
+#         $GEOIPS/setup.sh setup_vim8_plugins  # vim syntax highlighting
+# 
+#         echo ""
+#         echo "Confirm environment variables point to desired installation parameters:"
+#         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
+#         echo "    GEOIPS_CONFIG_FILE:   $GEOIPS_CONFIG_FILE"
+#         echo "    GEOIPS_ACTIVE_BRANCH: $GEOIPS_ACTIVE_BRANCH"
+#         echo "    which conda (should point geoips_dependencies/bin): "`which conda`
+#         echo "    which python (should point to miniconda3 envs/geoips_conda): "`which python`
+#     fi
 
 check_continue "installing geoips, cartopy data, dependencies, and external packages" "run basic test script"
 

--- a/setup.sh
+++ b/setup.sh
@@ -91,7 +91,7 @@ elif [[ "$1" == "install" ]]; then
     # This was getting 0.18.0 sometimes without specifying version ???  Force to 0.20.0
 
     # Update to latest 20220607, previously cartopy 0.20.2 and matplotlib 3.4.3.
-    $BASECONDAPATH/conda install -c conda-forge "cartopy>=0.20.2" "matplotlib>=3.5.2" --yes
+    conda install -c conda-forge "cartopy>=0.20.2" "matplotlib>=3.5.2" --yes
 
     pip install -e "$GEOIPS_PACKAGES_DIR/geoips[efficiency_improvements,\
                                                   test_outputs,\

--- a/setup.sh
+++ b/setup.sh
@@ -250,7 +250,7 @@ elif [[ "$1" =~ "clone_test_repo" ]]; then
     fi
 elif [[ "$1" =~ "update_test_repo" ]]; then
     if [[ "$3" == "" ]]; then
-        branch=dev
+        branch=main
     else
         branch=$3
     fi
@@ -359,7 +359,7 @@ elif [[ "$1" =~ "clone_source_repo" ]]; then
     fi
 elif [[ "$1" =~ "update_source_repo" ]]; then
     if [[ "$3" == "" ]]; then
-        branch=dev
+        branch=main
     else
         branch=$3
     fi


### PR DESCRIPTION
# Related Issue
NRLMMD-GEOIPS/geoips#6
NRLMMD-GEOIPS/geoips#8
NRLMMD-GEOIPS/geoips#9

# Reviewer Checklist

### Ensure you are logged into GitHub

### Confirm all requirements are met for pull request
* Ensure appropriate / sufficient content
    * **Title format**: geoips#<issue_num> <modified_repo_name> - \<Short description>
        * Example: geoips#8 geoips_template_plugin - Updating GEOIPS_REPO_URL to github
    * **Included Issue**: Link to related Issue included at the beginning of pull request
        * Example: GEOIPS/geoips#8
    * **CHANGELOG updated**: Functionality included in pull request is ALSO referenced in CHANGELOG.md
    * **Demonstrated Testing**: Proper testing / output was demonstrated for functionality updates
    * **Included Outputs**: Imagery is included in "Output" section for new or changed product outputs (for reports!)
* Ensure all appropriate tags / attributes added along right-hand side of pull request
    * **Label**: Issue ID Label, with color #00FF00 (bright green): geoips#<issue_num>
        * Example: geoips#8
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link above)
    * **Check Issue Label**: Issue ID label added to Issue in bright green
    
### Once all items in checklist have been confirmed:
* **Approve pull request**
    * Click "Files changed" tab
    * Click green "Review changes" button
    * Select "Approve" option
    * Add message if desired
    * Click green "Submit review" button
    * Project status will automatically be updated in Project "GeoIPS2 - All Repos and All Functionality" when pull request is approved.
 
# Testing Instructions
Follow complete installation instructions in 
https://github.com/NRLMMD-GEOIPS/geoips/blob/main/README.md

Notes on pre-installation:
1. Should work with existing conda either activated in .bashrc, or not
2. Should remove all shapefiles from ~/.local/share/cartopy (so they are auto downloaded during processing)

# Summary

NRLMMD-GEOIPS/geoips#6,8,9 - Streamline installation process

### Installation and Test
* **base_install_and_test.sh**
    * Exit immediately if GEOIPS_BASEDIR or GEOIPS_REPO_URL are not defined
    * Comment out several sections of installation, to reduce time and disk space
        * natural-earth-vector data download (will rely on latest shapefiles during cartopy processing)
        * natural-earth-vector linking to ~/.local/share/cartopy
            * Will NOT reinstate this step - cartopy supports CARTOPY_DATA_DIR as of 6 August 2021
        * vim8 installation (only for use of vim8 plugins to help with following style guides)
        * vim8 plugin installation
        * seviri setup
    * Remove BASECONDAPATH from conda cartopy installation (conda will be in PATH)
* **README.md**
    * Update github.com GEOIPS_ACTIVE_BRANCH from dev to main


# Output
GEOIPS_BASEDIR and GEOIPS_REPO_URL environment variable checking:
```
bash$ unset GEOIPS_BASEDIR
bash$ ./base_install_and_test.sh
Must set GEOIPS_BASEDIR environment variable prior to installation

bash$ export GEOIPS_BASEDIR=~/geoproc; unset GEOIPS_REPO_URL
bash$ ./base_install_and_test.sh
Must defined GEOIPS_REPO_URL environment variable prior to setting up geoips

bash$ export GEOIPS_BASEDIR=~/geoproc; export GEOIPS_REPO_URL=https://github.com/NRLMMD-GEOIPS
bash$ ./base_install_and_test.sh
NOTE Approximately 30GB disk space / 10GB memory required for complete installation and test
NOTE Expert users can install piece meal to avoid this time consuming installation process (>1h)
     This full installation installs ALL dependencies from scratch,
     to ensure a consistent environment for successful test returns
     This includes
          * Full Miniconda installation
          * full cartopy coastline and political borders information
          * ABI test datasets
          * vim8 installation with syntax highlighting to encourage following style guide
Confirm environment variables point to desired installation parameters:
    GEOIPS_BASEDIR:       /users/surratt/geoproc
    GEOIPS_CONFIG_FILE:   /users/surratt/geoproc/geoips_packages/geoips/setup/config_geoips
    GEOIPS_ACTIVE_BRANCH: dev
    which conda (should not exist yet): /users/surratt/geoproc/geoips_dependencies/bin/conda
Just completed 'verifying GEOIPS_BASEDIR and GEOIPS_CONFIG_FILE and GEOIPS_ACTIVE_BRANCH'
Y or y to perform 'update geoips repo to dev'
K or k to skip 'update geoips repo to dev' but continue to following step
Q or q to quit installation altogether?
[y/k/q]:
```

Python environment after install:
```
# Old conda initialized in .bashrc
bash$ which python
/anaconda3/bin/python
bash$ source ~/geoproc/geoips_packages/geoips/setup/config_geoips
bash$ which python
~/geoproc/geoips_dependencies/miniconda3/envs/geoips_conda/bin/python

```

Auto-download of shapefiles:
```
27_151951    mpl_utils 156   INFO: Writing geoips_outdirs/preprocessed/tcwww/tc2020/AL/AL202020/png/IR-BD/goes-16/20200918_195020_AL202020_abi_goes-16_IR-BD_110kts_100p00_1p0.png
geoips_dependencies/miniconda3/envs/geoips_conda/lib/python3.9/site-packages/cartopy/io/__init__.py:241: DownloadWarning: Downloading: https://naturalearth.s3.amazonaws.com/10m_physical/ne_10m_coastline.zip
  warnings.warn(f'Downloading: {url}', DownloadWarning)
geoips_dependencies/miniconda3/envs/geoips_conda/lib/python3.9/site-packages/cartopy/io/__init__.py:241: DownloadWarning: Downloading: https://naturalearth.s3.amazonaws.com/10m_cultural/ne_10m_admin_0_boundary_line
  warnings.warn(f'Downloading: {url}', DownloadWarning)
geoips_dependencies/miniconda3/envs/geoips_conda/lib/python3.9/site-packages/cartopy/io/__init__.py:241: DownloadWarning: Downloading: https://naturalearth.s3.amazonaws.com/10m_cultural/ne_10m_admin_1_states_provin
  warnings.warn(f'Downloading: {url}', DownloadWarning)
geoips_dependencies/miniconda3/envs/geoips_conda/lib/python3.9/site-packages/cartopy/io/__init__.py:241: DownloadWarning: Downloading: https://naturalearth.s3.amazonaws.com/10m_physical/ne_10m_rivers_lake_centerlin
  warnings.warn(f'Downloading: {url}', DownloadWarning)
```

Final 0 return:
```
Package: geoips_base
Total run time: 422 seconds
Number data types run: 3
Number data types failed: 0

full return: 0
```