### PR TITLE
geoips#22 geoips - remove rcloneconf link to configrclonercloneconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
     # # # See the included license for more details.
 
 
+NRLMMD-GEOIPS/geoips#22 - Remove rclone.conf link to ~/.config/rclone
+
+### Installation and Test
+* **setup.sh**
+    * Update setup_rclone command to remove the link from $GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
+        to ~/.config/rclone/rclone.conf
+    * Update setup_abi_test_data command to use explicit
+        --config $GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
+        argument rather than relying on default ~/.config/rclone/rclone.conf configuration
+
+
 NRLMMD-GEOIPS/geoips#15 - Add low memory options for base install tests
 
 ### Test Repo Updates

--- a/setup.sh
+++ b/setup.sh
@@ -125,22 +125,24 @@ elif [[ "$1" == "setup_abi_test_data" ]]; then
     echo `date -u` "from https://registry.opendata.aws/noaa-goes."
     echo ""
 
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc $abidir
-    rclone copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc $abidir
+    rcloneconf=$GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
+
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc $abidir
+    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc $abidir
 
 elif [[ "$1" == "setup_seviri" ]]; then
     mkdir -p $GEOIPS_DEPENDENCIES_DIR/seviri_wavelet
@@ -151,6 +153,7 @@ elif [[ "$1" == "setup_seviri" ]]; then
     make all -C $GEOIPS_DEPENDENCIES_DIR/seviri_wavelet/PublicDecompWT/xRITDecompress
     mkdir -p $GEOIPS_DEPENDENCIES_DIR/bin
     ln -sfv $GEOIPS_DEPENDENCIES_DIR/seviri_wavelet/PublicDecompWT/xRITDecompress/xRITDecompress $GEOIPS_DEPENDENCIES_DIR/bin/xRITDecompress
+
 elif [[ "$1" == "setup_rclone" ]]; then
     mkdir -p $GEOIPS_DEPENDENCIES_DIR/rclone
     opsys=linux
@@ -168,16 +171,7 @@ elif [[ "$1" == "setup_rclone" ]]; then
     unzip $GEOIPS_DEPENDENCIES_DIR/rclone/rclone-current-${opsys}-${arch}.zip
     # rclone-current expands into rclone-<vers>, not rclone-current, so link arbitrary rclone* subdirectory
     ln -sfv ${GEOIPS_DEPENDENCIES_DIR}/rclone*/rclone*/rclone ${GEOIPS_DEPENDENCIES_DIR}/bin/rclone
-    mkdir -p ~/.config/rclone/
-    ln -sv ${GEOIPS_PACKAGES_DIR}/geoips/setup/rclone_setup/rclone.conf ~/.config/rclone 
-    if [[ $? != 0 ]]; then
-        echo ""
-        echo "**********"
-        echo "WARNING: rclone.conf not initiated in ~/.config"
-        echo "    If you want to replace ~/.config/rclone/rclone.conf with geoips version, run the following:"
-        echo "    ln -sfv ${GEOIPS_PACKAGES_DIR}/geoips/setup/rclone_setup/rclone.conf ~/.config/rclone"
-        echo "**********"
-    fi
+
 elif [[ "$1" == "setup_vim8" ]]; then
     mkdir -p $GEOIPS_DEPENDENCIES_DIR/vim8_build
     cwd=`pwd`

--- a/setup/config_geoips
+++ b/setup/config_geoips
@@ -11,8 +11,6 @@ else
     export GEOIPS_VERS=`cat $CURRENT_CONFIGPATH/../VERSION`
 fi
 
-git lfs install
-
 export GEOIPS_BASEDIR=`dirname $CURRENT_CONFIGPATH`
 export GEOIPS_BASEDIR=`dirname $GEOIPS_BASEDIR`
 export GEOIPS_BASEDIR=`dirname $GEOIPS_BASEDIR`


### PR DESCRIPTION
# Related Issue
NRLMMD-GEOIPS/geoips#22

# Reviewer Checklist

### Ensure you are logged into GitHub

### Confirm all requirements are met for pull request
* Ensure appropriate / sufficient content
    * **Title format**: geoips#<issue_num> <modified_repo_name> - \<Short description>
        * Example: geoips#8 geoips_template_plugin - Updating GEOIPS_REPO_URL to github
    * **Included Issue**: Link to related Issue included at the beginning of pull request
        * Example: GEOIPS/geoips#8
    * **CHANGELOG updated**: Functionality included in pull request is ALSO referenced in CHANGELOG.md
    * **Demonstrated Testing**: Proper testing / output was demonstrated for functionality updates
    * **Included Outputs**: Imagery is included in "Output" section for new or changed product outputs (for reports!)
* Ensure all appropriate tags / attributes added along right-hand side of pull request
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link above)
    * **Check Issue Label**: Issue ID label added to Issue in bright green
    
### Once all items in checklist have been confirmed:
* **Approve pull request**
    * Click "Files changed" tab
    * Click green "Review changes" button
    * Select "Approve" option
    * Add message if desired
    * Click green "Submit review" button
    * Project status will automatically be updated in Project "GeoIPS2 - All Repos and All Functionality" when pull request is approved.

# Testing Instructions
```
rm -f ~/.config/rclone/rclone.conf
$GEOIPS/setup.sh setup_rclone
$GEOIPS/setup.sh setup_abi_test_data
```
This will no longer link to ~/.config, and will use the $GEOIPS/setup/rclone_setup/rclone.conf file directly from rclone commands.

# Summary

NRLMMD-GEOIPS/geoips#22 - Remove rclone.conf link to ~/.config/rclone

### Installation and Test
* **setup.sh**
    * Update setup_rclone command to remove the link from $GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
        to ~/.config/rclone/rclone.conf
    * Update setup_abi_test_data command to use explicit
        --config $GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
        argument rather than relying on default ~/.config/rclone/rclone.conf configuration


# Output
```
(geoips_conda) setup.sh setup_rclone
...

(geoips_conda) which rclone
~/geoproc/geoips_dependencies/bin/rclone

(geoips_conda) ls -l ~/.config
total 8
drwxrwxr-x. 2 surratt surratt 4096 Aug 17  2020 matplotlib

(geoips_conda) rm -rf tests/data/

(geoips_conda) setup.sh setup_abi_test_data
...

(geoips_conda) ls -1 tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C*
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc
tests/data/goes16_20200918_1950/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc
```