### PR TITLE
geoips#25 geoips - Support low_bandwidth option for installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
     # # # or FITNESS FOR A PARTICULAR PURPOSE.
     # # # See the included license for more details.
 
+NRLMMD-GEOIPS/geoips#25 - add low_bandwidth option
+
+### Installation and Test
+* **README.md** - Pass low_memory and low_bandwidth options to base_install_and_test.sh
+* **setup.sh** - Support low_bandwidth option for setup_abi_test_data (only download B14), and install (pip install minimum packages for tests)
+* **base_install_and_test.sh** - Pass "low_bandwidth" option through to setup.sh
 
 NRLMMD-GEOIPS/geoips#17 - Update Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Base geoips installation and test
     # This prompts you through all the steps of installing geoips from scratch, using the parameters specified above
     # Installs and tests everything!
     # Requires <30GB disk space, <16GB memory
-    $GEOIPS_BASEDIR/geoips_packages/geoips/base_install_and_test.sh $GEOIPS_ACTIVE_BRANCH
+    $GEOIPS_BASEDIR/geoips_packages/geoips/base_install_and_test.sh $GEOIPS_ACTIVE_BRANCH low_memory low_bandwidth
 
     # Low memory option. No high res Visible outputs.  Same setup, just different tests.
     # Requires <30GB disk space, <8GB memory

--- a/base_install_and_test.sh
+++ b/base_install_and_test.sh
@@ -57,6 +57,13 @@ if [[ "$2" == "" ]]; then
 else
     memory_option="low_memory"
 fi
+
+if [[ "$3" == "" ]]; then
+    bandwidth_option="high_bandwidth"
+else
+    bandwidth_option="low_memory"
+fi
+
     
 if [[ "$GEOIPS_BASEDIR" == "" ]]; then
     echo "Must set GEOIPS_BASEDIR environment variable prior to installation"
@@ -156,7 +163,7 @@ check_continue "creating geoips_conda_env (should point to $GEOIPS_BASEDIR/geoip
         date -u
         # Actually install geoips and all dependencies (cartopy, etc)
         source $GEOIPS_CONFIG_FILE
-        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh install
+        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh install $bandwidth_option
         echo ""
         echo "Confirm environment variables point to desired installation parameters:"
         echo "    GEOIPS_BASEDIR:       $GEOIPS_BASEDIR"
@@ -271,7 +278,7 @@ check_continue "installing geoips, cartopy data, dependencies, and external pack
     if [[ "$skip_next" == "no" ]]; then
         date -u
         source $GEOIPS_CONFIG_FILE
-        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh setup_abi_test_data
+        $GEOIPS_BASEDIR/geoips_packages/geoips/setup.sh setup_abi_test_data $bandwidth_option
         if [[ "$memory_option" == "low_memory" ]]; then
             $GEOIPS/tests/test_base_install_low_memory.sh
         else

--- a/setup.sh
+++ b/setup.sh
@@ -102,18 +102,28 @@ elif [[ "$1" == "install" ]]; then
     # Update to latest 20220607, previously cartopy 0.20.2 and matplotlib 3.4.3.
     conda install -c conda-forge "cartopy>=0.20.2" "matplotlib>=3.5.2" --yes
 
-    pip install -e "$GEOIPS_PACKAGES_DIR/geoips[efficiency_improvements,\
-                                                  test_outputs,\
-                                                  config_based,\
-                                                  hdf5_readers,\
-                                                  hdf4_readers,\
-                                                  geotiff_output,\
-                                                  syntax_checking,\
-                                                  documentation,\
-                                                  debug,\
-                                                  overpass_predictor,\
-                                                  coverage_checks,\
-                                                  geostationary_readers]"
+    if [[ "$2" == "low_bandwidth" ]]; then
+        pip install -e "$GEOIPS_PACKAGES_DIR/geoips[efficiency_improvements,\
+                                                      test_outputs,\
+                                                      config_based,\
+                                                      hdf5_readers,\
+                                                      debug,\
+                                                      coverage_checks,\
+                                                      geostationary_readers]"
+    else
+        pip install -e "$GEOIPS_PACKAGES_DIR/geoips[efficiency_improvements,\
+                                                      test_outputs,\
+                                                      config_based,\
+                                                      hdf5_readers,\
+                                                      hdf4_readers,\
+                                                      geotiff_output,\
+                                                      syntax_checking,\
+                                                      documentation,\
+                                                      debug,\
+                                                      overpass_predictor,\
+                                                      coverage_checks,\
+                                                      geostationary_readers]"
+    fi
 
 elif [[ "$1" == "setup_abi_test_data" ]]; then
     # rclone lsf publicAWS:noaa-goes16/ABI-L1b-RadF/2020/184/16/
@@ -127,22 +137,26 @@ elif [[ "$1" == "setup_abi_test_data" ]]; then
 
     rcloneconf=$GEOIPS_PACKAGES_DIR/geoips/setup/rclone_setup/rclone.conf
 
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc $abidir
-    rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc $abidir
+    if [[ "$2" == "low_bandwidth" ]]; then
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc $abidir
+    else
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc $abidir
+        rclone --config $rcloneconf copy -P publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc $abidir
+    fi
 
 elif [[ "$1" == "setup_seviri" ]]; then
     mkdir -p $GEOIPS_DEPENDENCIES_DIR/seviri_wavelet


### PR DESCRIPTION
# Related Issue
NRLMMD-GEOIPS/geoips#25

# Reviewer Checklist

### Ensure you are logged into GitHub

### Confirm all requirements are met for pull request
* Ensure appropriate / sufficient content
    * **Title format**: geoips#<issue_num> <modified_repo_name> - \<Short description>
        * Example: geoips#8 geoips_template_plugin - Updating GEOIPS_REPO_URL to github
    * **Included Issue**: Link to related Issue included at the beginning of pull request
        * Example: NRLMMD-GEOIPS/geoips#8
    * **CHANGELOG updated**: Functionality included in pull request is ALSO referenced in CHANGELOG.md
    * **Demonstrated Testing**: Proper testing / output was demonstrated for functionality updates
    * **Included Outputs**: Imagery is included in "Output" section for new or changed product outputs (for reports!)
    * **Test Scripts/Outputs for New Functionality**: If new functionality is included in PR,
        ensure related test scripts and test outputs were included.
* Ensure all appropriate tags / attributes added along right-hand side of pull request
    * **Label**: Added appropriate descriptors
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link above)
    
### Once all items in checklist have been confirmed:
* **Approve pull request**
    * Click "Files changed" tab
    * Click green "Review changes" button
    * Select "Approve" option
    * Add message if desired
    * Click green "Submit review" button
    * Project status will automatically be updated in Project "GeoIPS - All Repos and All Functionality" when pull request is approved.
 
# Testing Instructions
Complete full base_install_and_test.sh with both low_memory and low_bandwidth options
*     $GEOIPS_BASEDIR/geoips_packages/geoips/base_install_and_test.sh $GEOIPS_ACTIVE_BRANCH low_memory low_bandwidth


# Summary
### Installation and Test
* **README.md** - Pass low_memory and low_bandwidth options to base_install_and_test.sh
* **setup.sh** - Support low_bandwidth option for setup_abi_test_data (only download B14), and install (pip install minimum packages for tests)
* **base_install_and_test.sh** - Pass "low_bandwidth" option through to setup.sh

# Output
Must test after full merge to main.  Full output will be tested after merge.

```
$ setup.sh setup_abi_test_data low_bandwidth
** Setting up abi test data, from publicAWS:noaa-goes16/ABI-L1b-RadF/2020/262/19/ to $GEOIPS_PACKAGES_DIR/geoips/tests/data/goes16_20200918_1950/

NOAA Geostationary Operational Environmental Satellites (GOES) 16 & 17 was accessed on
Wed Aug 3 20:47:06 UTC 2022 from https://registry.opendata.aws/noaa-goes.

Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.5s

$ setup.sh setup_abi_test_data
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.5s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.4s
```