### PR TITLE
geoips#31 -- update gitignore to ignore all test data inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 geoips.egg-info
 *.simg
 *.egg-info
+tests/data/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
     # # # or FITNESS FOR A PARTICULAR PURPOSE.
     # # # See the included license for more details.
 
+NRLMMD-GEOIPS/geoips#31 - add test datasets to .gitignore
+
+### Improvements
+* **geoips/.gitignore**
+    * Add tests/data/** to .gitignore so they no longer appear in git status
+
+
 NRLMMD-GEOIPS/geoips#25 - add low_bandwidth option
 
 ### Installation and Test


### PR DESCRIPTION
# Related Issue
fixes NRLMMD-GEOIPS/geoips#31

# Summary 
NRLMMD-GEOIPS/geoips#31 - add test datasets to .gitignore

### Improvements
* **geoips/.gitignore**
    * Add tests/data/** to .gitignore so they no longer appear in git status

# Outputs
```
bash$ git status
On branch dev
Your branch is up to date with 'origin/dev'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        tests/data/

nothing added to commit but untracked files present (use "git add" to track)
```

```
bash$ git diff .gitignore
diff --git a/.gitignore b/.gitignore
index c826ba4d..4cef5e7f 100644
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 geoips.egg-info
 *.simg
 *.egg-info
+tests/data/**


bash$ git status
On branch dev
Your branch is up to date with 'origin/dev'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .gitignore

no changes added to commit (use "git add" and/or "git commit -a")
```