### PR TITLE
29 convert python script docstrings to numpy docstring format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@
     # # # or FITNESS FOR A PARTICULAR PURPOSE.
     # # # See the included license for more details.
 
+
+NRLMMD-GEOIPS/geoips#29: 2022-08-28, Update image_utils to numpy docstrings
+
+### Documentation
+* Update image_utils directory for proper numpy style docstrings
+    * **geoips/image_utils/__init__.py**
+    * **geoips/image_utils/colormap_utils.py**
+    * **geoips/image_utils/maps.py**
+    * **geoips/image_utils/mpl_utils.py**
+* **geoips/compare_outputs.py** Update imagemagick compare metric from rmse to ae + fuzz 1%
+
 NRLMMD-GEOIPS/geoips#31 - add test datasets to .gitignore
 
 ### Improvements

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -163,8 +163,7 @@ def images_match(output_product, compare_product, threshold=0.0000001):
     out_diffimg = get_out_diff_fname(compare_product, output_product)
 
     call_list = ['compare', '-verbose', '-quiet',
-                 '-metric', 'rmse',
-                 '-dissimilarity-threshold', '{0:0.15f}'.format(threshold),
+                 '-metric', 'ae', '-fuzz', "1%",
                  output_product,
                  compare_product,
                  out_diffimg]

--- a/geoips/image_utils/__init__.py
+++ b/geoips/image_utils/__init__.py
@@ -15,3 +15,4 @@
 # # # without even the implied warranty of MERCHANTABILITY
 # # # or FITNESS FOR A PARTICULAR PURPOSE.
 # # # See the included license for more details.
+"""image_utils init file."""

--- a/geoips/image_utils/colormap_utils.py
+++ b/geoips/image_utils/colormap_utils.py
@@ -1,22 +1,22 @@
 # # # Distribution Statement A. Approved for public release. Distribution unlimited.
-# # # 
+# # #
 # # # Author:
 # # # Naval Research Laboratory, Marine Meteorology Division
-# # # 
+# # #
 # # # This program is free software:
 # # # you can redistribute it and/or modify it under the terms
 # # # of the NRLMMD License included with this program.
-# # # 
+# # #
 # # # If you did not receive the license, see
 # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 # # # for more information.
-# # # 
+# # #
 # # # This program is distributed WITHOUT ANY WARRANTY;
 # # # without even the implied warranty of MERCHANTABILITY
 # # # or FITNESS FOR A PARTICULAR PURPOSE.
 # # # See the included license for more details.
 
-''' Module for generating specific colormaps on the fly '''
+"""Module for generating specific colormaps on the fly."""
 # Installed Libraries
 import logging
 
@@ -24,15 +24,18 @@ LOG = logging.getLogger(__name__)
 
 
 def set_matplotlib_colors_rgb():
-    ''' For rgb imagery, we require no color information (it is entirely specified by the RGB(A) arrays)
-    
-    Args:
-        No arguments
+    """
+    Create matplotlib Colors parameters dictionary.
 
-    Returns:
-        mpl_colors_info (dict) Specifies matplotlib Colors parameters for use in both plotting and colorbar generation
-                               For RGBA arrays, all fields are "None"
-    '''
+    For rgb imagery, we require no color information (it is entirely
+    specified by the RGB(A) arrays).
+
+    Returns
+    -------
+    mpl_colors_info : dict
+        Specifies matplotlib Colors parameters for use in both plotting
+        and colorbar generation. For RGBA arrays, all fields are "None".
+    """
     mpl_colors_info = {'cmap': None,
                        'norm': None,
                        'cbar_ticks': None,
@@ -45,19 +48,31 @@ def set_matplotlib_colors_rgb():
 
 
 def set_matplotlib_colors_standard(data_range, cmap_name='Greys', cbar_label=None, create_colorbar=True):
-    ''' Set the matplotlib colors information appropriately, for use in colorbar and image production.
+    """
+    Set the matplotlib colors information.
 
-    Args:
-        data_range (list) : [min_val, max_val]
-        cmap_name (str) : Default 'Greys' - specify the standard matplotlib colormap.
-        cbar_label (str) : Default None - If specified, use cbar_label string as colorbar label.
-        create_colorbar (bool) : Default True - Specify whether the image should contain a colorbar or not.
+    For use in colorbar and image production.
 
-    Returns:
-        mpl_colors_info (dict) Specifies matplotlib Colors parameters for use in both plotting and colorbar generation
-                                See geoips.image_utils.mpl_utils.create_colorbar for field descriptions.
-    '''
+    Parameters
+    ----------
+    data_range : list
+        the minimum and maximum value for the data range
+        [min_val, max_val]
+    cmap_name : str, default='Greys'
+        Specify the standard matplotlib colormap
+    cbar_label : str, optional
+        If specified, use cbar_label string as colorbar label
+    create_colorbar : bool, default=True
+        Specify whether the image should contain a colorbar or not
 
+    Returns
+    -------
+    mpl_colors_info : dict
+        Specifies matplotlib Colors parameters for use in both plotting
+        and colorbar generation.
+        See geoips.image_utils.mpl_utils.create_colorbar for field
+        descriptions.
+    """
     min_val = data_range[0]
     max_val = data_range[1]
     from matplotlib import cm
@@ -89,23 +104,39 @@ def set_matplotlib_colors_standard(data_range, cmap_name='Greys', cbar_label=Non
 def set_mpl_colors_info_dict(cmap, norm, cbar_ticks, cbar_tick_labels=None, boundaries=None,
                              cbar_label=None, cbar_spacing='proportional', create_colorbar=True,
                              cbar_full_width=False):
-    ''' Create the mpl_colors_info dictionary directly from passed arguments
+    """
+    Create the mpl_colors_info dictionary directly from passed arguments.
 
-    Args:
-        cmap (Colormap) : This is a valid matplotlib cm Colormap object that can be used for both plotting and colorbar
-                            creation
-        norm (Normalize) : This is a valid matplotlib Normalize object that can be used for both plotting and colorbar
-                            creation.
-        cbar_ticks (list) : List of values where tick marks should be placed on colorbar
-        boundaries (list) :  List of boundaries to use in matplotlib plotting and oclorbar creation
-        cbar_spacing (string) : Default 'proportional': One of 'proportional' or 'uniform'
-        colorbar (bool) : True if colorbar should be created with the set of color info, False otherwise
-        cbar_full_width (bool) : default False, True if colorbar should be full width of figure, center 50% if False
+    Parameters
+    ----------
+    cmap : Colormap
+        This is a valid matplotlib cm Colormap object that can be used for
+        both plotting and colorbar creation.
+    norm : Normalize
+        This is a valid matplotlib Normalize object that can be used for
+        both plotting and colorbar creation.
+    cbar_ticks : list
+        List of values where tick marks should be placed on colorbar
+    cbar_tick_labels : list, optional
+        List of tick label values
+    boundaries : list, optional
+        List of boundaries to use in matplotlib plotting and colorbar
+        creation
+    cbar_label, optional
+        The label for the colorbar
+    cbar_spacing : str, default='proportional'
+        One of 'proportional' or 'uniform'
+    create_colorbar : bool, default=True
+        True if colorbar should be created with the set of color info, False otherwise
+    cbar_full_width : bool, default=False
+        True if colorbar should be full width of figure, center 50% if False
 
-    Returns:
-        (dict) : Dictionary of mpl_colors_info for use in plotting and colorbar creation.
-    '''
-
+    Returns
+    -------
+    mpl_colors_info : dict
+        Dictionary of mpl_colors_info for use in plotting and colorbar
+        creation.
+    """
     mpl_colors_info = {}
     mpl_colors_info['cmap'] = cmap
     mpl_colors_info['norm'] = norm
@@ -120,23 +151,27 @@ def set_mpl_colors_info_dict(cmap, norm, cbar_ticks, cbar_tick_labels=None, boun
 
 
 def from_ascii(fname, reverse=False):
-    ''' Create a ListedColormap instance from an ascii text file of RGB values
-    
+    """
+    Create a ListedColormap instance from an ASCII file of RGB values.
+
+    Parameters
+    ----------
+    fname : str
+        Full path to ascii RGB colortable file
+    reverse : bool, default=False
+        If True, reverse the colormap
+
+    Returns
+    -------
+    cmap : ListedColormap object
+        The colormap name will be the os.path.basename of the file.
+
+    Notes
+    -----
      * Lines preceded by '#' are ignored.
      * 0-255 or 0-1.0 RGB values (0-255 values are normalized to 0-1.0 for matplotlib usage)
      * One white space delimited RGB value per line
-
-    Args:
-        fname (str): Full path to ascii RGB colortable file
-        reverse (Optional[bool]):
-            * DEFAULT False
-            * If True, reverse the colormap
-
-    Returns:
-        ListedColormap object: The colormap name will be the os.path.basename of the file.
-
-    '''
-
+    """
     #Read data from ascii file into an NLines by 3 float array, skipping lines preceded by "#"
     lines = []
     with open(fname) as palette:
@@ -167,31 +202,29 @@ def from_ascii(fname, reverse=False):
 
 
 def create_linear_segmented_colormap(cmapname, min_val, max_val, transition_vals, transition_colors):
-    ''' Use argument values to fill in the dict used in LinearSegmentedColormap
-        +------------------+-----------+-------------------------------------------------------+
-        | Parameters:      | Type:     | Description:                                          |
-        +==================+===========+=======================================================+
-        | cmapname:        | *str*     | Name to attach to the matplotlib.color ColorMap object|
-        +------------------+-----------+-------------------------------------------------------+
-        | min_val:         | *float*   | Overall minimum value for the colormap                |
-        |                  |           |     Range must be normalized between 0 and 1          |
-        +------------------+-----------+-------------------------------------------------------+
-        | max_val:         | *float*   | Overall maximum value for the colormap                |
-        |                  |           |     Range must be normalized between 0 and 1          |
-        |                  |           |                                                       |
-        +------------------+-----------+-------------------------------------------------------+
-        | transition_vals: | *list*    | A list of value ranges specified as tuples for        |
-        |                  |   of      |     generating a specific range of colors             |
-        |                  |*tuples*   |     ie [(0, 10), (10, 30), (30, 60)]                  |
-        +------------------+-----------+-------------------------------------------------------+
-        |transition_colors:| *list*    | A list of color ranges specified as tuples for        |
-        |                  |   of      |     generating a specific range of colors             |
-        |                  |*tuples*   |     corresponding to the transition_vals specified    |
-        |                  |   of      |     above                                             |
-        |                  |*colors*   |     ie [('yellow', 'orange'),                         |
-        |                  |           |         ('pink', 'red'),                              |
-        |                  |           |         ('violet', 'purple')]                         |
-        +------------------+-----------+-------------------------------------------------------+
+    """
+    Create a LinearSegmentedColormap instance.
+
+    Parameters
+    ----------
+    cmapname : str
+        Name to attach to the matplotlib.color ColorMap object
+    min_val : float
+        Overall minimum value for the colormap
+        Range must be normalized between 0 and 1
+    max_val : float
+        Overall maximum value for the colormap
+        Range must be normalized between 0 and 1
+    transition_vals : array-like
+        A list of value ranges specified as tuples for generating a
+        specific range of colors ie [(0, 10), (10, 30), (30, 60)]
+    transition_colors : array-like
+        A list of color ranges specified as tuples for generating a
+        specific range of colors corresponding to the transition_vals
+        specified ie
+            [('yellow', 'orange'),
+             ('pink', 'red'),
+             ('violet', 'purple')]
 
         TRANSITIONPOINT1 = 0.0
         TRANSITIONPOINT4 = 1.0
@@ -209,7 +242,12 @@ def create_linear_segmented_colormap(cmapname, min_val, max_val, transition_vals
                          (TRANSITIONPOINT3, 2to3ENDCOLOR, 3to4STARTCOLOR),
                          (TRANSITIONPOINT4, 3to4ENDCOLOR, IGNORED)),
             }
-    '''
+
+    Returns
+    -------
+    cm : LinearSegmentedColormap
+        matplotlib colormap object
+    """
     from matplotlib.colors import ColorConverter, LinearSegmentedColormap
     # Sort transitions on start_val
     bluetuple = ()

--- a/geoips/image_utils/maps.py
+++ b/geoips/image_utils/maps.py
@@ -1,22 +1,22 @@
 # # # Distribution Statement A. Approved for public release. Distribution unlimited.
-# # # 
+# # #
 # # # Author:
 # # # Naval Research Laboratory, Marine Meteorology Division
-# # # 
+# # #
 # # # This program is free software:
 # # # you can redistribute it and/or modify it under the terms
 # # # of the NRLMMD License included with this program.
-# # # 
+# # #
 # # # If you did not receive the license, see
 # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 # # # for more information.
-# # # 
+# # #
 # # # This program is distributed WITHOUT ANY WARRANTY;
 # # # without even the implied warranty of MERCHANTABILITY
 # # # or FITNESS FOR A PARTICULAR PURPOSE.
 # # # See the included license for more details.
 
-''' matplotlib geographic map (basemap or cartopy) utilities '''
+"""matplotlib geographic map (basemap or cartopy) utilities."""
 
 # Python Standard Libraries
 import logging
@@ -25,18 +25,21 @@ LOG = logging.getLogger(__name__)
 
 
 def ellps2axis(ellps_name):
-    """Get semi-major and semi-minor axis from ellipsis definition
+    """
+    Get semi-major and semi-minor axis from ellipsis definition.
 
     Parameters
-    ---------
+    ----------
     ellps_name : str
         Standard name of ellipsis
 
     Returns
     -------
-    (avar, bvar) : semi-major and semi-minor axis
+    avar : float
+        semi-major axis
+    bvar : float
+        semi-minor axis
     """
-
     ellps = {'helmert': {'a': 6378200.0, 'b': 6356818.1696278909},
              'intl': {'a': 6378388.0, 'b': 6356911.9461279465},
              'merit': {'a': 6378137.0, 'b': 6356752.2982159676},
@@ -90,29 +93,44 @@ def ellps2axis(ellps_name):
 
 
 def is_crs(mapobj):
-    ''' Determine if the map object we are using is a cartopy crs instance.
+    """
+    Determine if the map object we are using is a cartopy crs instance.
 
-    Args:
-        mapobj (map object) : Basemap or cartopy._PROJ4Projection object
+    Parameters
+    ----------
+    mapobj : map object
+        Basemap or cartopy._PROJ4Projection object
 
-    Returns:
-        (Bool) : True if it is a CRS object, False otherwise.
-    '''
+    Returns
+    -------
+    crs : bool
+        True if it is a CRS object, False otherwise.
+    """
     import pyresample
+    crs = False
     if 'cartopy' in str(mapobj.__class__):
-        return True
-    return False
+        crs = True
+    return crs
 
 
 def area_def2mapobj(area_def):
-    ''' Convert pyresample AreaDefinition object to a cartopy CRS or Basemap object. Default to basemap
+    """
+    Convert to map object.
 
-    Args:
-        area_def (AreaDefinition): pyresample AreaDefinition object
+    Convert pyresample AreaDefinition object to a cartopy CRS or Basemap
+    object. Default to basemap.
 
-    Returns:
-        (map object) : Either Basemap instance (if Basemap is installed), or cartopy CRS object
-    '''
+    Parameters
+    ----------
+    area_def : AreaDefinition
+        pyresample AreaDefinition object
+
+    Returns
+    -------
+    mapobj : CRS map object
+        Either Basemap instance (if Basemap is installed), or cartopy
+        CRS object.
+    """
     try:
         # old pyresample.area_def2basemap appears to fail over the dateline.
         # Created our own for now
@@ -128,20 +146,18 @@ def area_def2mapobj(area_def):
 
 
 def area_def2basemap(area_def, **kwargs):
-    """Get Basemap object from AreaDefinition
+    """
+    Get Basemap object from AreaDefinition.
 
     Parameters
-    ---------
+    ----------
     area_def : object
         geometry.AreaDefinition object
-    **kwargs: Keyword arguments
-        Additional initialization arguments for Basemap
 
     Returns
     -------
     bmap : Basemap object
     """
-
     from mpl_toolkits.basemap import Basemap
     try:
         avar, bvar = ellps2axis(area_def.proj_dict['ellps'])
@@ -199,15 +215,21 @@ def area_def2basemap(area_def, **kwargs):
 
 
 def parallels(area_def, grid_size):
-    ''' Calculates the parallels (latitude lines) that fall within the input sector.
+    """
+    Calculate the parallels (latitude) that fall within the input sector.
 
-    Args:
-        area_def (AreaDefinition): pyresample AreaDefinition
-        grid_size (float): grid spacing in degrees
+    Parameters
+    ----------
+    area_def : AreaDefinition
+        pyresample AreaDefinition
+    grid_size : float
+        grid spacing in degrees
 
-    Returns:
-        (list) latitude locations for gridlines
-    '''
+    Returns
+    -------
+    lat_ticks : list
+        latitude locations for gridlines
+    """
     from math import ceil
     from numpy import arange
     from numpy.ma import masked_greater
@@ -222,15 +244,21 @@ def parallels(area_def, grid_size):
 
 
 def meridians(area_def, grid_size):
-    ''' Calculates the meridians (longitude lines) that fall within the input sector.
+    """
+    Calculate the meridians (longitude) that are within the input sector.
 
-    Args:
-        area_def (AreaDefinition) : pyresample AreaDefinition
+    Parameters
+    ----------
+    area_def : AreaDefinition
+        pyresample AreaDefinition
+    grid_size : float
+        grid spacing in degrees
 
-    Returns:
-        (list) longitude locations for gridlines
-    '''
-
+    Returns
+    -------
+    meridians_to_draw : list
+        longitude locations for gridlines
+    """
     import numpy
     corners = area_def.corners
     lons = [numpy.rad2deg(corn.lon) for corn in corners]
@@ -262,15 +290,21 @@ def meridians(area_def, grid_size):
 
 
 def check_gridlines_info_dict(gridlines_info):
-    ''' Check that all required fields are included in the gridlines_info dictionary
+    """
+    Check gridlines_info dictionary for that all required fields.
 
-    Args:
-        gridlines_info (dict) : dictionary to check for required fields. For complete list of
-                                  fields, and appropriate defaults, see
-                                  geoips.image_utils.maps.get_gridlines_info_dict
-    Returns:
-        (Bool) : True if all fields are included, False if any fields are missing.
-    '''
+    Parameters
+    ----------
+    gridlines_info : dict
+        dictionary to check for required fields. For complete list of
+        fields, and appropriate defaults, see
+        geoips.image_utils.maps.get_gridlines_info_dict
+
+    Raises
+    ------
+    ValueError
+        If required field is missing
+    """
     required_fields = ['grid_lat_spacing', 'grid_lon_spacing', 'grid_lat_fontsize', 'grid_lon_fontsize',
                        'grid_lat_xoffset', 'grid_lon_xoffset', 'grid_lat_yoffset', 'grid_lon_yoffset',
                        'left_label', 'right_label', 'top_label', 'bottom_label',
@@ -284,33 +318,45 @@ def check_gridlines_info_dict(gridlines_info):
 
 
 def set_gridlines_info_dict(gridlines_info, area_def):
-    ''' Set the final values for gridlines plotting params, pulling from argument and defaults.
+    """
+    Set plotting gridlines.
 
-    Args:
-      gridlines_info (dict) : Dictionary of parameters for plotting gridlines.
-                              The following fields are available.  If a field is not included in the dictionary,
-                              the field is added to the return dictionary and the default is used.
-                                gridlines_info['grid_lat_spacing']      default auto calculated 5 lat grid lines
-                                gridlines_info['grid_lon_spacing']      default auto calculated 5 lon grid lines
-                                gridlines_info['grid_lat_xoffset']      default None (0.01 * image height)
-                                gridlines_info['grid_lon_xoffset']      default None (0.01 * image width)
-                                gridlines_info['grid_lat_yoffset']      default None (0.01 * image height)
-                                gridlines_info['grid_lon_yoffset']      default None (0.01 * image width)
-                                gridlines_info['grid_lat_fontsize']     default None (plot fontsize)
-                                gridlines_info['grid_lon_fontsize']     default None (plot fontsize)
-                                gridlines_info['left_label']            default True
-                                gridlines_info['right_label']           default False
-                                gridlines_info['top_label']             default True
-                                gridlines_info['bottom_label']          default False
-                                gridlines_info['grid_lat_linewidth']    default 1
-                                gridlines_info['grid_lon_linewidth']    default 1
-                                gridlines_info['grid_lat_color']        default 'black'
-                                gridlines_info['grid_lon_color']        default 'black'
-                                gridlines_info['grid_lat_dashes']       default [4, 2]
-                                gridlines_info['grid_lon_dashes']       default [4, 2]
-    Returns:
-        (dict) : gridlines_info dictionary, with fields as specified above.
-    '''
+    Set the final values for gridlines plotting params, pulling from
+    argument and defaults.
+
+    Parameters
+    ----------
+    gridlines_info : dict
+        Dictionary of parameters for plotting gridlines. The following
+        fields are available.  If a field is not included in the
+        dictionary, the field is added to the return dictionary and the
+        default is used.
+            gridlines_info['grid_lat_spacing']      default auto calculated 5 lat grid lines
+            gridlines_info['grid_lon_spacing']      default auto calculated 5 lon grid lines
+            gridlines_info['grid_lat_xoffset']      default None (0.01 * image height)
+            gridlines_info['grid_lon_xoffset']      default None (0.01 * image width)
+            gridlines_info['grid_lat_yoffset']      default None (0.01 * image height)
+            gridlines_info['grid_lon_yoffset']      default None (0.01 * image width)
+            gridlines_info['grid_lat_fontsize']     default None (plot fontsize)
+            gridlines_info['grid_lon_fontsize']     default None (plot fontsize)
+            gridlines_info['left_label']            default True
+            gridlines_info['right_label']           default False
+            gridlines_info['top_label']             default True
+            gridlines_info['bottom_label']          default False
+            gridlines_info['grid_lat_linewidth']    default 1
+            gridlines_info['grid_lon_linewidth']    default 1
+            gridlines_info['grid_lat_color']        default 'black'
+            gridlines_info['grid_lon_color']        default 'black'
+            gridlines_info['grid_lat_dashes']       default [4, 2]
+            gridlines_info['grid_lon_dashes']       default [4, 2]
+    area_def : AreaDefinition
+        pyresample AreaDefinition
+
+    Returns
+    -------
+    use_gridlines_info : dict
+        gridlines_info dictionary, with fields as specified above.
+    """
     use_gridlines_info = {}
 
     if gridlines_info is None or 'grid_lat_spacing' not in gridlines_info.keys()\
@@ -371,15 +417,24 @@ def set_gridlines_info_dict(gridlines_info, area_def):
 
 
 def check_boundaries_info_dict(boundaries_info):
-    ''' Check that all required fields are included in the boundaries_info dictionary
+    """
+    Check boundaries_info dictionary for required fields.
 
-    Args:
-        boundaries_info (dict) : dictionary to check for required fields. For complete list of
-                                    fields, and appropriate defaults, see
-                                    geoips.image_utils.maps.get_boundaries_info_dict
-    Returns:
-        (Bool) : True if all fields are included, False if any fields are missing.
-    '''
+    Parameters
+    ----------
+    boundaries_info : dict
+        dictionary to check for required fields.
+
+    Raises
+    ------
+    ValueError
+        if any field is missing
+
+    See Also
+    --------
+    geoips.image_utils.maps.get_boundaries_info_dict
+        For complete list of fields, and appropriate defaults
+    """
     required_fields = ['request_coastlines', 'coastlines_color', 'coastlines_linewidth',
                        'request_rivers', 'rivers_color', 'rivers_linewidth',
                        'request_states', 'states_color', 'states_linewidth',
@@ -391,29 +446,37 @@ def check_boundaries_info_dict(boundaries_info):
 
 
 def set_boundaries_info_dict(boundaries_info):
-    ''' Set the final values for coastlines, states, countries plotting params, pulling from argument and defaults.
+    """
+    Set the boundary information.
 
-    Args:
-      boundaries_info (dict) : Dictionary of parameters for plotting gridlines.
-                               The following fields are available.  If a field is not included in the dictionary,
-                               the field is added to the return dictionary and the default is used.
-                                  boundaries_info['request_coastlines']       default True
-                                  boundaries_info['request_countries']        default True
-                                  boundaries_info['request_states']           default True
-                                  boundaries_info['request_rivers']           default True
+    Set the final values for coastlines, states, countries plotting params,
+    pulling from argument and defaults.
 
-                                  boundaries_info['coastlines_linewidth']     default 2
-                                  boundaries_info['countries_linewidth']      default 1
-                                  boundaries_info['states_linewidth']         default 0.5
-                                  boundaries_info['rivers_linewidth']         default 0
+    Parameters
+    ----------
+    boundaries_info : dict
+        Dictionary of parameters for plotting gridlines.
+        The following fields are available.  If a field is not included in the dictionary,
+        the field is added to the return dictionary and the default is used.
+            boundaries_info['request_coastlines']       default True
+            boundaries_info['request_countries']        default True
+            boundaries_info['request_states']           default True
+            boundaries_info['request_rivers']           default True
 
-                                  boundaries_info['coastlines_color']         default 'red'
-                                  boundaries_info['countries_color']          default 'red'
-                                  boundaries_info['states_color']             default 'red'
-                                  boundaries_info['rivers_color']             default 'red'
-    Returns:
-        (dict) : boundaries_info dictionary, with fields as specified above.
-    '''
+            boundaries_info['coastlines_linewidth']     default 2
+            boundaries_info['countries_linewidth']      default 1
+            boundaries_info['states_linewidth']         default 0.5
+            boundaries_info['rivers_linewidth']         default 0
+
+            boundaries_info['coastlines_color']         default 'red'
+            boundaries_info['countries_color']          default 'red'
+            boundaries_info['states_color']             default 'red'
+            boundaries_info['rivers_color']             default 'red'
+    Returns
+    -------
+    use_boundaries_info : dict
+        boundaries_info dictionary, with fields as specified above.
+    """
     use_boundaries_info = {}
     use_boundaries_info['request_coastlines'] = True
     use_boundaries_info['request_countries'] = True
@@ -440,19 +503,28 @@ def set_boundaries_info_dict(boundaries_info):
 
 
 def draw_boundaries(mapobj, curr_ax, boundaries_info, zorder=None):
-    ''' Draw boundaries on specified map instance (basemap or cartopy), based on specs found in boundaries_info
+    """
+    Draw basemap or cartopy boundaries.
 
-    Args:
-        mapobj (map object) : Basemap or CRS object for plotting boundaries
-        curr_ax (matplotlib.axes._axes.Axes) : matplotlib Axes object for plotting boundaries
-        boundaries_info (dict) : Dictionary of parameters for plotting map boundaries.
-                                 See geoips.image_utils.maps.check_boundaries_info_dict
-                                      for required dictionary entries and defaults.
+    Draw boundaries on specified map instance (basemap or cartopy), based
+    on specs found in boundaries_info
 
-    Returns:
-        No return values
-    '''
+    Parameters
+    ----------
+    mapobj : map object
+        Basemap or CRS object for plotting boundaries
+    curr_ax : matplotlib.axes._axes.Axes
+        matplotlib Axes object for plotting boundaries
+    zorder : int, optional
+        The matplotlib zorder
+    boundaries_info : dict
+        Dictionary of parameters for plotting map boundaries.
 
+    See Also
+    --------
+    geoips.image_utils.maps.check_boundaries_info_dict
+          for required dictionary entries and defaults.
+    """
     LOG.info('Drawing coastlines, countries, states, rivers')
     check_boundaries_info_dict(boundaries_info)
 
@@ -506,19 +578,30 @@ def draw_boundaries(mapobj, curr_ax, boundaries_info, zorder=None):
 
 
 def draw_gridlines(mapobj, area_def, curr_ax, gridlines_info, zorder=None):
-    ''' Draw gridlines on either cartopy or Basemap map object, as specified by gridlines_info
+    """
+    Draw gridlines on map object.
 
-    Args:
-        mapobj (map object) : Basemap or CRS object for plotting boundaries
-        area_def (AreaDefinition) : pyresample AreaDefinition object
-        curr_ax (matplotlib.axes._axes.Axes) : matplotlib Axes object for plotting boundaries
-        gridlines_info (dict) : dictionary to check for required fields. For complete list of
-                                  fields, and appropriate defaults, see
-                                  geoips.image_utils.maps.get_gridlines_info_dict
+    Draw gridlines on either cartopy or Basemap map object, as specified
+    by gridlines_info
 
-    Returns:
-        No return value
-    '''
+    Parameters
+    ----------
+    mapobj : map object
+        Basemap or CRS object for plotting boundaries
+    area_def : AreaDefinition
+        pyresample AreaDefinition object
+    curr_ax : matplotlib.axes._axes.Axes
+        matplotlib Axes object for plotting boundaries
+    gridlines_info : dict
+        dictionary to check for required fields.
+    zorder : int, optional
+        The matplotlib zorder value
+
+    See Also
+    --------
+    geoips.image_utils.maps.get_gridlines_info_dict
+        For complete list of fields, and appropriate default
+    """
     LOG.info('Drawing gridlines')
     check_gridlines_info_dict(gridlines_info)
 

--- a/geoips/image_utils/mpl_utils.py
+++ b/geoips/image_utils/mpl_utils.py
@@ -1,22 +1,22 @@
 # # # Distribution Statement A. Approved for public release. Distribution unlimited.
-# # # 
+# # #
 # # # Author:
 # # # Naval Research Laboratory, Marine Meteorology Division
-# # # 
+# # #
 # # # This program is free software:
 # # # you can redistribute it and/or modify it under the terms
 # # # of the NRLMMD License included with this program.
-# # # 
+# # #
 # # # If you did not receive the license, see
 # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 # # # for more information.
-# # # 
+# # #
 # # # This program is distributed WITHOUT ANY WARRANTY;
 # # # without even the implied warranty of MERCHANTABILITY
 # # # or FITNESS FOR A PARTICULAR PURPOSE.
 # # # See the included license for more details.
 
-''' matplotlib utilities '''
+"""matplotlib utilities."""
 
 # Python Standard Libraries
 import logging
@@ -28,54 +28,77 @@ LOG = logging.getLogger(__name__)
 
 
 def percent_unmasked_rgba(rgba):
-    ''' Return percentage of array that is NOT fully transparent / masked (ie, non-zero values in the 4th dimension)
+    """
+    Convert to percent.
 
-    Args:
-        rgba (numpy.ndarray) : 4 dimensional array where the 4th dimension is the alpha transparency array:
-                               1 is fully opaque, 0 is fully transparent
+    Return percentage of array that is NOT fully transparent / masked
+    (ie, non-zero values in the 4th dimension)
 
-    Returns:
-        float : Coverage in percentage, between 0 and 100.
-    '''
+    Parameters
+    ----------
+    rgba : numpy.ndarray
+        4 dimensional array where the 4th dimension is the alpha transparency array:
+        1 is fully opaque, 0 is fully transparent
+
+    Returns
+    -------
+    coverage : float
+        Coverage in percentage, between 0 and 100.
+    """
     import numpy
-    return 100.0 * numpy.count_nonzero(rgba[:, :, 3]) / rgba[:, :, 3].size
+    coverage = 100.0 * numpy.count_nonzero(rgba[:, :, 3]) / rgba[:, :, 3].size
+    return coverage
 
 
 def rgba_from_arrays(red, grn, blu, alp=None):
-    ''' Return rgba for plotting in matplot lib from red, green, blue, and alpha arrays
+    """
+    Return rgba from red, green, blue, and alpha arrays.
 
-    Args:
-        red (numpy.ndarray) : numpy masked array of red gun values
-        grn (numpy.ndarray) : numpy masked array of green gun values
-        blu (numpy.ndarray) : numpy masked array of blue gun values
-        alp (numpy.ndarray) : DEFAULT None, numpy.ndarray of alpha values 1 is fully opaque, 0 is fully transparent
-                                If none, calculate alpha from red, grn, blu guns
+    Parameters
+    ----------
+    red : numpy.ndarray
+        red gun values
+    grn : numpy.ndarray
+        green gun values
+    blu : numpy.ndarray
+        blue gun values
+    alp : numpy.ndarray, optional
+        alpha values 1 is fully opaque, 0 is fully transparent
+        If none, calculate alpha from red, grn, blu guns
 
-    Returns:
-        (numpy.ndarray) : 4 layer dimensional numpy.ndarray
-    '''
-
+    Returns
+    -------
+    rgba : numpy.ndarray
+        4 layer dimensional numpy.ndarray
+    """
     import numpy
     if alp is None:
         alp = alpha_from_masked_arrays([red, grn, blu])
     red.fill_value = 0
     grn.fill_value = 0
     blu.fill_value = 0
-    return numpy.dstack([red.filled(), grn.filled(), blu.filled(), alp])
+    rgba = numpy.dstack([red.filled(), grn.filled(), blu.filled(), alp])
+    return rgba
 
 
 def alpha_from_masked_arrays(arrays):
-    ''' Return an alpha transparency array based on the masks from a list of masked arrays. 0=transparent, 1=opaque
+    """
+    Convert from arrays to alpha.
 
-    Args:
-        arrays (list): list of numpy masked arrays, must all be the same shape
+    Return an alpha transparency array based on the masks from a list of
+    masked arrays. 0=transparent, 1=opaque
 
-    Returns:
-        numpy.ndarray : Returns a numpy array of floats to be used as the alpha transparency layer in matplotlib,
-                          values between 0 and 1, where
-                            0 is fully transparent and
-                            1 is fully opaque
-    '''
+    Parameters
+    ----------
+    arrays : numpy.ndarray
+        list of numpy masked arrays, must all be the same shape
+
+    Returns
+    -------
+    alp : numpy.ndarray
+        the alpha transparency layer in matplotlib, values between
+        0 and 1, where 0 is fully transparent and 1 is fully opaque
+    """
     import numpy
     alp = numpy.zeros(arrays[0].shape, dtype=numpy.bool)
     for img in arrays:
@@ -94,24 +117,32 @@ def alpha_from_masked_arrays(arrays):
 
 def plot_overlays(mapobj, curr_ax, area_def, boundaries_info, gridlines_info,
                   boundaries_zorder=None, gridlines_zorder=None):
-    ''' Plot specified coastlines and gridlines on the matplotlib axes.
+    """
+    Plot specified coastlines and gridlines on the matplotlib axes.
 
-    Args:
-        mapobj (map object): Basemap or CRS object for boundary and gridline plotting.
-        ax (matplotlib.axes._axes.Axes): matplotlib Axes object for boundary and gridline plotting.
-        area_def (AreaDefinition) : pyresample AreaDefinition object specifying the area covered by the current plot
-        boundaries_info (dict) : Dictionary of parameters for plotting map boundaries.
-                                 See geoips.image_utils.maps.set_boundaries_info_dict
-                                     for required fields and defaults
-        gridlines_info (dict) : Dictionary of parameters for plotting gridlines.
-                                If a field is not included in the dictionary, the default is used for that field.
-                                 See geoips.image_utils.maps.set_gridlines_info_dict
-                                     for required fields and defaults
-    Returns:
-        No return values. Overlays are plotted directly on the mapobj and ax instances.
+    Parameters
+    ----------
+    mapobj : map object
+        Basemap or CRS object for boundary and gridline plotting.
+    ax : matplotlib.axes._axes.Axes
+        matplotlib Axes object for boundary and gridline plotting.
+    area_def : AreaDefinition
+        pyresample AreaDefinition object specifying the area covered by
+        the current plot
+    boundaries_info : dict, optional
+        Dictionary of parameters for plotting map boundaries.
+    gridlines_info : dict, optional
+        Dictionary of parameters for plotting gridlines.
+        If a field is not included in the dictionary, the default is used
+        for that field.
 
-    '''
-
+    See Also
+    --------
+    geoips.image_utils.maps.set_boundaries_info_dict
+        for required fields and defaults for boundaries_info
+    geoips.image_utils.maps.set_gridlines_info_dict
+        for required fields and defaults for gridlines_info
+    """
     from geoips.image_utils.maps import set_boundaries_info_dict, set_gridlines_info_dict
     use_boundaries_info = set_boundaries_info_dict(boundaries_info)
     use_gridlines_info = set_gridlines_info_dict(gridlines_info, area_def)
@@ -124,17 +155,25 @@ def plot_overlays(mapobj, curr_ax, area_def, boundaries_info, gridlines_info,
 
 
 def save_image(fig, out_fname, is_final=True, image_datetime=None, remove_duplicate_minrange=None, savefig_kwargs=None):
-    ''' Save the image specified by the matplotlib figure "fig" to the filename out_fname.
+    """
+    Save the image specified by the matplotlib figure "fig" to the filename out_fname.
 
-    Args:
-        fig (Figure) : matplotlib.figure.Figure object that needs to be written to a file.
-        out_fname (str) : string specifying the full path to the output filename
-        is_final (bool) : Default True. Final imagery must set_axis_on for all axes. Non-final imagery must be
-                                        transparent with set_axis_off for all axes, and no pad inches.
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure object that needs to be written to a file.
+    out_fname : str
+        full path to the output filename
+    is_final : bool, default=True
+        Final imagery must set_axis_on for all axes. Non-final imagery
+        must be transparent with set_axis_off for all axes, and no pad
+        inches.
 
-    Returns:
-        No return values (image is written to disk and IMAGESUCCESS is written to log file)
-    '''
+    Notes
+    -----
+    No return values (image is written to disk and IMAGESUCCESS is
+    written to log file)
+    """
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.use('agg')
@@ -162,7 +201,7 @@ def save_image(fig, out_fname, is_final=True, image_datetime=None, remove_duplic
         if not pathexists(dirname(out_fname)):
             make_dirs(dirname(out_fname))
         # no annotations
-        # frameon=False makes it have no titles / lat/lons. does not avoid colorbar, since that is its own ax 
+        # frameon=False makes it have no titles / lat/lons. does not avoid colorbar, since that is its own ax
         for ax in fig.axes:
             LOG.info('Removing ax from %s', ax)
             ax.set_axis_off()
@@ -180,13 +219,43 @@ def save_image(fig, out_fname, is_final=True, image_datetime=None, remove_duplic
 
 
 def remove_duplicates(fname, min_range):
+    """Not implemented."""
     pass
 
 
 def get_title_string_from_objects(area_def, xarray_obj, product_name_title, product_datatype_title=None,
                                   bg_xarray=None, bg_product_name_title=None, bg_datatype_title=None,
                                   title_copyright=None, title_format=None):
+    """
+    Get the title from object information.
 
+    Parameters
+    ----------
+    area_def : AreaDefinition
+        pyresample AreaDefinition object specifying the area covered by
+        the current plot
+    xarray_obj : xarray.Dataset
+        data used to produce product
+    product_name_title : str
+        name to display for the title
+    product_datatype_title : str, optional
+        the data type
+    bg_xarray : xarray, optional
+        data used for background
+    bg_product_name_title : str, optional
+        background product title
+    bg_datatype_title : str, optional
+        background data type
+    title_copyright : str, optional
+        string for copyright
+    title_format : str, optional
+        format for title
+
+    Returns
+    -------
+    title_string : str
+        the title to use for matplotlib
+    """
     if title_copyright is None:
         title_copyright = gpaths['GEOIPS_COPYRIGHT']
 
@@ -232,17 +301,25 @@ def get_title_string_from_objects(area_def, xarray_obj, product_name_title, prod
 
 
 def plot_image(main_ax, data, mapobj, mpl_colors_info, zorder=None):
-    ''' Plot the "data" array and map in the matplotlib "main_ax"
+    """
+    Plot the "data" array and map in the matplotlib "main_ax".
 
-        Args:
-            main_ax (Axes) : matplotlib Axes object for plotting data and overlays 
-            data (numpy.ndarray) : Numpy array of data to plot
-            mapobj (Map Object) : Basemap or Cartopy CRS instance 
-            mpl_colors_info (dict) Specifies matplotlib Colors parameters for use in both plotting and colorbar
-                                   See geoips.image_utils.mpl_utils.create_colorbar for field descriptions.
-       Returns:
-            No return values
-    '''
+    Parameters
+    ----------
+    main_ax : Axes
+        matplotlib Axes object for plotting data and overlays
+    data : numpy.ndarray)
+        Numpy array of data to plot
+    mapobj : Map Object
+        Basemap or Cartopy CRS instance
+    mpl_colors_info : dict
+        Specifies matplotlib Colors parameters for use in both plotting and colorbar
+
+    See Also
+    --------
+    geoips.image_utils.mpl_utils.create_colorbar
+        for field descriptions for mpl_colors_info
+    """
     # main_ax.set_aspect('auto')
 
     LOG.info('imshow')
@@ -275,26 +352,40 @@ def plot_image(main_ax, data, mapobj, mpl_colors_info, zorder=None):
 
 def create_figure_and_main_ax_and_mapobj(x_size, y_size, area_def,
                                          font_size=None, existing_mapobj=None, noborder=False):
-    ''' Create a figure of x pixels horizontally and y pixels vertically. Use information from matplotlib.rcParams
-        xsize = (float(x_size)/dpi)/(right_margin - left_margin)
-        ysize = (float(y_size)/dpi)/(top_margin - bottom_margin)
-        fig = plt.figure(figsize=[xsize, ysize])
-        Parameters:
-            x_size (int): number pixels horizontally
-            y_size (int): number pixels vertically
-            area_def (AreaDefinition) : pyresample AreaDefinition object - used for
-                                        initializing map object (basemap or cartopy)
-            existing_mapobj (CRS or basemap) : Default None: If specified, do not regenerate mapobj. If None, create
-                                                             CRS or basemap object from specified area_def.
-            noborder (bool) : Default False: If true, use [0, 0, 1, 1] for axes (allowing for image exact shape of
-                                             sector).
-        Return:
-            (matplotlib.figure.Figure, matplotlib.axes._axes.Axes, mapobject)
-                matplotlib Figure object to subsequently use for plotting imagery / colorbars / etc
-                matplotlib Axes object corresponding to the single main plotting area.
-                cartopy crs or Basemap object for plotting
-    '''
+    """
+    Create a figure of x pixels horizontally and y pixels vertically.
 
+    Use information from matplotlib.rcParams.
+
+    Parameters
+    ----------
+    x_size : int
+        number pixels horizontally
+        xsize = (float(x_size)/dpi)/(right_margin - left_margin)
+    y_size : int
+        number pixels vertically
+        ysize = (float(y_size)/dpi)/(top_margin - bottom_margin)
+    font_size : int
+        matplotlib font size
+    area_def : AreaDefinition
+        pyresample AreaDefinition object - used for
+        initializing map object (basemap or cartopy)
+    existing_mapobj : CRS or basemap, optional
+        If specified, do not regenerate mapobj. If None, create
+        CRS or basemap object from specified area_def.
+    noborder : bool, default=False
+        If true, use [0, 0, 1, 1] for axes (allowing for image exact
+        shape of sector).
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        matplotlib Figure object to subsequently use for plotting imagery / colorbars / etc
+    main_ax : matplotlib.axes._axes.Axes
+        matplotlib Axes object corresponding to the single main plotting area.
+    mapobj : mapobject
+        cartopy crs or Basemap object for plotting
+    """
     import matplotlib
     matplotlib.use('agg')
     rc_params = matplotlib.rcParams
@@ -360,7 +451,7 @@ def create_figure_and_main_ax_and_mapobj(x_size, y_size, area_def,
                                 bottom_margin,
                                 right_margin - left_margin,
                                 top_margin - bottom_margin],
-	    						projection=mapobj,
+                                projection=mapobj,
                                 frame_on=not noborder,
                                )
     else:
@@ -372,11 +463,14 @@ def create_figure_and_main_ax_and_mapobj(x_size, y_size, area_def,
 
 
 def set_fonts(figure_y_size, font_size=None):
-    ''' Set the fonts in the matplotlib.rcParams dictionary, using matplotlib.rc
-        Parameters:
-            figure_y_size (int): Font size set relative to number of pixels in the y direction
-        No return values
-    '''
+    """
+    Set the fonts in the matplotlib.rcParams dictionary, using matplotlib.rc.
+
+    Parameters
+    ----------
+    figure_y_size : int
+        Font size set relative to number of pixels in the y direction
+    """
     import matplotlib
     matplotlib.use('agg')
     mplrc = matplotlib.rc
@@ -398,13 +492,24 @@ def set_fonts(figure_y_size, font_size=None):
 
 
 def set_title(ax, title_string, figure_y_size, xpos=None, ypos=None, fontsize=None):
-    ''' Set the title on figure axis "ax" to string "title_string" 
-        Parameters:
-            ax (Axes): matplotlib.axes._axes.Axes object to add the title
-            title_string (str): string specifying title to attach to axis "ax"
-            figure_y_size (int): vertical size of the image, used to proportionally set the title size
-        No returns
-    '''
+    """
+    Set the title on figure axis "ax" to string "title_string".
+
+    Parameters
+    ----------
+    ax : Axes
+        matplotlib.axes._axes.Axes object to add the title
+    title_string : str
+        string specifying title to attach to axis "ax"
+    figure_y_size : int
+        vertical size of the image, used to proportionally set the title size
+    xpos : float, optional
+        x position of the title
+    ypos : float, optional
+        y position of the title
+    fontsize : int, optional
+        matplotlib font size
+    """
     import matplotlib
     matplotlib.use('agg')
     rc_params = matplotlib.rcParams
@@ -430,32 +535,42 @@ def set_title(ax, title_string, figure_y_size, xpos=None, ypos=None, fontsize=No
 
 
 def create_colorbar(fig, mpl_colors_info):
-    '''Routine to create a single colorbar with specified matplotlib ColorbarBase parameters
-       cbar_ax = fig.add_axes([<cbar_start_pos>, <cbar_bottom_pos>, <cbar_width>, <cbar_height>])
-       cbar = matplotlib.colorbar.ColorbarBase(cbar_ax, cmap=mpl_cmap, extend='both', orientation='horizontal',
-                                               norm=cmap_norm, ticks=cmap_ticks, boundaries=cmap_boundaries,
-                                               spacing=cmap_spacing)
-       cbar.set_label(cbar_label, size=fontsize)
+    """
+    Routine to create a single colorbar.
 
-        Parameters:
-            fig (Figure): matplotlib.figure.Figure object to attach the colorbar - the colorbar will create its own ax
-            mpl_colors_info (dict) : Dictionary of matplotlib Color information, required fields below
-                mpl_colors_info['cmap'] (Colormap): matplotlib.colors.Colormap object (LinearSegmentedColormap, etc)
-                                                    - this is used to plot the image and to generated the colorbar
-                mpl_colors_info['norm'] (Normalize): matplotlib.colors.Normalize object (BoundaryNorm, Normalize, etc)
-                                                    - again, this should be used to plot the data also
-                mpl_colors_info['cbar_ticks'] (list): list of floats - values requiring tick marks on the colorbar
-                mpl_colors_info['cbar_tick_labels'] (list): list of values to use to label tick marks, if other than
-                                                            found in cmap_ticks
-                mpl_colors_info['boundaries'] (list): if cmap_norm is BoundaryNorm, list of boundaries for discrete
-                                                      colors
-                mpl_colors_info['cbar_spacing (string): DEFAULT 'proportional', 'uniform' or 'proportional'
-                mpl_colors_info['cbar_label (string): string label for colorbar
-                mpl_colors_info['colorbar']: (bool) True if a colorbar should be included in the image, False if no cbar
-        Returns:
-            (matplotlib.colorbar.ColorbarBase): This will have all the pertinent information for ensuring plot and
-                                                colorbar use the same parameters
-    '''
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure object to attach the colorbar - the colorbar will create its own ax
+    mpl_colors_info : dict
+        Dictionary of matplotlib Color information, required fields below
+            mpl_colors_info['cmap'] (Colormap): matplotlib.colors.Colormap object (LinearSegmentedColormap, etc)
+                                                - this is used to plot the image and to generated the colorbar
+            mpl_colors_info['norm'] (Normalize): matplotlib.colors.Normalize object (BoundaryNorm, Normalize, etc)
+                                                - again, this should be used to plot the data also
+            mpl_colors_info['cbar_ticks'] (list): list of floats - values requiring tick marks on the colorbar
+            mpl_colors_info['cbar_tick_labels'] (list): list of values to use to label tick marks, if other than
+                                                        found in cmap_ticks
+            mpl_colors_info['boundaries'] (list): if cmap_norm is BoundaryNorm, list of boundaries for discrete
+                                                  colors
+            mpl_colors_info['cbar_spacing (string): DEFAULT 'proportional', 'uniform' or 'proportional'
+            mpl_colors_info['cbar_label (string): string label for colorbar
+            mpl_colors_info['colorbar']: (bool) True if a colorbar should be included in the image, False if no cbar
+    Returns
+    -------
+    cbar : matplotlib.colorbar.ColorbarBase
+        This will have all the pertinent information for ensuring plot and
+        colorbar use the same parameters
+
+    Notes
+    -----
+    cbar_ax = fig.add_axes([<cbar_start_pos>, <cbar_bottom_pos>, <cbar_width>, <cbar_height>])
+    cbar = matplotlib.colorbar.ColorbarBase(cbar_ax, cmap=mpl_cmap, extend='both', orientation='horizontal',
+                                            norm=cmap_norm, ticks=cmap_ticks, boundaries=cmap_boundaries,
+                                            spacing=cmap_spacing)
+    cbar.set_label(cbar_label, size=fontsize)
+
+    """
     cmap_ticklabels = mpl_colors_info['cbar_tick_labels']
     cmap_ticks = mpl_colors_info['cbar_ticks']
     cmap_norm = mpl_colors_info['norm']


### PR DESCRIPTION
# Related Issues
fixes NRLMMD-GEOIPS/geoips#[XXX]

# Testing Instructions
Check for valid numpy docstrings:
```
find ./geoips/image_utils/ -type f -name "*.py" -exec pydocstyle --convention=numpy  "{}" \;
```

Check that basic test script still runs:
```
geoips/tests/test_base_install_low_memory.sh
```

# Summary
NRLMMD-GEOIPS/geoips#29: 2022-08-28, Update image_utils to numpy docstrings

### Documentation
* Update image_utils directory for proper numpy style docstrings
    * **geoips/image_utils/__init__.py**
    * **geoips/image_utils/colormap_utils.py**
    * **geoips/image_utils/maps.py**
    * **geoips/image_utils/mpl_utils.py**
* **geoips/compare_outputs.py** Update imagemagick compare metric from rmse to ae + fuzz 1%

# Output
No output from pydocstyle:
```
(geoips_conda) find ./geoips/image_utils/ -type f -name "*.py" -exec pydocstyle --convention=numpy  "{}" \;
(geoips_conda)
```

0 return from test script:
```
Package: geoips_base
Total run time: 145 seconds
Number data types run: 3
Number data types failed: 0
```
