### PR TITLE
Switch from GEOIPS_BASEDIR to GEOIPS_TESTDATA_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
     # # # for more details. If you did not receive the license, for more information see:
     # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
+# Use GEOIPS_TESTDATA_DIR rather than GEOIPS_BASEDIR/test_data
+* Updated all locations where `GEOIPS_BASEDIR/test_data` was used to use `GEOIPS_TESTDATA_DIR` 
+  instead
 
 # v1.5.4: 2022-11-28, open source release
 ## GEOIPS#119: 2022-11-16, installation updates, test script bug fixes

--- a/docs/available_functionality.rst
+++ b/docs/available_functionality.rst
@@ -139,7 +139,7 @@ v1.4.2
 ###################################
 
 ***********************************
-v1.4.2 Output Formats 
+v1.4.2 Output Formats
 ***********************************
 
 ***********************************
@@ -166,16 +166,16 @@ unprojected_image interface module:
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000001___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000002___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000003___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000004___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000005___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000006___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000007___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000008___-202004040800-C_ \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000001___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000002___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000003___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000004___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000005___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000006___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000007___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000008___-202004040800-C_ \
                  --procflow single_source \
                  --reader_name seviri_hrit \
                  --product_name WV-Upper \
@@ -192,12 +192,12 @@ unprojected_image interface module:
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
                  --procflow single_source \
                  --reader_name modis_hdf4 \
                  --product_name Infrared \
@@ -244,7 +244,7 @@ Text wind vectors sectored to a given region
 .. code:: bash
     :number-lines:
 
-    run_procflow ${GEOIPS_BASEDIR}/test_data/test_data_smos/data/SM_OPER_MIR_SCNFSW_20200216T120839_20200216T135041_110_001_7.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_smos/data/SM_OPER_MIR_SCNFSW_20200216T120839_20200216T135041_110_001_7.nc \
                  --procflow single_source \
                  --reader_name smos_winds_netcdf \
                  --product_name sectored \
@@ -288,7 +288,7 @@ Text wind vector output. No sectoring applied, full dataset converted to text wi
 .. code:: bash
     :number-lines:
 
-    run_procflow ${GEOIPS_BASEDIR}/test_data/test_data_smap/data/RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_smap/data/RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc \
                  --procflow single_source \
                  --reader_name smap_remss_winds_netcdf \
                  --product_name unsectored \
@@ -334,7 +334,7 @@ the HaiYang 2-B and 2-C scatterometer instruments.
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
                  --procflow single_source \
                  --reader_name scat_knmi_winds_netcdf \
                  --product_name windspeed \
@@ -406,7 +406,7 @@ Each full disk scene contains 16 NetCDF files - 1 file per channel.
                  --sector_list global \
                  --sectorfiles $GEOIPS/tests/sectors/static/global.yaml
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_abi_day/data/goes17_20210718_0150/
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_abi_day/data/goes17_20210718_0150/
                  --procflow single_source \
                  --reader_name abi_netcdf \
                  --product_name Infrared-Gray \
@@ -422,7 +422,7 @@ Each full disk scene contains 16 NetCDF files - 1 file per channel.
 
 .. image:: images/available_functionality/20210718.015031.goes-17.abi.Infrared-Gray.global.22p79.noaa.20p0.png
    :width: 600
-   
+
 
 AHI HSD
 ===================================
@@ -455,16 +455,16 @@ Each full disk scene contains 160 HSD files - 10 slices per band, with 16 bands 
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0110.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0210.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0310.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0410.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0510.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0610.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0710.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0810.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0910.DAT \
-                 $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S1010.DAT \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0110.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0210.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0310.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0410.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0510.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0610.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0710.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0810.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0910.DAT \
+                 $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S1010.DAT \
                  --procflow single_source \
                  --reader_name ahi_hsd \
                  --product_name Infrared-Gray \
@@ -506,7 +506,7 @@ This reader handles reader Goes VARiable (gvar) data in netcdf format.
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
                  --procflow single_source \
                  --reader_name ewsg_netcdf \
                  --product_name Infrared-Gray \
@@ -572,16 +572,16 @@ The GeoIPS installation and test script will prompt for PublicDecompWT download 
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000001___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000002___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000003___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000004___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000005___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000006___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000007___-202004040800-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000008___-202004040800-C_ \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000001___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000002___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000003___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000004___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000005___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000006___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000007___-202004040800-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000008___-202004040800-C_ \
                  --procflow single_source \
                  --reader_name seviri_hrit\
                  --product_name Infrared-Gray \
@@ -598,16 +598,16 @@ The GeoIPS installation and test script will prompt for PublicDecompWT download 
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-EPI______-202202092200-__ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000001___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000002___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000003___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000004___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000005___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000006___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000007___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000008___-202202092200-C_ \
-                 $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-PRO______-202202092200-__ \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-EPI______-202202092200-__ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000001___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000002___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000003___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000004___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000005___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000006___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000007___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000008___-202202092200-C_ \
+                 $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-PRO______-202202092200-__ \
                  --procflow single_source \
                  --reader_name seviri_hrit\
                  --product_name Infrared-Gray \
@@ -672,12 +672,12 @@ At night, a single granule consists of only the 1km dataset.
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
                  --procflow single_source \
                  --reader_name modis_hdf4 \
                  --product_name Infrared-Gray \
@@ -694,9 +694,9 @@ At night, a single granule consists of only the 1km dataset.
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD021KM.A2021004.1705.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD03.A2021004.1705.061.NRT.hdf \
-                 $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD14.A2021004.1705.006.NRT.hdf \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD021KM.A2021004.1705.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD03.A2021004.1705.061.NRT.hdf \
+                 $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD14.A2021004.1705.006.NRT.hdf \
                  --procflow single_source \
                  --reader_name modis_hdf4 \
                  --product_name Infrared-Gray \
@@ -747,10 +747,10 @@ See examples below for sample filenames.
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ102MOD.A2021040.0736.002.2021040145245.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ103MOD.A2021040.0736.002.2021040142228.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ102MOD.A2021040.0742.002.2021040143010.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ103MOD.A2021040.0742.002.2021040140938.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102MOD.A2021040.0736.002.2021040145245.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103MOD.A2021040.0736.002.2021040142228.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ102MOD.A2021040.0742.002.2021040143010.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103MOD.A2021040.0742.002.2021040140938.nc \
                  --procflow single_source \
                  --reader_name viirs_netcdf \
                  --product_name Infrared-Gray \
@@ -760,12 +760,12 @@ See examples below for sample filenames.
                  --sector_list global \
                  --sectorfiles $GEOIPS/tests/sectors/static/global.yaml
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02DNB.A2021036.0806.001.2021036140558.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02IMG.A2021036.0806.001.2021036140558.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02MOD.A2021036.0806.001.2021036140558.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03DNB.A2021036.0806.001.2021036135524.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03IMG.A2021036.0806.001.2021036135524.nc \
-                 $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03MOD.A2021036.0806.001.2021036135524.nc \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02DNB.A2021036.0806.001.2021036140558.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02IMG.A2021036.0806.001.2021036140558.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02MOD.A2021036.0806.001.2021036140558.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03DNB.A2021036.0806.001.2021036135524.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03IMG.A2021036.0806.001.2021036135524.nc \
+                 $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03MOD.A2021036.0806.001.2021036135524.nc \
                  --procflow single_source \
                  --reader_name viirs_netcdf \
                  --product_name Infrared-Gray \
@@ -980,9 +980,9 @@ GMI contains 13 channels between 10 and 183 GHz. See example call below for samp
 .. code:: bash
     :number-lines:
 
-    run_procflow $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
-                 $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
-                 $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
+    run_procflow $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
+                 $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
+                 $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
                  --procflow single_source \
                  --reader_name gmi_hdf5 \
                  --product_name 89H \

--- a/setup/bash_setup/gitall
+++ b/setup/bash_setup/gitall
@@ -1,22 +1,22 @@
 ##############################################################################
-### Convenience function that runs git in all available test data repos 
+### Convenience function that runs git in all available test data repos
 ##############################################################################
-function gitalltestdata { 
+function gitalltestdata {
   if [[ ! -z $PS1 ]]; then
 
     # Save current directory so they don't end up someplace new.
     cwd=$PWD
 
-    if [[ -e $GEOIPS_BASEDIR/test_data ]]; then
-        cd $GEOIPS_BASEDIR/test_data
+    if [[ -e $GEOIPS_TESTDATA_DIR ]]; then
+        cd $GEOIPS_TESTDATA_DIR
         mods=`ls`
         for mod in $mods; do
             # Print directory
-            echo -e "\033[1;35m$GEOIPS_BASEDIR/test_data/$mod:\n\t$@:\033[0m"
+            echo -e "\033[1;35m$GEOIPS_TESTDATA_DIR/$mod:\n\t$@:\033[0m"
             # Run the git command on passed arguments
             mkdir -p $GEOIPS_OUTDIRS/gitlog
-            logf=$GEOIPS_OUTDIRS/gitlog/`date +%Y%m%d%H%M`.log 
-            git -C $GEOIPS_BASEDIR/test_data/$mod $@ | tee -a $logf
+            logf=$GEOIPS_OUTDIRS/gitlog/`date +%Y%m%d%H%M`.log
+            git -C $GEOIPS_TESTDATA_DIR/$mod $@ | tee -a $logf
         done
     fi
 
@@ -26,9 +26,9 @@ function gitalltestdata {
 }
 
 ##############################################################################
-### Convenience function that runs git in all available repos 
+### Convenience function that runs git in all available repos
 ##############################################################################
-function gitall { 
+function gitall {
   if [[ ! -z $PS1 ]]; then
 
     # Save current directory so they don't end up someplace new.
@@ -42,7 +42,7 @@ function gitall {
             echo -e "\033[1;35m$GEOIPS_PACKAGES_DIR/$mod:\n\t$@:\033[0m"
             # Run the git command on passed arguments
             mkdir -p $GEOIPS_OUTDIRS/gitlog
-            logf=$GEOIPS_OUTDIRS/gitlog/`date +%Y%m%d%H%M`.log 
+            logf=$GEOIPS_OUTDIRS/gitlog/`date +%Y%m%d%H%M`.log
             git -C $GEOIPS_PACKAGES_DIR/$mod $@ | tee -a $logf
             cd ..
         done
@@ -54,9 +54,9 @@ function gitall {
 }
 
 ##############################################################################
-### Convenience function that runs ls in all available repos 
+### Convenience function that runs ls in all available repos
 ##############################################################################
-function lsall { 
+function lsall {
   if [[ ! -z $PS1 ]]; then
 
     # Save current directory so they don't end up someplace new.
@@ -81,9 +81,9 @@ function lsall {
 }
 
 ##############################################################################
-### Convenience function that runs grep in all available repos 
+### Convenience function that runs grep in all available repos
 ##############################################################################
-function grepall { 
+function grepall {
   if [[ ! -z $PS1 ]]; then
 
     # Save current directory so they don't end up someplace new.
@@ -106,4 +106,3 @@ function grepall {
     cd $cwd
   fi
 }
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,14 +26,14 @@ functionality within each repository.
 ```
     # Run a single ABI static sector Infrared test case:
     $GEOIPS_PACKAGES_DIR/geoips/tests/scripts/abi.sh
-    
+
     # Run multiple ABI products at once (TC Infrared-Gray, IR-BD, Visible, WV, and static Infrared)
     $GEOIPS_PACKAGES_DIR/geoips/tests/scripts/abi_config.sh
-    
+
     # Test all modules for correct standard interface - this automatically tests any new modules,
     # no modifications required to this script.
     $GEOIPS_PACKAGES_DIR/geoips/tests/scripts/test_interface.py
-    
+
     # Test ALL functionality within the current repo (just calls 3 scripts above, and ensures they all return 0)
     $GEOIPS_PACKAGES_DIR/geoips/tests/test_all.sh
 ```
@@ -50,12 +50,12 @@ regarding linking it to the standard release (we do not want to include test dat
 geoips source repo for size considerations.)
 
 ```
-mkdir -p $GEOIPS_BASEDIR/test_data/test_data_<type>
-mkdir $GEOIPS_BASEDIR/test_data/test_data_<type>/data
-mkdir $GEOIPS_BASEDIR/test_data/test_data_<type>/outputs
-mkdir $GEOIPS_BASEDIR/test_data/test_data_<type>/sectors
-mkdir -p $GEOIPS_BASEDIR/test_data/test_data_<type>/tests/scripts
-vim $GEOIPS_BASEDIR/test_data/test_data_<type>/tests/test_all.sh
+mkdir -p $GEOIPS_TESTDATA_DIR/test_data_<type>
+mkdir $GEOIPS_TESTDATA_DIR/test_data_<type>/data
+mkdir $GEOIPS_TESTDATA_DIR/test_data_<type>/outputs
+mkdir $GEOIPS_TESTDATA_DIR/test_data_<type>/sectors
+mkdir -p $GEOIPS_TESTDATA_DIR/test_data_<type>/tests/scripts
+vim $GEOIPS_TESTDATA_DIR/test_data_<type>/tests/test_all.sh
 ```
 
 Create "test_all.sh" script which will contain calls to ALL test scripts required to completely
@@ -63,28 +63,28 @@ test all functionality.  Contents of test_all.sh as follows (replace items in <>
 
 ```
    #!/bin/sh
-   
+
    # This should contain test calls to cover ALL required functionality tests for the geoips repo.
-   
+
    # The $GEOIPS tests modules sourced within this script handle:
    # setting up the appropriate associative arrays for tracking the overall return value,
-   # calling the test scripts appropriately, and 
+   # calling the test scripts appropriately, and
    # setting the final return value.
-   
+
    # Note you must use the variable "call" in the for the loop
-   
+
    . $GEOIPS/tests/utils/test_all_pre.sh <repo_name>
-   
+
    echo ""
    # "call" used in test_all_run.sh
    for call in \
-               "$GEOIPS_BASEDIR/test_data/test_data_<type>/tests/scripts/<test_script_1>" \
-               "$GEOIPS_BASEDIR/test_data/test_data_<type>/tests/scripts/<test_script_2>" \
-               "$GEOIPS_BASEDIR/test_data/test_data_<type>/tests/scripts/<test_script_3>"
+               "$GEOIPS_TESTDATA_DIR/test_data_<type>/tests/scripts/<test_script_1>" \
+               "$GEOIPS_TESTDATA_DIR/test_data_<type>/tests/scripts/<test_script_2>" \
+               "$GEOIPS_TESTDATA_DIR/test_data_<type>/tests/scripts/<test_script_3>"
    do
        . $GEOIPS/tests/utils/test_all_run.sh
    done
-   
+
    . $GEOIPS/tests/utils/test_all_post.sh
 ```
 
@@ -132,16 +132,16 @@ Once you've created a new test script, and produced valid test outputs, update t
 ```
    # Copy new files into test repos
    $GEOIPS_PACKAGES_DIR/geoips/tests/utils/copy_diffs_for_eval.sh <reponame>
-   
+
    # Evaluate the new outputs, ensure everything looks good
-   
+
    # Delete all the unnecessary files from the test repos, and any old "bad" products
    $GEOIPS_PACKAGES_DIR/geoips/tests/utils/delete_files_from_repo.sh <reponame>
-   
-   cd $GEOIPS_BASEDIR/test_data/test_data_<type>
+
+   cd $GEOIPS_TESTDATA_DIR/test_data_<type>
    # git commit appropriately
    # git push
-   
+
    # Add your new call to test_all.sh so we ensure it is in the testing rotation:
    vim $GEOIPS_PACKAGES_DIR/test_data/test_data_<type>/tests/test_all.sh
 ```

--- a/tests/scripts/ahi.tc.WV.geotiff.sh
+++ b/tests/scripts/ahi.tc.WV.geotiff.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/* \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/* \
           --procflow single_source \
           --reader_name ahi_hsd \
           --product_name WV \

--- a/tests/scripts/amsr2.tc.89H-Physical.imagery_annotated.sh
+++ b/tests/scripts/amsr2.tc.89H-Physical.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_amsr2/data/20200518.062048.gcom-w1.amsr2.amsr2_nesdismanatigcom.x.x.mbt.x.e202005180759470_c202005180937100.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_amsr2/data/20200518.062048.gcom-w1.amsr2.amsr2_nesdismanatigcom.x.x.mbt.x.e202005180759470_c202005180937100.nc \
           --procflow single_source \
           --reader_name amsr2_netcdf \
           --product_name 89H-Physical \

--- a/tests/scripts/amsub_mirs.tc.183-3H.imagery_annotated.sh
+++ b/tests/scripts/amsub_mirs.tc.183-3H.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_amsub/data/NPR-MIRS-IMG_v11r4_ma2_s202104192335000_e202104190118000_c202104200206490.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_amsub/data/NPR-MIRS-IMG_v11r4_ma2_s202104192335000_e202104190118000_c202104200206490.nc \
           --procflow single_source \
           --reader_name amsub_mirs \
           --product_name 183-3H \

--- a/tests/scripts/ascat_knmi.tc.windbarbs.imagery_windbarbs_clean.sh
+++ b/tests/scripts/ascat_knmi.tc.windbarbs.imagery_windbarbs_clean.sh
@@ -17,7 +17,7 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 # https://www.nrlmry.navy.mil/tcdat/tc2021/WP/WP022021/txt/SCT_winds_knmi_metop-c_WP02_202104210141
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/metopc_knmi_125/ascat_20210421_010000_metopc_12730_eps_o_coa_3203_ovw.l2.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_scat/data/metopc_knmi_125/ascat_20210421_010000_metopc_12730_eps_o_coa_3203_ovw.l2.nc \
           --procflow single_source \
           --reader_name scat_knmi_winds_netcdf \
           --product_name windbarbs \
@@ -37,4 +37,3 @@ run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/metopc_knmi_125/ascat
 ss_retval=$?
 
 exit $((ss_retval))
-

--- a/tests/scripts/ascat_low_knmi.tc.windbarbs.imagery_windbarbs.sh
+++ b/tests/scripts/ascat_low_knmi.tc.windbarbs.imagery_windbarbs.sh
@@ -17,7 +17,7 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 # https://www.nrlmry.navy.mil/tcdat/tc2021/WP/WP022021/txt/SCT_winds_knmi_metop-c_WP02_202104210141
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/metopc_knmi_250/ascat_20210421_010000_metopc_12730_eps_o_250_3203_ovw.l2.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_scat/data/metopc_knmi_250/ascat_20210421_010000_metopc_12730_eps_o_250_3203_ovw.l2.nc \
           --procflow single_source \
           --reader_name scat_knmi_winds_netcdf \
           --product_name windbarbs \
@@ -36,4 +36,3 @@ run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/metopc_knmi_250/ascat
 ss_retval=$?
 
 exit $((ss_retval))
-

--- a/tests/scripts/ascat_uhr.tc.wind-ambiguities.imagery_windbarbs.sh
+++ b/tests/scripts/ascat_uhr.tc.wind-ambiguities.imagery_windbarbs.sh
@@ -17,7 +17,7 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 # https://www.nrlmry.navy.mil/tcdat/tc2021/WP/WP022021/txt/SCT_winds_knmi_metop-c_WP02_202104210141
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/20210421_metopc_byu_uhr_tc2021wp02surigae/210421_0142_12730_SURIGAE_210421_0000.WRave3.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_scat/data/20210421_metopc_byu_uhr_tc2021wp02surigae/210421_0142_12730_SURIGAE_210421_0000.WRave3.nc \
           --procflow single_source \
           --reader_name ascat_uhr_netcdf \
           --product_name wind-ambiguities \
@@ -37,4 +37,3 @@ run_procflow $GEOIPS_BASEDIR/test_data/test_data_scat/data/20210421_metopc_byu_u
 ss_retval=$?
 
 exit $((ss_retval))
-

--- a/tests/scripts/atms.tc.165H.netcdf_geoips.sh
+++ b/tests/scripts/atms.tc.165H.netcdf_geoips.sh
@@ -17,20 +17,20 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 run_procflow \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0838266_e0838583_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0838586_e0839303_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0839306_e0840023_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0840026_e0840343_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0840346_e0841063_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0841066_e0841383_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0841386_e0842103_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0838266_e0838583_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0838586_e0839303_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0839306_e0840023_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0840026_e0840343_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0840346_e0841063_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0841066_e0841383_b19295_fnmoc_ops.h5 \
-          $GEOIPS_BASEDIR/test_data/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0841386_e0842103_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0838266_e0838583_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0838586_e0839303_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0839306_e0840023_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0840026_e0840343_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0840346_e0841063_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0841066_e0841383_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/GATMO_j01_d20210809_t0841386_e0842103_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0838266_e0838583_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0838586_e0839303_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0839306_e0840023_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0840026_e0840343_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0840346_e0841063_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0841066_e0841383_b19295_fnmoc_ops.h5 \
+          $GEOIPS_TESTDATA_DIR/test_data_atms/data/jpss-1_20210809_0838_tc2021ep11Kevin/SATMS_j01_d20210809_t0841386_e0842103_b19295_fnmoc_ops.h5 \
           --procflow single_source \
           --reader_name atms_hdf5 \
           --product_name 165H \

--- a/tests/scripts/documentation_imagery.sh
+++ b/tests/scripts/documentation_imagery.sh
@@ -87,7 +87,7 @@ check_returns $retval $output_image
 # 1.3.1 HY-2 Reader, hy2b
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
              --procflow single_source \
              --reader_name scat_knmi_winds_netcdf \
              --product_name windspeed \
@@ -114,7 +114,7 @@ check_returns $retval $output_image
 # ABI Reader - GOES-17
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_abi_day/data/goes17_20210718_0150/OR_ABI-L1b-RadF-M6C14_G17_s20211990150319_e20211990159386_c20211990159442.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_abi_day/data/goes17_20210718_0150/OR_ABI-L1b-RadF-M6C14_G17_s20211990150319_e20211990159386_c20211990159442.nc \
              --procflow single_source \
              --reader_name abi_netcdf \
              --product_name Infrared-Gray \
@@ -160,16 +160,16 @@ check_returns $retval $output_image
 # AHI Reader
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0110.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0210.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0310.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0410.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0510.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0610.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0710.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0810.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0910.DAT \
-             $GEOIPS_BASEDIR/test_data/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S1010.DAT \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0110.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0210.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0310.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0410.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0510.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0610.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0710.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0810.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S0910.DAT \
+             $GEOIPS_TESTDATA_DIR/test_data_ahi_day/data/20200405_0000/HS_H08_20200405_0000_B13_FLDK_R20_S1010.DAT \
              --procflow single_source \
              --reader_name ahi_hsd \
              --product_name Infrared-Gray \
@@ -192,7 +192,7 @@ check_returns $retval $output_image
 # EWS-G Reader
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
              --procflow single_source \
              --reader_name ewsg_netcdf \
              --product_name Infrared-Gray \
@@ -215,16 +215,16 @@ check_returns $retval $output_image
 # SEVIRI HRIT Reader - MSG-1
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000001___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000002___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000003___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000004___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000005___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000006___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000007___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000008___-202004040800-C_ \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000001___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000002___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000003___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000004___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000005___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000006___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000007___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-IR_108___-000008___-202004040800-C_ \
              --procflow single_source \
              --reader_name seviri_hrit\
              --product_name Infrared-Gray \
@@ -247,16 +247,16 @@ check_returns $retval $output_image
 # SEVIRI HRIT Reader - MSG-4
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-EPI______-202202092200-__ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000001___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000002___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000003___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000004___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000005___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000006___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000007___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000008___-202202092200-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-PRO______-202202092200-__ \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-EPI______-202202092200-__ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000001___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000002___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000003___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000004___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000005___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000006___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000007___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-IR_108___-000008___-202202092200-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20220209.2200_meteoEU/H-000-MSG4__-MSG4________-_________-PRO______-202202092200-__ \
              --procflow single_source \
              --reader_name seviri_hrit\
              --product_name Infrared-Gray \
@@ -283,12 +283,12 @@ check_returns $retval $output_image
 # MODIS Reader - Aqua
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
              --procflow single_source \
              --reader_name modis_hdf4 \
              --product_name Infrared-Gray \
@@ -311,9 +311,9 @@ check_returns $retval $output_image
 # MODIS Reader - Terra
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD021KM.A2021004.1705.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD03.A2021004.1705.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/terra/170500/MOD14.A2021004.1705.006.NRT.hdf \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD021KM.A2021004.1705.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD03.A2021004.1705.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/terra/170500/MOD14.A2021004.1705.006.NRT.hdf \
              --procflow single_source \
              --reader_name modis_hdf4 \
              --product_name Infrared-Gray \
@@ -336,10 +336,10 @@ check_returns $retval $output_image
 # VIIRS Reader - JPSS
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ102IMG.A2021040.0736.002.2021040145245.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ103IMG.A2021040.0736.002.2021040142228.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ102IMG.A2021040.0742.002.2021040143010.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ103IMG.A2021040.0742.002.2021040140938.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102IMG.A2021040.0736.002.2021040145245.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103IMG.A2021040.0736.002.2021040142228.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ102IMG.A2021040.0742.002.2021040143010.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103IMG.A2021040.0742.002.2021040140938.nc \
              --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Infrared-Gray \
@@ -362,12 +362,12 @@ check_returns $retval $output_image
 # VIIRS Reader - NPP
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02DNB.A2021036.0806.001.2021036140558.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02IMG.A2021036.0806.001.2021036140558.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP02MOD.A2021036.0806.001.2021036140558.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03DNB.A2021036.0806.001.2021036135524.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03IMG.A2021036.0806.001.2021036135524.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20210205/080600/VNP03MOD.A2021036.0806.001.2021036135524.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02DNB.A2021036.0806.001.2021036140558.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02IMG.A2021036.0806.001.2021036140558.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP02MOD.A2021036.0806.001.2021036140558.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03DNB.A2021036.0806.001.2021036135524.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03IMG.A2021036.0806.001.2021036135524.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20210205/080600/VNP03MOD.A2021036.0806.001.2021036135524.nc \
              --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Infrared-Gray \
@@ -406,9 +406,9 @@ check_returns $retval $output_image
 # GMI Reader
 ####################################################################
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
-             $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
-             $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
+             $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
+             $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
              --procflow single_source \
              --reader_name gmi_hdf5 \
              --product_name 89H \

--- a/tests/scripts/ewsg.static.Infrared.imagery_clean.sh
+++ b/tests/scripts/ewsg.static.Infrared.imagery_clean.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_ewsg/data/2020.1211.2312.goes-13.gvar.nc \
           --procflow single_source \
           --reader_name ewsg_netcdf \
           --product_name Infrared \

--- a/tests/scripts/gmi.tc.89pct.imagery_clean.sh
+++ b/tests/scripts/gmi.tc.89pct.imagery_clean.sh
@@ -16,9 +16,9 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
-             $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
-             $GEOIPS_BASEDIR/test_data/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5 \
+             $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5 \
+             $GEOIPS_TESTDATA_DIR/test_data_gpm/data/1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5 \
              --procflow single_source \
              --reader_name gmi_hdf5 \
              --product_name 89pct \

--- a/tests/scripts/hy2.tc.windspeed.imagery_annotated.sh
+++ b/tests/scripts/hy2.tc.windspeed.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_hy2/data/hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc \
           --procflow single_source \
           --reader_name scat_knmi_winds_netcdf \
           --product_name windspeed \

--- a/tests/scripts/imerg.tc.Rain.imagery_clean.sh
+++ b/tests/scripts/imerg.tc.Rain.imagery_clean.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_gpm/data/3B-HHR-L.MS.MRG.3IMERG.20200917-S170000-E172959.1020.V06B.RT-H5 \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_gpm/data/3B-HHR-L.MS.MRG.3IMERG.20200917-S170000-E172959.1020.V06B.RT-H5 \
           --procflow single_source \
           --reader_name imerg_hdf5 \
           --product_name Rain \

--- a/tests/scripts/mimic_coarse.static.TPW-CIMSS.imagery_annotated.sh
+++ b/tests/scripts/mimic_coarse.static.TPW-CIMSS.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_tpw/data/coarse/comp20210723.000000.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_tpw/data/coarse/comp20210723.000000.nc \
           --procflow single_source \
           --reader_name mimic_netcdf \
           --product_name TPW-CIMSS \

--- a/tests/scripts/mimic_fine.tc.TPW-PWAT.imagery_annotated.sh
+++ b/tests/scripts/mimic_fine.tc.TPW-PWAT.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_tpw/data/fine/comp20210419.230000.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_tpw/data/fine/comp20210419.230000.nc \
           --procflow single_source \
           --reader_name mimic_netcdf \
           --product_name TPW-PWAT \

--- a/tests/scripts/modis.Infrared.unprojected_image.sh
+++ b/tests/scripts/modis.Infrared.unprojected_image.sh
@@ -16,12 +16,12 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
-             $GEOIPS_BASEDIR/test_data/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD021KM.A2021004.2005.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/200500/MYD03.A2021004.2005.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD021KM.A2021004.2010.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201000/MYD03.A2021004.2010.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD021KM.A2021004.2015.061.NRT.hdf \
+             $GEOIPS_TESTDATA_DIR/test_data_modis/data/aqua/20210104/201500/MYD03.A2021004.2015.061.NRT.hdf \
              --procflow single_source \
              --reader_name modis_hdf4 \
              --product_name Infrared \

--- a/tests/scripts/oscat_knmi.tc.windbarbs.imagery_windbarbs.sh
+++ b/tests/scripts/oscat_knmi.tc.windbarbs.imagery_windbarbs.sh
@@ -18,7 +18,7 @@
 # set of arguments.
 # https://www.nrlmry.navy.mil/tcdat/tc2021/WP/WP022021/txt/SCT_winds_knmi_metop-c_WP02_202104210141
 run_procflow \
-    $GEOIPS_BASEDIR/test_data/test_data_scat/data/oscat_250/oscat_20210209_022459_scasa1_23155_o_250_2202_ovw_l2.nc \
+    $GEOIPS_TESTDATA_DIR/test_data_scat/data/oscat_250/oscat_20210209_022459_scasa1_23155_o_250_2202_ovw_l2.nc \
     --procflow single_source \
     --reader_name scat_knmi_winds_netcdf \
     --product_name windbarbs \
@@ -38,4 +38,3 @@ run_procflow \
 ss_retval=$?
 
 exit $((ss_retval))
-

--- a/tests/scripts/saphir.tc.183-3HNearest.imagery_annotated.sh
+++ b/tests/scripts/saphir.tc.183-3HNearest.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_saphir/data/MT1SAPSL1A__1.09_000_1_19_I_2021_02_09_00_30_03_2021_02_09_01_11_16_48144_48144_497_33_33_KUX_00.h5 \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_saphir/data/MT1SAPSL1A__1.09_000_1_19_I_2021_02_09_00_30_03_2021_02_09_01_11_16_48144_48144_497_33_33_KUX_00.h5 \
           --procflow single_source \
           --reader_name saphir_hdf5 \
           --product_name 183-3HNearest \

--- a/tests/scripts/sar.tc.nrcs.imagery_annotated.sh
+++ b/tests/scripts/sar.tc.nrcs.imagery_annotated.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_sar/data/STAR_SAR_20181025203206_WP312018_31W_FIX_3km.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_sar/data/STAR_SAR_20181025203206_WP312018_31W_FIX_3km.nc \
           --procflow single_source \
           --reader_name sar_winds_netcdf \
           --product_name nrcs \

--- a/tests/scripts/seviri.WV-Upper.unprojected_image.sh
+++ b/tests/scripts/seviri.WV-Upper.unprojected_image.sh
@@ -16,16 +16,16 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000001___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000002___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000003___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000004___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000005___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000006___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000007___-202004040800-C_ \
-             $GEOIPS_BASEDIR/test_data/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000008___-202004040800-C_ \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-EPI______-202004040800-__ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-_________-PRO______-202004040800-__ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000001___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000002___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000003___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000004___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000005___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000006___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000007___-202004040800-C_ \
+             $GEOIPS_TESTDATA_DIR/test_data_seviri/data/20200404.0800_meteoIO_tc2020sh24irondro/H-000-MSG1__-MSG1_IODC___-WV_062___-000008___-202004040800-C_ \
              --procflow single_source \
              --reader_name seviri_hrit \
              --product_name WV-Upper \

--- a/tests/scripts/smap.unsectored.text_winds.sh
+++ b/tests/scripts/smap.unsectored.text_winds.sh
@@ -19,7 +19,7 @@
 
 # For reference, bdeck file with coverage is: $GEOIPS/tests/sectored/bwp202021.dat
 # Not used for unsectored output, but potentially for other products
-run_procflow ${GEOIPS_BASEDIR}/test_data/test_data_smap/data/RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_smap/data/RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc \
              --procflow single_source \
              --reader_name smap_remss_winds_netcdf \
              --product_name unsectored \

--- a/tests/scripts/smos.tc.sectored.text_winds.sh
+++ b/tests/scripts/smos.tc.sectored.text_winds.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow ${GEOIPS_BASEDIR}/test_data/test_data_smos/data/SM_OPER_MIR_SCNFSW_20200216T120839_20200216T135041_110_001_7.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_smos/data/SM_OPER_MIR_SCNFSW_20200216T120839_20200216T135041_110_001_7.nc \
              --procflow single_source \
              --reader_name smos_winds_netcdf \
              --product_name sectored \

--- a/tests/scripts/ssmi.tc.37pct.imagery_clean.sh
+++ b/tests/scripts/ssmi.tc.37pct.imagery_clean.sh
@@ -17,8 +17,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 run_procflow \
-          $GEOIPS_BASEDIR/test_data/test_data_ssmi/data/US058SORB-DEFspp.sdrmi_f15_d20200519_s080800_e095300_r05633_cfnoc.def \
-          $GEOIPS_BASEDIR/test_data/test_data_ssmi/data/US058SORB-DEFspp.tdrmi_f15_d20200519_s080800_e095300_r05633_cfnoc.def \
+          $GEOIPS_TESTDATA_DIR/test_data_ssmi/data/US058SORB-DEFspp.sdrmi_f15_d20200519_s080800_e095300_r05633_cfnoc.def \
+          $GEOIPS_TESTDATA_DIR/test_data_ssmi/data/US058SORB-DEFspp.tdrmi_f15_d20200519_s080800_e095300_r05633_cfnoc.def \
           --procflow single_source \
           --reader_name ssmi_binary \
           --product_name 37pct \

--- a/tests/scripts/ssmis.color89.unprojected_image.sh
+++ b/tests/scripts/ssmis.color89.unprojected_image.sh
@@ -16,7 +16,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_ssmis/data/US058SORB-RAWspp.sdris_f16_d20200519_s084400_e102900_r85579_cfnoc.raw \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_ssmis/data/US058SORB-RAWspp.sdris_f16_d20200519_s084400_e102900_r85579_cfnoc.raw \
           --procflow single_source \
           --reader_name ssmis_binary \
           --product_name color89 \

--- a/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image.sh
+++ b/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image.sh
@@ -17,18 +17,18 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP02DNB.A2022042.1312.001.2022042183606.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP02IMG.A2022042.1312.001.2022042183606.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP02MOD.A2022042.1312.001.2022042183606.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP03DNB.A2022042.1312.001.2022042182240.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP03IMG.A2022042.1312.001.2022042182240.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131200/VNP03MOD.A2022042.1312.001.2022042182240.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP02DNB.A2022042.1318.001.2022042183444.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP02IMG.A2022042.1318.001.2022042183444.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP02MOD.A2022042.1318.001.2022042183444.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP03DNB.A2022042.1318.001.2022042182210.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP03IMG.A2022042.1318.001.2022042182210.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/npp/20220211/131800/VNP03MOD.A2022042.1318.001.2022042182210.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP02DNB.A2022042.1312.001.2022042183606.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP02IMG.A2022042.1312.001.2022042183606.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP02MOD.A2022042.1312.001.2022042183606.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP03DNB.A2022042.1312.001.2022042182240.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP03IMG.A2022042.1312.001.2022042182240.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131200/VNP03MOD.A2022042.1312.001.2022042182240.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP02DNB.A2022042.1318.001.2022042183444.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP02IMG.A2022042.1318.001.2022042183444.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP02MOD.A2022042.1318.001.2022042183444.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP03DNB.A2022042.1318.001.2022042182210.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP03IMG.A2022042.1318.001.2022042182210.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20220211/131800/VNP03MOD.A2022042.1318.001.2022042182210.nc \
              --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Night-Vis-IR-GeoIPS1 \

--- a/tests/scripts/viirsday.tc.Night-Vis-IR.imagery_annotated.sh
+++ b/tests/scripts/viirsday.tc.Night-Vis-IR.imagery_annotated.sh
@@ -17,14 +17,14 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ102DNB.A2021040.0736.002.2021040145245.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ102MOD.A2021040.0736.002.2021040145245.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ103DNB.A2021040.0736.002.2021040142228.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/073600/VJ103MOD.A2021040.0736.002.2021040142228.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ102DNB.A2021040.0742.002.2021040143010.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ102MOD.A2021040.0742.002.2021040143010.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ103DNB.A2021040.0742.002.2021040140938.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210209/074200/VJ103MOD.A2021040.0742.002.2021040140938.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102DNB.A2021040.0736.002.2021040145245.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102MOD.A2021040.0736.002.2021040145245.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103DNB.A2021040.0736.002.2021040142228.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103MOD.A2021040.0736.002.2021040142228.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ102DNB.A2021040.0742.002.2021040143010.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ102MOD.A2021040.0742.002.2021040143010.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103DNB.A2021040.0742.002.2021040140938.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103MOD.A2021040.0742.002.2021040140938.nc \
              --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Night-Vis-IR \

--- a/tests/scripts/viirsmoon.tc.Night-Vis-GeoIPS1.imagery_clean.sh
+++ b/tests/scripts/viirsmoon.tc.Night-Vis-GeoIPS1.imagery_clean.sh
@@ -17,12 +17,12 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ102DNB.A2021145.1912.002.2021146004551.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ102IMG.A2021145.1912.002.2021146004551.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ102MOD.A2021145.1912.002.2021146004551.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ103DNB.A2021145.1912.002.2021146002749.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ103IMG.A2021145.1912.002.2021146002749.nc \
-             $GEOIPS_BASEDIR/test_data/test_data_viirs/data/jpss/20210525/191200/VJ103MOD.A2021145.1912.002.2021146002749.nc \
+run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ102DNB.A2021145.1912.002.2021146004551.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ102IMG.A2021145.1912.002.2021146004551.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ102MOD.A2021145.1912.002.2021146004551.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ103DNB.A2021145.1912.002.2021146002749.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ103IMG.A2021145.1912.002.2021146002749.nc \
+             $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210525/191200/VJ103MOD.A2021145.1912.002.2021146002749.nc \
              --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Night-Vis-GeoIPS1 \

--- a/tests/utils/copy_diffs_for_eval.sh
+++ b/tests/utils/copy_diffs_for_eval.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "" ]]; then
     echo ""
     echo "Where <repo_name> either"
     echo "    $GEOIPS_PACKAGES_DIR/<repo_name>"
-    echo "    $GEOIPS_BASEDIR/test_data/<repo_name>"
+    echo "    $GEOIPS_TESTDATA_DIR/<repo_name>"
     exit 1
 fi
 
@@ -29,8 +29,8 @@ echo ""
 echo ""
 echo "Clearing out old test files (but NOT full diff_test_output dirs)..."
 echo ""
-rm -fv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*diff_test_output* 2> /dev/null
-rm -fv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*diff_test_output* 2> /dev/null
+rm -fv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*diff_test_output* 2> /dev/null
+rm -fv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*diff_test_output* 2> /dev/null
 rm -fv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*diff_test_output* 2> /dev/null
 rm -fv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*diff_test_output* 2> /dev/null
 rm -fv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*diff_test_output* 2> /dev/null
@@ -40,10 +40,10 @@ rm -fv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*/*diff_test_output* 
 echo ""
 echo ""
 echo ""
-echo "Copying the updated imagery files into $GEOIPS_BASEDIR/test_data/$repo_name/outputs/ ..."
+echo "Copying the updated imagery files into $GEOIPS_TESTDATA_DIR/$repo_name/outputs/ ..."
 echo ""
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/diff_test_output*/cp_*; do source $fname; done
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/diff_test_output*/cp_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/diff_test_output*/cp_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/diff_test_output*/cp_*; do source $fname; done
 for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/diff_test_output*/cp_*; do source $fname; done
 for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/diff_test_output*/cp_*; do source $fname; done
 for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/diff_test_output*/cp_*; do source $fname; done
@@ -55,8 +55,8 @@ echo ""
 echo "Running diffs on the newly copied files and the old files in the test repo:"
 echo ""
 # Look in both levels - some output product directories are directly in outputs, some in a subdirectory
-for dirname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/* \
-               $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/* \
+for dirname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/* \
+               $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/* \
@@ -82,10 +82,10 @@ done
 echo ""
 echo ""
 echo ""
-echo "Copying auto-generated diffs into $GEOIPS_BASEDIR/test_data/test_data_*/outputs/ "
+echo "Copying auto-generated diffs into $GEOIPS_TESTDATA_DIR/test_data_*/outputs/ "
 echo ""
-for dirname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/diff_test_output* \
-               $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/diff_test_output* \
+for dirname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/diff_test_output* \
+               $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/diff_test_output* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/diff_test_output* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/diff_test_output* \
                $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/diff_test_output* \
@@ -102,15 +102,15 @@ done
 echo ""
 echo ""
 echo ""
-echo "Removing empty yaml diff files from $GEOIPS_BASEDIR/test_data/$repo_name/outputs"
+echo "Removing empty yaml diff files from $GEOIPS_TESTDATA_DIR/$repo_name/outputs"
 echo ""
-find $GEOIPS_BASEDIR/test_data/$repo_name/outputs -maxdepth 1 -type f -name '*yaml' -size 0 -exec rm -v {} \;
+find $GEOIPS_TESTDATA_DIR/$repo_name/outputs -maxdepth 1 -type f -name '*yaml' -size 0 -exec rm -v {} \;
 
 echo ""
 echo ""
 echo ""
 echo "Now go look at the diffs in"
-echo "    $GEOIPS_BASEDIR/test_data/$repo_name"
+echo "    $GEOIPS_TESTDATA_DIR/$repo_name"
 echo "    $GEOIPS_PACKAGES_DIR/$repo_name"
 echo ""
 echo "Once you have evaluated the diffs, run:"

--- a/tests/utils/delete_diff_dirs.sh
+++ b/tests/utils/delete_diff_dirs.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "" ]]; then
     echo ""
     echo "Where <repo_name> either"
     echo "    $GEOIPS_PACKAGES_DIR/<repo_name>"
-    echo "    $GEOIPS_BASEDIR/test_data/<repo_name>"
+    echo "    $GEOIPS_TESTDATA_DIR/<repo_name>"
     exit 1
 fi
 
@@ -27,15 +27,15 @@ repo_name=$1
 echo "Deleting comparison files from test repos"
 # This will delete all test comparison files - the full directories as well as the individual files at the top level.
 # This is in preparation for updating all the test repos - assume we're done with all comparison files at this point.
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/*diff_test_output*
-rm -rfv $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/*diff_test_output*
+rm -rfv $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/*diff_test_output*
 
 rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*diff_test_output*
 rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*diff_test_output*
@@ -49,4 +49,3 @@ rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*diff_test_output*
 rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*diff_test_output*
 rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*diff_test_output*
 rm -rfv $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*diff_test_output*
-

--- a/tests/utils/delete_files_from_repo.sh
+++ b/tests/utils/delete_files_from_repo.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "" ]]; then
     echo ""
     echo "Where <repo_name> either"
     echo "    $GEOIPS_PACKAGES_DIR/<repo_name>"
-    echo "    $GEOIPS_BASEDIR/test_data/<repo_name>"
+    echo "    $GEOIPS_TESTDATA_DIR/<repo_name>"
     exit 1
 fi
 
@@ -26,10 +26,10 @@ repo_name=$1
 
 echo "Deleting bad files from test repos"
 # Include 2 levels - some repos have a subdirectory organization.
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/diff_test_output*/rm_*; do source $fname; done
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/diff_test_output*/rm_*; do source $fname; done
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/*/diff_test_output*/rm_*; do source $fname; done
-for fname in $GEOIPS_BASEDIR/test_data/$repo_name/outputs/*/*/*/*/diff_test_output*/rm_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/diff_test_output*/rm_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/diff_test_output*/rm_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/*/diff_test_output*/rm_*; do source $fname; done
+for fname in $GEOIPS_TESTDATA_DIR/$repo_name/outputs/*/*/*/*/diff_test_output*/rm_*; do source $fname; done
 
 for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/diff_test_output*/rm_*; do source $fname; done
 for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/diff_test_output*/rm_*; do source $fname; done
@@ -40,6 +40,6 @@ for fname in $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs/*/*/*/*/diff_test_out
 $GEOIPS_PACKAGES_DIR/geoips/tests/utils/delete_diff_dirs.sh $repo_name
 
 echo "Now go to the individual "
-echo "    $GEOIPS_BASEDIR/test_data/$repo_name/outputs"
+echo "    $GEOIPS_TESTDATA_DIR/$repo_name/outputs"
 echo "    $GEOIPS_PACKAGES_DIR/$repo_name/tests/outputs"
 echo "directories and add/commit new/removed/modified files"


### PR DESCRIPTION
# Related Issues
fixes NRLMMD-GEOIPS/geoips#57

# Testing Instructions
- Spot check scripts in `./geoips/tests/scripts`
- More thoroughly check the following:
    - `./setup/bash_setup/gitall`
    - `./docs/available_functionality.rst`
    - `./geoips/tests/utils/copy_diffs_for_eval.sh`
    - `./geoips/tests/utils/delete_diff_dirs.sh`
    - `./geoips/tests/utils/delete_files_from_repo.sh`

# Summary
### Update all uses of GEOIPS_BASEDIR/test_data to use GEOIPS_TESTDATA_DIR instead                                                                                                                                                                             
* Found all uses of GEOIPS_BASEDIR/test_data and replaced with GEOIPS_TESTDATA_DIR
  * Except where GEOIPS_BASEDIR/test_data is used to initialize GEOIPS_TESTDATA_DIR
