### PR TITLE
Update test_interfaces to include new interface modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,19 @@ Add validation tests to Base interface class
 Add separate interface tests for deprecated and new interfaces
 --------------------------------------------------------------
 
-* test_interfaces.py:
+* Move tests for deprecated interfaces to a separate function - will eventually be
+  removed.
+* Call both "plugins_all_valid" and "test_interface_plugins" for new interfaces.
 
-  * Some modifications to work with the name changes in the class-based interfaces
+  * "plugins_all_valid" merely returns True or False for full interface (if any fail,
+    returns False, error raised at the end of "test_interfaces")
+  * "test_interface_plugins" actually opens every plugin, and tests individually - if
+    any fail, they will be added to the failed_plugins list and an error raised at the
+    end for non-zero return.
+
+* Add logic to save lists of successful and failed interfaces - print all status at
+  the end, and only raise an error after printing full list of successful/failed
+  plugins.
 
 ::
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@
     # # # for more details. If you did not receive the license, for more information see:
     # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
+## GEOIPS/geoips#91: 2023-02-14, update test_interfaces
+### Installation and Test
+* interfaces:
+  * Added required arguments to class interfaces
+  * Renamed FilenameFormats class to FilenameFormatsInterface to match other interfaces
+* test_interfaces.py:
+  * Some modifications to work with the name changes in the class-based interfaces
+* base.py:
+  * is_valid: Added checks of required arguments to determine if a plugin's call
+    signature matches what is expected
+  * get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
+    changes to avoid future functionality to get tests to run successfully
+* abi_netcdf.py, ahi_hsd.py:
+  * Removed unused import of Hashable
+
 ## GEOIPS/geoips#92: 2023-02-09, update FilenameFormats class name
 ### Bug fixes
 * filename_formats.py:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ Removed unused import of Hashable
     geoips/interface_modules/readers/abi_netcdf.py
     geoips/interface_modules/readers/ahi_hsd.py
 
+Switched coverage from positional parameter to keyword argument
+---------------------------------------------------------------
+
+Standard filename format expects "coverage" to be a keyword argument, not a positional
+parameter.  Update filename formats accordingly so test_interfaces passes.
+
+::
+
+    modified: geoips/interface_modules/filename_formats/geoips_fname.py
+    modified: geoips/interface_modules/filename_formats/geotiff_fname.py
+    modified: geoips/interface_modules/filename_formats/tc_clean_fname.py
+    modified: geoips/interface_modules/filename_formats/tc_fname.py
+
 Installation and Test
 =====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@
 Bug fixes
 =========
 
+Add "self" to plugin_module_to_obj calls in "get_plugins"
+---------------------------------------------------------
+
+Fixed incorrect calls to plugin_module_to_obj from within get_plugins method.
+This was previously untested (prior to implementing "test_interfaces"
+
+::
+
+    modified:   geoips/interfaces/base.py
+
 Removed unused import of Hashable
 ---------------------------------
 
@@ -66,8 +76,7 @@ Add validation tests to Base interface class
 
 * plugin_is_valid: Added checks for required arguments and keyword arguments
   to determine if a plugin call signature matches what is expected
-* get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
-  changes to avoid future functionality to get tests to run successfully
+* test_interface: ensure all methods are functional, and all plugins are valid
 * plugins_all_valid: returns True if all plugins in the current interface are valid,
   False if any plugins are invalid (calls "plugin_is_valid" on each plugin)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,76 @@
     # # # for more details. If you did not receive the license, for more information see:
     # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
+
 ## GEOIPS/geoips#91: 2023-02-14, update test_interfaces
-### Installation and Test
-* interfaces:
-  * Added required arguments to class interfaces
-  * Renamed FilenameFormats class to FilenameFormatsInterface to match other interfaces
+
+*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
+************************************************************************
+
+Bug fixes
+=========
+
+Removed unused import of Hashable
+---------------------------------
+
+*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
+
+::
+
+    geoips/interface_modules/readers/abi_netcdf.py
+    geoips/interface_modules/readers/ahi_hsd.py
+
+Installation and Test
+=====================
+
+Add validation tests to Base interface class
+--------------------------------------------
+
+*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
+
+* plugin_is_valid: Added checks of required arguments to determine if a plugin's call
+  signature matches what is expected
+* get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
+  changes to avoid future functionality to get tests to run successfully
+* plugins_all_valid: returns True if all plugins in the current interface are valid,
+  False if any plugins are invalid (calls "plugin_is_valid" on each plugin)
+
+::
+
+    modified:   geoips/interfaces/base.py
+
+Add separate interface tests for deprecated and new interfaces
+--------------------------------------------------------------
+
 * test_interfaces.py:
+
   * Some modifications to work with the name changes in the class-based interfaces
-* base.py:
-  * plugin_is_valid: Added checks of required arguments to determine if a plugin's call
-    signature matches what is expected
-  * get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
-    changes to avoid future functionality to get tests to run successfully
-  * plugins_all_valid: returns True if all plugins in the current interface are valid,
-    False if any plugins are invalid (calls "plugin_is_valid" on each plugin)
-* abi_netcdf.py, ahi_hsd.py:
-  * Removed unused import of Hashable
+
+::
+
+    modified:   geoips/commandline/test_interfaces.py
+
+Update interface modules for validation testing
+-----------------------------------------------
+
+*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
+
+* Add required_args and required_kwargs to all interface modules
+* Standardize interface class names
+  * FilenameFormats -> FilenameFormatsInterface
+  * ColorMapInterface -> ColormapsInterface
+  * TitleFormattersInterface -> TitleFormatsInterface
+
+::
+
+    modified:   geoips/interfaces/algorithms.py
+    modified:   geoips/interfaces/colormaps.py
+    modified:   geoips/interfaces/filename_formats.py
+    modified:   geoips/interfaces/interpolators.py
+    modified:   geoips/interfaces/output_formats.py
+    modified:   geoips/interfaces/procflows.py
+    modified:   geoips/interfaces/readers.py
+    modified:   geoips/interfaces/title_formats.py
 
 ## GEOIPS/geoips#92: 2023-02-09, update FilenameFormats class name
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,13 +132,15 @@ Add separate interface tests for deprecated and new interfaces
 
 * Move tests for deprecated interfaces to a separate function - will eventually be
   removed.
-* Call both "plugins_all_valid" and "test_interface_plugins" for new interfaces.
+* Call only "test_interfaces" for all new-style interfaces.
 
-  * "plugins_all_valid" merely returns True or False for full interface (if any fail,
-    returns False, error raised at the end of "test_interfaces")
-  * "test_interface_plugins" actually opens every plugin, and tests individually - if
-    any fail, they will be added to the failed_plugins list and an error raised at the
-    end for non-zero return.
+  * "test_interface_plugins" actually tests every interface method, to ensure all work.
+
+    * get_plugins
+    * plugins_all_valid
+    * get_plugin
+    * plugin_is_valid
+    * Check every attribute (family, name, description)
 
 * Add logic to save lists of successful and failed interfaces - print all status at
   the end, and only raise an error after printing full list of successful/failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ Add validation tests to Base interface class
 
 *From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
 
-* plugin_is_valid: Added checks of required arguments to determine if a plugin's call
-  signature matches what is expected
+* plugin_is_valid: Added checks for required arguments and keyword arguments
+  to determine if a plugin call signature matches what is expected
 * get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
   changes to avoid future functionality to get tests to run successfully
 * plugins_all_valid: returns True if all plugins in the current interface are valid,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@
 * test_interfaces.py:
   * Some modifications to work with the name changes in the class-based interfaces
 * base.py:
-  * is_valid: Added checks of required arguments to determine if a plugin's call
+  * plugin_is_valid: Added checks of required arguments to determine if a plugin's call
     signature matches what is expected
   * get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
     changes to avoid future functionality to get tests to run successfully
+  * plugins_all_valid: returns True if all plugins in the current interface are valid,
+    False if any plugins are invalid (calls "plugin_is_valid" on each plugin)
 * abi_netcdf.py, ahi_hsd.py:
   * Removed unused import of Hashable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ parameter.  Update filename formats accordingly so test_interfaces passes.
 Installation and Test
 =====================
 
+Updated 89pct and 37pct products for function name "call"
+---------------------------------------------------------
+
+* Replaced pmw_37pct and pmw_89pct algorithm function names with default "call"
+* Updated setup.py to point to pmw_37pct module vs pmw_37pct.pmw_37pct Callable
+  function.
+* This provides 2 working examples of fully updated plugins.
+
+::
+
+        modified:   geoips/interface_modules/algorithms/pmw_tb/pmw_37pct.py
+        modified:   geoips/interface_modules/algorithms/pmw_tb/pmw_89pct.py
+        modified:   setup.py
+
 Add validation tests to Base interface class
 --------------------------------------------
 

--- a/geoips/commandline/test_interfaces.py
+++ b/geoips/commandline/test_interfaces.py
@@ -125,7 +125,7 @@ def main():
         # This returns a dictionary of all sorts of stuff.
         # If this fails and plugins_all_valid passes, we have a problem.
         try:
-            out_dict = test_curr_interface.test_interface_plugins()
+            out_dict = test_curr_interface.test_interface()
             out_dicts[curr_interface] = out_dict
         except Exception:
             print(traceback.format_exc())

--- a/geoips/commandline/test_interfaces.py
+++ b/geoips/commandline/test_interfaces.py
@@ -20,79 +20,36 @@ from importlib import import_module
 import traceback
 
 
-def main():
-    """Script to test all dev and stable interfaces."""
-    # Removed all interfaces that have been moved to new setup.
-    # This entire testing construct will be updated in the future to more fully
-    # test/validate the plugins.
+def test_deprecated_interfaces():
+    """Test the "old" deprecated interfaces.
+
+    This function will be removed once all interfaces are moved to the "new" setup.
+    """
+
     interfaces = [
-        "interfaces.algorithms",
         "dev.boundaries",
-        "interfaces.colormaps",
-        "interfaces.filename_formats",
         "dev.gridlines",
-        "interfaces.interpolators",
-        "interfaces.output_formats",
-        "interfaces.procflows",
         "dev.product",
-        "interfaces.readers",
-        "interfaces.title_formats",
     ]
 
-    interface_name_outliers = {'Boundaries': 'Map',
-                               'Colormaps': 'ColorMaps',
-                               'TitleFormats': 'TitleFormatters',
-                               }
-
     for curr_interface in interfaces:
-        #interface_name = curr_interface.split(".")[1]
-        raw_interface_name = curr_interface.split(".")[1]
-
-        interface_name = "".join([name.capitalize() for name in raw_interface_name.split('_')])
-
-        if interface_name in interface_name_outliers:
-            interface_name = interface_name_outliers[interface_name]
-
+        interface_name = curr_interface.split(".")[1]
         print("")
         print(f"Testing {curr_interface}...")
         print("ipython")
-
+        print(
+            f"    from geoips.{curr_interface} import test_{interface_name}_interface"
+        )
+        print(f"    test_{interface_name}_interface()")
+        test_curr_interface = getattr(
+            import_module(f"geoips.{curr_interface}"),
+            f"test_{interface_name}_interface",
+        )
         try:
-            test_curr_interface = getattr(
-                import_module(f"geoips.{curr_interface}"),
-                f"{interface_name}Interface",
-            )
-            print(
-                f"    from geoips.{curr_interface} import {interface_name}Interface"
-            )
-            print(f"    {interface_name}Interface()")
-
-            curr_class = test_curr_interface()
-
-            try:
-                out_dict = curr_class.test_interface_plugins()
-            except Exception:
-                print(traceback.format_exc())
-                raise
-        except AttributeError:
-            interface_name = raw_interface_name
-
-            test_curr_interface = getattr(
-                import_module(f"geoips.{curr_interface}"),
-                f"test_{interface_name}_interface",
-            )
-            print(
-                f"    from geoips.{curr_interface} import test_{interface_name}_interface"
-            )
-            print(f"    test_{interface_name}_interface()")
-
-            try:
-                out_dict = test_curr_interface()
-            except Exception:
-                print(traceback.format_exc())
-                raise
-
-        print(f"SUCCESSFUL INTERFACE {curr_interface}")
+            out_dict = test_curr_interface()
+        except Exception:
+            print(traceback.format_exc())
+            raise
 
         ppprinter = pprint.PrettyPrinter(indent=2)
         ppprinter.pprint(out_dict)
@@ -103,6 +60,65 @@ def main():
                 raise TypeError(
                     f"Failed validity check on {modname} in interface {curr_interface}"
                 )
+
+        print(f"SUCCESSFUL INTERFACE {curr_interface}")
+
+
+def main():
+    """Script to test all dev and stable interfaces."""
+
+    # Test all the "old" interfaces using the original logic.
+    test_deprecated_interfaces()
+
+    interfaces = [
+        "algorithms",
+        "colormaps",
+        "filename_formats",
+        "interpolators",
+        "output_formats",
+        "procflows",
+        "readers",
+        "title_formats",
+    ]
+
+    for curr_interface in interfaces:
+
+        print("")
+        print(f"Testing {curr_interface}...")
+
+        test_curr_interface = getattr(
+            import_module(f"geoips.interfaces"), curr_interface
+        )
+        print(f"    from geoips.interfaces import {curr_interface}")
+
+        # First just use plugins_all_valid, will return True or False
+        all_valid = test_curr_interface.plugins_all_valid()
+        if not all_valid:
+            raise TypeError(
+                f"Failed validity check on interface {curr_interface}",
+                f"plugins_all_valid returned {all_valid}"
+            )
+
+        # Now open all the interfaces (not just checking call signatures)
+        # This returns a dictionary of all sorts of stuff.
+        # If this fails and plugins_all_valid passes, we have a problem.
+        try:
+            out_dict = test_curr_interface.test_interface_plugins()
+        except Exception:
+            print(traceback.format_exc())
+            raise
+
+        ppprinter = pprint.PrettyPrinter(indent=2)
+        ppprinter.pprint(out_dict)
+
+        for modname in out_dict["validity_check"]:
+            if not out_dict["validity_check"][modname]:
+                print(f"FAILED INTERFACE {curr_interface} on {modname}")
+                raise TypeError(
+                    f"Failed validity check on {modname} in interface {curr_interface}"
+                )
+
+        print(f"SUCCESSFUL INTERFACE {curr_interface}")
 
 
 if __name__ == "__main__":

--- a/geoips/commandline/test_interfaces.py
+++ b/geoips/commandline/test_interfaces.py
@@ -34,7 +34,7 @@ def main():
         "interfaces.interpolators",
         "interfaces.output_formats",
         "interfaces.procflows",
-        #"dev.product",
+        "dev.product",
         "interfaces.readers",
         "interfaces.title_formats",
     ]
@@ -68,7 +68,7 @@ def main():
             print(f"    {interface_name}Interface()")
 
             curr_class = test_curr_interface()
-            
+
             try:
                 out_dict = curr_class.test_interface_plugins()
             except Exception:
@@ -91,15 +91,6 @@ def main():
             except Exception:
                 print(traceback.format_exc())
                 raise
-
-
-
-
-        #from geoips.interfaces.algorithms import AlgorithmsInterface
-        #alg = AlgorithmsInterface()
-        #out_dict = alg.test_interface_plugins()
-
-
 
         print(f"SUCCESSFUL INTERFACE {curr_interface}")
 

--- a/geoips/commandline/test_interfaces.py
+++ b/geoips/commandline/test_interfaces.py
@@ -26,36 +26,80 @@ def main():
     # This entire testing construct will be updated in the future to more fully
     # test/validate the plugins.
     interfaces = [
-        # "stable.reader",
-        # "dev.alg",
+        "interfaces.algorithms",
         "dev.boundaries",
-        # "dev.cmap",
-        # "dev.filename",
+        "interfaces.colormaps",
+        "interfaces.filename_formats",
         "dev.gridlines",
-        # "dev.interp",
-        # "dev.output",
-        # "dev.procflow",
-        "dev.product",
+        "interfaces.interpolators",
+        "interfaces.output_formats",
+        "interfaces.procflows",
+        #"dev.product",
+        "interfaces.readers",
+        "interfaces.title_formats",
     ]
 
+    interface_name_outliers = {'Boundaries': 'Map',
+                               'Colormaps': 'ColorMaps',
+                               'TitleFormats': 'TitleFormatters',
+                               }
+
     for curr_interface in interfaces:
-        interface_name = curr_interface.split(".")[1]
+        #interface_name = curr_interface.split(".")[1]
+        raw_interface_name = curr_interface.split(".")[1]
+
+        interface_name = "".join([name.capitalize() for name in raw_interface_name.split('_')])
+
+        if interface_name in interface_name_outliers:
+            interface_name = interface_name_outliers[interface_name]
+
         print("")
         print(f"Testing {curr_interface}...")
         print("ipython")
-        print(
-            f"    from geoips.{curr_interface} import test_{interface_name}_interface"
-        )
-        print(f"    test_{interface_name}_interface()")
-        test_curr_interface = getattr(
-            import_module(f"geoips.{curr_interface}"),
-            f"test_{interface_name}_interface",
-        )
+
         try:
-            out_dict = test_curr_interface()
-        except Exception:
-            print(traceback.format_exc())
-            raise
+            test_curr_interface = getattr(
+                import_module(f"geoips.{curr_interface}"),
+                f"{interface_name}Interface",
+            )
+            print(
+                f"    from geoips.{curr_interface} import {interface_name}Interface"
+            )
+            print(f"    {interface_name}Interface()")
+
+            curr_class = test_curr_interface()
+            
+            try:
+                out_dict = curr_class.test_interface_plugins()
+            except Exception:
+                print(traceback.format_exc())
+                raise
+        except AttributeError:
+            interface_name = raw_interface_name
+
+            test_curr_interface = getattr(
+                import_module(f"geoips.{curr_interface}"),
+                f"test_{interface_name}_interface",
+            )
+            print(
+                f"    from geoips.{curr_interface} import test_{interface_name}_interface"
+            )
+            print(f"    test_{interface_name}_interface()")
+
+            try:
+                out_dict = test_curr_interface()
+            except Exception:
+                print(traceback.format_exc())
+                raise
+
+
+
+
+        #from geoips.interfaces.algorithms import AlgorithmsInterface
+        #alg = AlgorithmsInterface()
+        #out_dict = alg.test_interface_plugins()
+
+
 
         print(f"SUCCESSFUL INTERFACE {curr_interface}")
 

--- a/geoips/commandline/test_interfaces.py
+++ b/geoips/commandline/test_interfaces.py
@@ -114,16 +114,8 @@ def main():
         )
         print(f"    from geoips.interfaces import {curr_interface}")
 
-        # First just use plugins_all_valid, will return True or False
-        all_valid = test_curr_interface.plugins_all_valid()
-        if not all_valid:
-            failed_interfaces += [curr_interface]
-        else:
-            successful_interfaces += [curr_interface]
-
-        # Now open all the interfaces (not just checking call signatures)
+        # Open all the interfaces (not just checking call signatures)
         # This returns a dictionary of all sorts of stuff.
-        # If this fails and plugins_all_valid passes, we have a problem.
         try:
             out_dict = test_curr_interface.test_interface()
             out_dicts[curr_interface] = out_dict
@@ -136,6 +128,10 @@ def main():
     for intname in out_dicts:
         ppprinter.pprint(out_dict)
         out_dict = out_dicts[intname]
+        if out_dict["all_valid"] is True:
+            successful_interfaces += [intname]
+        else:
+            failed_interfaces += [intname]
         for modname in out_dict["validity_check"]:
             if not out_dict["validity_check"][modname]:
                 failed_plugins += [f"{intname} on {modname}"]

--- a/geoips/interface_modules/algorithms/pmw_tb/pmw_37pct.py
+++ b/geoips/interface_modules/algorithms/pmw_tb/pmw_37pct.py
@@ -22,13 +22,8 @@ family = "list_numpy_to_numpy"
 description = "Passive Microwave 37 MHz Polarization Corrected Temperature"
 
 
-# Eventually the callable function for all plugins will be named "call".
-# Currently this functionality does not quite work, so changing back to pmw_37pct
-# (current/old default is to use the plugin name as the callable function name).
-# Once using "call" is fully functional, this plugin will be the first example
-# using the fully updated formatting (family and description currently working)
-# def call(
-def pmw_37pct(
+# This is the "new" format for plugins - default to "call" function name for Callable.
+def call(
     arrays,
     output_data_range=None,
     min_outbounds="crop",

--- a/geoips/interface_modules/algorithms/pmw_tb/pmw_89pct.py
+++ b/geoips/interface_modules/algorithms/pmw_tb/pmw_89pct.py
@@ -22,7 +22,7 @@ family = "list_numpy_to_numpy"
 description = "Passive Microwave 89 MHz Polarization Corrected Temperature"
 
 
-def pmw_89pct(
+def call(
     arrays,
     output_data_range,
     min_outbounds="crop",

--- a/geoips/interface_modules/filename_formats/geoips_fname.py
+++ b/geoips/interface_modules/filename_formats/geoips_fname.py
@@ -27,7 +27,7 @@ def geoips_fname(
     area_def,
     xarray_obj,
     product_name,
-    coverage,
+    coverage=None,
     output_type="png",
     output_type_dir=None,
     product_dir=None,

--- a/geoips/interface_modules/filename_formats/geotiff_fname.py
+++ b/geoips/interface_modules/filename_formats/geotiff_fname.py
@@ -26,7 +26,7 @@ def geotiff_fname(
     area_def,
     xarray_obj,
     product_name,
-    coverage,
+    coverage=None,
     output_type="tif",
     output_type_dir=None,
     product_dir=None,

--- a/geoips/interface_modules/filename_formats/tc_clean_fname.py
+++ b/geoips/interface_modules/filename_formats/tc_clean_fname.py
@@ -20,7 +20,7 @@ def tc_clean_fname(
     area_def,
     xarray_obj,
     product_name,
-    coverage,
+    coverage=None,
     output_type="png",
     output_type_dir=None,
     product_dir=None,

--- a/geoips/interface_modules/filename_formats/tc_fname.py
+++ b/geoips/interface_modules/filename_formats/tc_fname.py
@@ -36,7 +36,7 @@ def tc_fname(
     area_def,
     xarray_obj,
     product_name,
-    coverage,
+    coverage=None,
     output_type="png",
     output_type_dir=None,
     product_dir=None,

--- a/geoips/interface_modules/readers/abi_netcdf.py
+++ b/geoips/interface_modules/readers/abi_netcdf.py
@@ -16,7 +16,6 @@ import logging
 import os
 from glob import glob
 from datetime import datetime, timedelta
-from collections import Hashable
 import numpy as np
 import xarray
 

--- a/geoips/interface_modules/readers/ahi_hsd.py
+++ b/geoips/interface_modules/readers/ahi_hsd.py
@@ -17,7 +17,6 @@ import logging
 from glob import glob
 from struct import unpack
 from datetime import datetime, timedelta
-from collections import Hashable
 import socket
 
 # Installed Libraries

--- a/geoips/interfaces/algorithms.py
+++ b/geoips/interfaces/algorithms.py
@@ -4,6 +4,16 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class AlgorithmsInterface(BaseInterface):
     name = "algorithms"
     deprecated_family_attr = "alg_func_type"
+    required_args = {'single_channel': ['arrays'],
+                     'channel_combination': ['arrays'],
+                     'list_numpy_to_numpy': ['arrays'],
+                     'xarray_to_numpy': ['xobj'],
+                     'rgb': ['arrays'],
+                     'xarray_dict_to_xarray': ['xarray_dict'],
+                     'xarray_dict_dict_to_xarray': ['xarray_dict_dict'],
+                     'xarray_dict_to_xarray_dict': ['xarray_dict'],
+                     'xarray_dict_area_def_to_numpy': ['xarray_dict', 'area_def'],
+                     }
 
 
 algorithms = AlgorithmsInterface()

--- a/geoips/interfaces/algorithms.py
+++ b/geoips/interfaces/algorithms.py
@@ -4,17 +4,30 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class AlgorithmsInterface(BaseInterface):
     name = "algorithms"
     deprecated_family_attr = "alg_func_type"
-    required_args = {'single_channel': ['arrays'],
-                     'channel_combination': ['arrays'],
-                     'list_numpy_to_numpy': ['arrays'],
-                     'xarray_to_numpy': ['xobj'],
-                     'rgb': ['arrays'],
-                     'xarray_dict_to_xarray': ['xarray_dict'],
-                     'xarray_dict_dict_to_xarray': ['xarray_dict_dict'],
-                     'xarray_dict_to_xarray_dict': ['xarray_dict'],
-                     'xarray_dict_area_def_to_numpy': ['xarray_dict', 'area_def'],
-                     }
+
+    required_args = {
+        "single_channel": ["arrays"],
+        "channel_combination": ["arrays"],
+        "list_numpy_to_numpy": ["arrays"],
+        "xarray_to_numpy": ["xobj"],
+        "rgb": ["arrays"],
+        "xarray_dict_to_xarray": ["xarray_dict"],
+        "xarray_dict_dict_to_xarray": ["xarray_dict_dict"],
+        "xarray_dict_to_xarray_dict": ["xarray_dict"],
+        "xarray_dict_area_def_to_numpy": ["xarray_dict", "area_def"],
+    }
+
+    required_keyword_args = {
+        "single_channel": [],
+        "channel_combination": [],
+        "xarray_to_numpy": [],
+        "list_numpy_to_numpy": [],
+        "rgb": [],
+        "xarray_dict_to_xarray": [],
+        "xarray_dict_dict_to_xarray": [],
+        "xarray_dict_to_xarray_dict": [],
+        "xarray_dict_area_def_to_numpy": [],
+    }
 
 
 algorithms = AlgorithmsInterface()
-

--- a/geoips/interfaces/algorithms.py
+++ b/geoips/interfaces/algorithms.py
@@ -17,7 +17,7 @@ class AlgorithmsInterface(BaseInterface):
         "xarray_dict_area_def_to_numpy": ["xarray_dict", "area_def"],
     }
 
-    required_keyword_args = {
+    required_kwargs = {
         "single_channel": [],
         "channel_combination": [],
         "xarray_to_numpy": [],

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -270,7 +270,7 @@ class BaseInterface:
             # Below line doesn't seem to deal with entry points inside directories.
             # i.e. searches for "pmw_37pct", but can't find it because it is defined
             #   as "pmw_tb.pmw_37pct"
-            #module = find_entry_point(self.entry_point_group, name)
+            # module = find_entry_point(self.entry_point_group, name)
             eps = get_all_entry_points(self.entry_point_group)
             eps_names = [ep.__name__ for ep in eps]
             ep_index = eps_names.index(name)
@@ -283,8 +283,8 @@ class BaseInterface:
         # If "module" is not callable, treat this as a deprecated entry point
         # whose callable is specified in setup.py directly
         else:
-            #func = module
-            #module = import_module(func.__module__)
+            # func = module
+            # module = import_module(func.__module__)
             # Below line can probably be replaced with above two lines if
             # commented out line in try block above is fixed.
             func = eps[ep_index]
@@ -310,7 +310,7 @@ class BaseInterface:
             else:
                 plugins.append(
                     plugin_module_to_obj(self, module, module_call_func=ep.__name__)
-                    #self._plugin_module_to_obj(module, module_call_func=ep.__name__)
+                    # self._plugin_module_to_obj(module, module_call_func=ep.__name__)
                 )
 
         # plugins = [
@@ -342,7 +342,7 @@ class BaseInterface:
         expected_args = self.required_args[plugin.family]
 
         sig = inspect.signature(plugin.__call__)
-        arg_list = [s.strip().split('=')[0] for s in str(sig).strip('()').split(',')]
+        arg_list = [s.strip().split("=")[0] for s in str(sig).strip("()").split(",")]
 
         for expected_arg in expected_args:
             if expected_arg not in arg_list:
@@ -366,7 +366,7 @@ class BaseInterface:
             - 'family' contains a dict whose keys are plugin names and whose vlaues are the contents of the 'family'
               attribute for each Plugin.
         """
-        #plugin_names = self.get_plugins(sort_by="family")
+        # plugin_names = self.get_plugins(sort_by="family")
         plugins = self.get_plugins()
         family_list = []
         plugin_names = {}
@@ -386,6 +386,6 @@ class BaseInterface:
             for curr_name in plugin_names[curr_family]:
                 output["validity_check"][curr_name] = self.is_valid(curr_name)
                 output["func"][curr_name] = self.get_plugin(curr_name)
-                #output["family"][curr_name] = self.get_family(curr_name)
+                # output["family"][curr_name] = self.get_family(curr_name)
                 output["family"][curr_name] = curr_family
         return output

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -19,6 +19,7 @@
 """Base classes for BaseInterface and BasePlugin.
 """
 
+import inspect
 import logging
 from importlib import import_module
 from typing import Callable
@@ -340,7 +341,6 @@ class BaseInterface:
         plugin = self.get_plugin(name)
         expected_args = self.required_args[plugin.family]
 
-        import inspect
         sig = inspect.signature(plugin.__call__)
         arg_list = [s.strip().split('=')[0] for s in str(sig).strip('()').split(',')]
 

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -320,7 +320,7 @@ class BaseInterface:
         # ]
         return plugins
 
-    def is_valid(self, name):
+    def plugin_is_valid(self, name):
         """Check that an interface is valid.
 
         Check that the requested interface function has the correct call signature.
@@ -347,13 +347,27 @@ class BaseInterface:
         for expected_arg in expected_args:
             if expected_arg not in arg_list:
                 return False
+
+        expected_kwargs = self.required_kwargs[plugin.family]
+        return True
+
+    def plugins_all_valid(self):
+        """Test the current interface by validating every Plugin.
+
+        Returns:
+            True if all plugins are valid, False if any plugin is invalid.
+        """
+        plugins = self.get_plugins()
+        for plugin in plugins:
+            if not self.plugin_is_valid(plugin.name):
+                return False
         return True
 
     def test_interface_plugins(self):
         """Test the current interface by validating every Plugin.
 
         Test this interface by opening every Plugin available to the interface. Then validate each plugin by calling
-        `is_valid` for each.
+        `plugin_is_valid` for each.
 
         Returns:
             A dictionary containing three keys: 'by_family', 'validity_check', 'func', and 'family'. The value for each
@@ -361,7 +375,7 @@ class BaseInterface:
 
             - 'by_family' contains a dictionary of plugin names sorted by family.
             - 'validity_check' contains a dict whose keys are plugin names and whose values are bools where `True`
-              indicates that the Plugin's function is valid according to `is_valid`.
+              indicates that the Plugin's function is valid according to `plugin_is_valid`.
             - 'func' contains a dict whose keys are plugin names and whose values are the function for each Plugin.
             - 'family' contains a dict whose keys are plugin names and whose vlaues are the contents of the 'family'
               attribute for each Plugin.
@@ -384,7 +398,7 @@ class BaseInterface:
         }
         for curr_family in plugin_names:
             for curr_name in plugin_names[curr_family]:
-                output["validity_check"][curr_name] = self.is_valid(curr_name)
+                output["validity_check"][curr_name] = self.plugin_is_valid(curr_name)
                 output["func"][curr_name] = self.get_plugin(curr_name)
                 # output["family"][curr_name] = self.get_family(curr_name)
                 output["family"][curr_name] = curr_family

--- a/geoips/interfaces/colormaps.py
+++ b/geoips/interfaces/colormaps.py
@@ -1,18 +1,29 @@
 from geoips.interfaces.base import BaseInterface, BasePlugin
 
 
-class ColorMapsInterface(BaseInterface):
+class ColormapsInterface(BaseInterface):
     name = "colormaps"
     entry_point_group = "user_colormaps"
     deprecated_family_attr = "cmap_type"
-    required_args = {'rgb': [],
-                     'ascii': [],
-                     'linear_segmented': [],
-                     'linear_norm': [],
-                     'product_based': [],
-                     'explicit': [],
-                     'builtin_matplotlib_cmap': ['data_range']}
+    required_args = {
+        "rgb": [],
+        "ascii": [],
+        "linear_segmented": [],
+        "linear_norm": [],
+        "product_based": [],
+        "explicit": [],
+        "builtin_matplotlib_cmap": ["data_range"],
+    }
+
+    required_kwargs = {
+        "rgb": [],
+        "ascii": [],
+        "linear_segmented": ["data_range"],
+        "linear_norm": ["data_range"],
+        "product_based": ["product_name", "data_range"],
+        "explicit": [],
+        "builtin_matplotlib_cmap": ["cmap_name", "cbar_label", "create_colorbar"],
+    }
 
 
-colormaps = ColorMapsInterface()
-
+colormaps = ColormapsInterface()

--- a/geoips/interfaces/colormaps.py
+++ b/geoips/interfaces/colormaps.py
@@ -5,6 +5,13 @@ class ColorMapsInterface(BaseInterface):
     name = "colormaps"
     entry_point_group = "user_colormaps"
     deprecated_family_attr = "cmap_type"
+    required_args = {'rgb': [],
+                     'ascii': [],
+                     'linear_segmented': [],
+                     'linear_norm': [],
+                     'product_based': [],
+                     'explicit': [],
+                     'builtin_matplotlib_cmap': ['data_range']}
 
 
 colormaps = ColorMapsInterface()

--- a/geoips/interfaces/colormaps.py
+++ b/geoips/interfaces/colormaps.py
@@ -18,11 +18,15 @@ class ColormapsInterface(BaseInterface):
     required_kwargs = {
         "rgb": [],
         "ascii": [],
-        "linear_segmented": ["data_range"],
-        "linear_norm": ["data_range"],
-        "product_based": ["product_name", "data_range"],
+        "linear_segmented": [("data_range",)],
+        "linear_norm": [("data_range",)],
+        "product_based": [("product_name",), ("data_range",)],
         "explicit": [],
-        "builtin_matplotlib_cmap": ["cmap_name", "cbar_label", "create_colorbar"],
+        "builtin_matplotlib_cmap": [
+            ("cmap_name",),
+            ("cbar_label",),
+            ("create_colorbar",),
+        ],
     }
 
 

--- a/geoips/interfaces/filename_formats.py
+++ b/geoips/interfaces/filename_formats.py
@@ -1,10 +1,19 @@
 from geoips.interfaces.base import BaseInterface, BasePlugin
 
 
-class FilenameFormats(BaseInterface):
+class FilenameFormatsInterface(BaseInterface):
     name = "filename_formats"
     entry_point_group = "filename_formats"
     deprecated_family_attr = "filename_type"
+
+    required_args = {'standard': ['area_def', 'xarray_obj', 'product_name'],
+                     'xarray_metadata_to_filename': ['xarray_obj'],
+                     'data': ['area_def', 'xarray_obj', 'product_names'],
+                     'standard_metadata': ['area_def',
+                                           'xarray_obj',
+                                           'product_filename'
+                                           ],
+                     }
 
     def find_duplicates(self, *args, **kwargs):
         try:
@@ -20,5 +29,5 @@ class FilenameFormats(BaseInterface):
         duplicates = self.find_duplicates()
 
 
-filename_formats = FilenameFormats()
+filename_formats = FilenameFormatsInterface()
 

--- a/geoips/interfaces/filename_formats.py
+++ b/geoips/interfaces/filename_formats.py
@@ -6,14 +6,34 @@ class FilenameFormatsInterface(BaseInterface):
     entry_point_group = "filename_formats"
     deprecated_family_attr = "filename_type"
 
-    required_args = {'standard': ['area_def', 'xarray_obj', 'product_name'],
-                     'xarray_metadata_to_filename': ['xarray_obj'],
-                     'data': ['area_def', 'xarray_obj', 'product_names'],
-                     'standard_metadata': ['area_def',
-                                           'xarray_obj',
-                                           'product_filename'
-                                           ],
-                     }
+    required_args = {
+        "standard": ["area_def", "xarray_obj", "product_name"],
+        "xarray_metadata_to_filename": ["xarray_obj"],
+        "data": ["area_def", "xarray_obj", "product_names"],
+        "standard_metadata": ["area_def", "xarray_obj", "product_filename"],
+    }
+    required_kwargs = {
+        "standard": [
+            "coverage",
+            "output_type",
+            "output_type_dir",
+            "product_dir",
+            "product_subdir",
+            "source_dir",
+            "basedir",
+        ],
+        "xarray_metadata_to_filename": ["extension", "basedir"],
+        "data": [
+            "coverage",
+            "output_type",
+            "output_type_dir",
+            "product_dir",
+            "product_subdir",
+            "source_dir",
+            "basedir",
+        ],
+        "standard_metadata": ["metadata_dir", "metadata_type", "basedir"],
+    }
 
     def find_duplicates(self, *args, **kwargs):
         try:
@@ -30,4 +50,3 @@ class FilenameFormatsInterface(BaseInterface):
 
 
 filename_formats = FilenameFormatsInterface()
-

--- a/geoips/interfaces/interpolators.py
+++ b/geoips/interfaces/interpolators.py
@@ -5,6 +5,8 @@ class InterpolatorsInterface(BaseInterface):
     name = "interpolators"
     entry_point_group = "interpolation"
     deprecated_family_attr = "interp_type"
+    required_args = {'2d': ['area_def', 'input_xarray', 'output_xarray', 'varlist'],
+                     'grid': ['area_def', 'input_xarray', 'output_xarray', 'varlist']}
 
 
 interpolators = InterpolatorsInterface()

--- a/geoips/interfaces/interpolators.py
+++ b/geoips/interfaces/interpolators.py
@@ -5,9 +5,12 @@ class InterpolatorsInterface(BaseInterface):
     name = "interpolators"
     entry_point_group = "interpolation"
     deprecated_family_attr = "interp_type"
-    required_args = {'2d': ['area_def', 'input_xarray', 'output_xarray', 'varlist'],
-                     'grid': ['area_def', 'input_xarray', 'output_xarray', 'varlist']}
+    required_args = {
+        "2d": ["area_def", "input_xarray", "output_xarray", "varlist"],
+        "grid": ["area_def", "input_xarray", "output_xarray", "varlist"],
+    }
+
+    required_kwargs = {"2d": ["array_num"], "grid": ["array_num"]}
 
 
 interpolators = InterpolatorsInterface()
-

--- a/geoips/interfaces/output_formats.py
+++ b/geoips/interfaces/output_formats.py
@@ -62,6 +62,9 @@ class OutputFormatsInterface(BaseInterface):
         "xarray_dict_to_image": [],
         "xarray_data": [],
         "standard_metadata": ["metadata_dir", "basedir", "output_dict"],
+        "xrdict_varlist_outfnames_to_outlist": [],
+        "xrdict_area_varlist_to_outlist": [],
+        "xrdict_area_product_outfnames_to_outlist": [],
     }
 
 

--- a/geoips/interfaces/output_formats.py
+++ b/geoips/interfaces/output_formats.py
@@ -4,43 +4,65 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class OutputFormatsInterface(BaseInterface):
     name = "output_formats"
     deprecated_family_attr = "output_type"
-    required_args = {'image': ['area_def',
-                               'xarray_obj',
-                               'product_name',
-                               'output_fnames'
-                               ],
-                     'unprojected': ['xarray_obj', 'product_name', 'output_fnames'],
-                     'image_overlay': ['area_def',
-                                       'xarray_obj',
-                                       'product_name',
-                                       'output_fnames'
-                                       ],
-                     'image_multi': ['area_def',
-                                     'xarray_obj',
-                                     'product_names',
-                                     'output_fnames',
-                                     'mpl_colors_info'
-                                     ],
-                     'xrdict_area_varlist_to_outlist': ['xarray_dict',
-                                                        'area_def',
-                                                        'varlist'
-                                                        ],
-                     'xrdict_area_product_outfnames_to_outlist': ['xarray_dict',
-                                                                  'area_def',
-                                                                  'product_name',
-                                                                  'output_fnames'
-                                                                  ],
-                     'xrdict_varlist_outfnames_to_outlist': ['xarray_dict',
-                                                             'varlist',
-                                                             'output_fnames'
-                                                             ],
-                     'xarray_data': ['xarray_obj', 'product_names', 'output_fnames'],
-                     'standard_metadata': ['area_def',
-                                           'xarray_obj',
-                                           'metadata_yaml_filename',
-                                           'product_filename'
-                                           ],
-                     }
+    required_args = {
+        "image": ["area_def", "xarray_obj", "product_name", "output_fnames"],
+        "unprojected": ["xarray_obj", "product_name", "output_fnames"],
+        "image_overlay": ["area_def", "xarray_obj", "product_name", "output_fnames"],
+        "image_multi": [
+            "area_def",
+            "xarray_obj",
+            "product_names",
+            "output_fnames",
+            "mpl_colors_info",
+        ],
+        "xrdict_area_varlist_to_outlist": ["xarray_dict", "area_def", "varlist"],
+        "xrdict_area_product_outfnames_to_outlist": [
+            "xarray_dict",
+            "area_def",
+            "product_name",
+            "output_fnames",
+        ],
+        "xrdict_varlist_outfnames_to_outlist": [
+            "xarray_dict",
+            "varlist",
+            "output_fnames",
+        ],
+        "xarray_data": ["xarray_obj", "product_names", "output_fnames"],
+        "standard_metadata": [
+            "area_def",
+            "xarray_obj",
+            "metadata_yaml_filename",
+            "product_filename",
+        ],
+    }
+    required_kwargs = {
+        "image": ["product_name_title", "mpl_colors_info", "existing_image"],
+        "unprojected": ["product_name_title", "mpl_colors_info"],
+        "image_overlay": [
+            "product_name_title",
+            "clean_fname",
+            "mpl_colors_info",
+            "clean_fname",
+            "boundaries_info",
+            "gridlines_info",
+            "clean_fname",
+            "product_datatype_title",
+            "clean_fname",
+            "bg_data",
+            "bg_mpl_colors_info",
+            "clean_fname",
+            "bg_xarray",
+            "bg_product_name_title",
+            "bg_datatype_title",
+            "clean_fname",
+            "remove_duplicate_minrange",
+        ],
+        "image_multi": ["product_name_titles"],
+        "xarray_dict_data": ["append", "overwrite"],
+        "xarray_dict_to_image": [],
+        "xarray_data": [],
+        "standard_metadata": ["metadata_dir", "basedir", "output_dict"],
+    }
+
 
 output_formats = OutputFormatsInterface()
-

--- a/geoips/interfaces/output_formats.py
+++ b/geoips/interfaces/output_formats.py
@@ -4,7 +4,43 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class OutputFormatsInterface(BaseInterface):
     name = "output_formats"
     deprecated_family_attr = "output_type"
-
+    required_args = {'image': ['area_def',
+                               'xarray_obj',
+                               'product_name',
+                               'output_fnames'
+                               ],
+                     'unprojected': ['xarray_obj', 'product_name', 'output_fnames'],
+                     'image_overlay': ['area_def',
+                                       'xarray_obj',
+                                       'product_name',
+                                       'output_fnames'
+                                       ],
+                     'image_multi': ['area_def',
+                                     'xarray_obj',
+                                     'product_names',
+                                     'output_fnames',
+                                     'mpl_colors_info'
+                                     ],
+                     'xrdict_area_varlist_to_outlist': ['xarray_dict',
+                                                        'area_def',
+                                                        'varlist'
+                                                        ],
+                     'xrdict_area_product_outfnames_to_outlist': ['xarray_dict',
+                                                                  'area_def',
+                                                                  'product_name',
+                                                                  'output_fnames'
+                                                                  ],
+                     'xrdict_varlist_outfnames_to_outlist': ['xarray_dict',
+                                                             'varlist',
+                                                             'output_fnames'
+                                                             ],
+                     'xarray_data': ['xarray_obj', 'product_names', 'output_fnames'],
+                     'standard_metadata': ['area_def',
+                                           'xarray_obj',
+                                           'metadata_yaml_filename',
+                                           'product_filename'
+                                           ],
+                     }
 
 output_formats = OutputFormatsInterface()
 

--- a/geoips/interfaces/procflows.py
+++ b/geoips/interfaces/procflows.py
@@ -4,8 +4,8 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class ProcflowsInterface(BaseInterface):
     name = "procflows"
     deprecated_family_attr = "procflow_type"
-    required_args = {'standard': ['fnames']}
+    required_args = {"standard": ["fnames"]}
+    required_kwargs = {"standard": ["command_line_args"]}
 
 
 procflows = ProcflowsInterface()
-

--- a/geoips/interfaces/procflows.py
+++ b/geoips/interfaces/procflows.py
@@ -4,6 +4,7 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class ProcflowsInterface(BaseInterface):
     name = "procflows"
     deprecated_family_attr = "procflow_type"
+    required_args = {'standard': ['fnames']}
 
 
 procflows = ProcflowsInterface()

--- a/geoips/interfaces/readers.py
+++ b/geoips/interfaces/readers.py
@@ -4,8 +4,10 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class ReadersInterface(BaseInterface):
     name = "readers"
     deprecated_family_attr = "reader_type"
-    required_args = {'standard': ['fnames']}
+    required_args = {"standard": ["fnames"]}
+    required_kwargs = {
+        "standard": ["metadata_only", "chans", "area_def", "self_register"]
+    }
 
 
 readers = ReadersInterface()
-

--- a/geoips/interfaces/readers.py
+++ b/geoips/interfaces/readers.py
@@ -4,6 +4,7 @@ from geoips.interfaces.base import BaseInterface, BasePlugin
 class ReadersInterface(BaseInterface):
     name = "readers"
     deprecated_family_attr = "reader_type"
+    required_args = {'standard': ['fnames']}
 
 
 readers = ReadersInterface()

--- a/geoips/interfaces/title_formats.py
+++ b/geoips/interfaces/title_formats.py
@@ -1,12 +1,12 @@
 from geoips.interfaces.base import BaseInterface, BasePlugin
 
 
-class TitleFormattersInterface(BaseInterface):
+class TitleFormatsInterface(BaseInterface):
     name = "title_formats"
     entry_point_group = "title_formats"
     deprecated_family_attr = "title_type"
-    required_args = {'standard': []}
+    required_args = {"standard": []}
+    required_kwargs = {"standard": []}
 
 
-title_formats = TitleFormattersInterface()
-
+title_formats = TitleFormatsInterface()

--- a/geoips/interfaces/title_formats.py
+++ b/geoips/interfaces/title_formats.py
@@ -5,6 +5,7 @@ class TitleFormattersInterface(BaseInterface):
     name = "title_formats"
     entry_point_group = "title_formats"
     deprecated_family_attr = "title_type"
+    required_args = {'standard': []}
 
 
 title_formats = TitleFormattersInterface()

--- a/setup.py
+++ b/setup.py
@@ -181,8 +181,10 @@ setuptools.setup(
         ],
         "geoips.algorithms": [
             "single_channel=geoips.interface_modules.algorithms.single_channel:single_channel",
-            "pmw_tb.pmw_37pct=geoips.interface_modules.algorithms.pmw_tb.pmw_37pct:pmw_37pct",
-            "pmw_tb.pmw_89pct=geoips.interface_modules.algorithms.pmw_tb.pmw_89pct:pmw_89pct",
+            # Note 37pct has been updated for function name "call"
+            "pmw_tb.pmw_37pct=geoips.interface_modules.algorithms.pmw_tb.pmw_37pct",
+            # Note 89pct has been updated for function name "call"
+            "pmw_tb.pmw_89pct=geoips.interface_modules.algorithms.pmw_tb.pmw_89pct",
             "pmw_tb.pmw_color37=geoips.interface_modules.algorithms.pmw_tb.pmw_color37:pmw_color37",
             "pmw_tb.pmw_color89=geoips.interface_modules.algorithms.pmw_tb.pmw_color89:pmw_color89",
             "sfc_winds.windbarbs=geoips.interface_modules.algorithms.sfc_winds.windbarbs:windbarbs",


### PR DESCRIPTION
<!-- PULL REQUEST REQUIREMENTS FOR APPROVAL
* **Title format**: <Short description>
    * Default title based on Issue title can be sufficient if the Issue was named succinctly and appropriately
* Appropriate tags / attributes added along right-hand side of pull request
    * **Reviewers**: Add at least 2 reviewers
    * **Assignees**: Assign person who is responsible for finalizing the PR and resolving comments
    * **Label**: Add appropriate descriptors
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link below)
--->

# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/geoips#91
fixes NRLMMD-GEOIPS/geoips#90  <-- Found and fixed this bug while I was in here.

<!--- This can point to an issue in another repository if appropriate --->

# Testing Instructions
<!---
* Link to ticket with testing instructions
OR
* Note that no exhaustive testing is required (if you have sufficient output below to demonstrate success, and it will be fully tested with next release)
OR
* include testing instructions directly here if appropriate
--->
Run test_interfaces.py in geoips/commandline.

# Summary
## GEOIPS/geoips#91: 2023-02-14, update test_interfaces

*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*
************************************************************************

Bug fixes
=========

Removed unused import of Hashable
---------------------------------

*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*

::

    geoips/interface_modules/readers/abi_netcdf.py
    geoips/interface_modules/readers/ahi_hsd.py

Switched coverage from positional parameter to keyword argument
---------------------------------------------------------------

Standard filename format expects "coverage" to be a keyword argument, not a positional
parameter.  Update filename formats accordingly so test_interfaces passes.

::

    modified: geoips/interface_modules/filename_formats/geoips_fname.py
    modified: geoips/interface_modules/filename_formats/geotiff_fname.py
    modified: geoips/interface_modules/filename_formats/tc_clean_fname.py
    modified: geoips/interface_modules/filename_formats/tc_fname.py

Installation and Test
=====================

Add validation tests to Base interface class
--------------------------------------------

*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*

* plugin_is_valid: Added checks for required arguments and keyword arguments
  to determine if a plugin call signature matches what is expected
* get_plugin, get_plugins, test_interface_plugins: A few bug fixes, but mostly
  changes to avoid future functionality to get tests to run successfully
* plugins_all_valid: returns True if all plugins in the current interface are valid,
  False if any plugins are invalid (calls "plugin_is_valid" on each plugin)

::

    modified:   geoips/interfaces/base.py

Add separate interface tests for deprecated and new interfaces
--------------------------------------------------------------

* Move tests for deprecated interfaces to a separate function - will eventually be
  removed.
* Call both "plugins_all_valid" and "test_interface_plugins" for new interfaces.

  * "plugins_all_valid" merely returns True or False for full interface (if any fail,
    returns False, error raised at the end of "test_interfaces")
  * "test_interface_plugins" actually opens every plugin, and tests individually - if
    any fail, they will be added to the failed_plugins list and an error raised at the
    end for non-zero return.

* Add logic to save lists of successful and failed interfaces - print all status at
  the end, and only raise an error after printing full list of successful/failed
  plugins.

::

    modified:   geoips/commandline/test_interfaces.py

Update interface modules for validation testing
-----------------------------------------------

*From issue NRLMMD-GEOIPS/geoips#91: 2023-02-14, update test_interfaces*

* Add required_args and required_kwargs to all interface modules
* Standardize interface class names
  * FilenameFormats -> FilenameFormatsInterface
  * ColorMapInterface -> ColormapsInterface
  * TitleFormattersInterface -> TitleFormatsInterface

::

    modified:   geoips/interfaces/algorithms.py
    modified:   geoips/interfaces/colormaps.py
    modified:   geoips/interfaces/filename_formats.py
    modified:   geoips/interfaces/interpolators.py
    modified:   geoips/interfaces/output_formats.py
    modified:   geoips/interfaces/procflows.py
    modified:   geoips/interfaces/readers.py
    modified:   geoips/interfaces/title_formats.py

# Output
<!---
* Optional output demonstrating functionality - command line or imagery output
* If there is any additional command line output you can copy/paste here to indicate the changes you made work as expected, please include
* Imagery output is EXPECTED for new or changed image products
    * Ideally include the least amount of formatting possible in test outputs
    * Clean imagery, no YAML metadata outputs, small representative sector
    * We want to minimize the dependencies that could cause test outputs to change
* Related Testing is EXPECTED for new image products
    * Create <repo>/tests/scripts/<testname>.sh
    * Update <repo>/tests/test_all.sh
--->
Output of test_interfaces:
Mon Feb 13 16:54:16 CST 2023  Running  test_interfaces
test_interfaces
/home/lwilson/geoproc/test_data//logs/20230213/20230213.225343_geoips_base/test_all_geoips_base.log_test_interfaces.log
Return: 0 
[test_all_geoips_base.log_test_interfaces.log](https://github.com/NRLMMD-GEOIPS/geoips/files/10736340/test_all_geoips_base.log_test_interfaces.log)

Output images of test_base_install_low_memory.sh:
![20200918 195020 goes-16 abi Infrared goes16 45p56 noaa 10p0](https://user-images.githubusercontent.com/89750654/218846901-5a23efa5-c945-47e3-8422-35abe0881731.png)
![20200918_195020_AL202020_abi_goes-16_Infrared_110kts_100p00_1p0](https://user-images.githubusercontent.com/89750654/218846908-faf7d18f-523d-4e28-9224-9586ef5daf05.png)
