### PR TITLE
Replace `GEOIPS_PACKAGES_DIR` with `importlib.resources.files` in yaml plugin validation unit tests

### DIFF
--- a/docs/source/releases/v1_10_0_dev0.rst
+++ b/docs/source/releases/v1_10_0_dev0.rst
@@ -145,3 +145,17 @@ Add unit tests to validate yaml-based plugins and schema
     created: tests/test_pytest/test_yaml_plugins.py
     modified: pyproject.toml
     moved: bad_schema -> tests/pytests/bad_plugins
+
+Bug Fixes
+=========
+
+Don't rely on environment variables in unit tests
+-------------------------------------------------
+
+*From issue NRLMMD-GEOIPS/geoips#156: 2023-04-06, Don't rely on environment variables in unit tests*
+
+* Switched from using GEOIPS_PACKAGES_DIR to importlib.resources.files
+
+::
+
+    modified: tests/test_pytest/test_yaml_plugins.py

--- a/tests/test_pytest/test_yaml_plugins.py
+++ b/tests/test_pytest/test_yaml_plugins.py
@@ -2,23 +2,26 @@ import pytest
 
 import jsonschema
 from pathlib import Path
+from importlib import resources
 
 from geoips.schema import validate
-from os import getenv
 
 
 test_path = Path(__file__).parent
-package_path = getenv('GEOIPS_PACKAGES_DIR')+'/geoips'
+package_path = Path(resources.files("geoips"))
 
-yaml_plugins = Path(f"{package_path}/geoips/interface_modules/").rglob("*.yaml")
+yaml_plugins = Path(f"{package_path}/interface_modules/").rglob("*.yaml")
 bad_yaml_plugins = Path(f"{test_path}/bad_plugins").rglob("*.yaml")
+
 
 @pytest.mark.parametrize("plugin_file", yaml_plugins)
 def test_is_plugin_valid(plugin_file):
+    """Test whether a plugin validates against its interface's schema."""
     validate(plugin_file)
+
 
 @pytest.mark.parametrize("plugin_file", bad_yaml_plugins)
 def test_is_plugin_invalid(plugin_file):
+    """Test that a plugin fails to validate against its interface's schema."""
     with pytest.raises(jsonschema.exceptions.ValidationError):
         validate(plugin_file)
-


### PR DESCRIPTION
<!-- PULL REQUEST REQUIREMENTS FOR APPROVAL
* **Title format**: <Short description>
    * Default title based on Issue title can be sufficient if the Issue was named succinctly and appropriately
* Appropriate tags / attributes added along right-hand side of pull request
    * **Reviewers**: Add at least 2 reviewers
    * **Assignees**: Assign person who is responsible for finalizing the PR and resolving comments
    * **Label**: Add appropriate descriptors
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link below)
--->

# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/geoips#[156]
<!--- This can point to an issue in another repository if appropriate --->

# Testing Instructions
<!---
* Link to ticket with testing instructions
OR
* Note that no exhaustive testing is required (if you have sufficient output below to demonstrate success, and it will be fully tested with next release)
OR
* include testing instructions directly here if appropriate
--->
This should return all tests passed with a few warnings:
```
pip install -e .[test]
pytest ./tests
```

Results should look like this:
```
> pytest ./tests
====================================================================================================================================================== test session starts =======================================================================================================================================================
platform linux -- Python 3.10.10, pytest-7.2.2, pluggy-1.0.0
rootdir: /local/home/jsolbrig/geoips/github/geoips
plugins: cov-4.0.0, typeguard-2.13.3
collected 15 items                                                                                                                                                                                                                                                                                                               

tests/test_pytest/test_yaml_plugins.py ...............                                                                                                                                                                                                                                                                     [100%]

======================================================================================================================================================== warnings summary ========================================================================================================================================================
geoips/interfaces/base.py:237
geoips/interfaces/base.py:237
geoips/interfaces/base.py:237
geoips/interfaces/base.py:237
  /local/home/jsolbrig/geoips/github/geoips/geoips/interfaces/base.py:237: DeprecationWarning: Use of 'entry_point_group' to specify the entry point group of an interface is deprecated. The interface name should match the name of the entry point group.
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================================= 15 passed, 4 warnings in 0.17s =================================================================================================================================================
```

# Summary
<!---
* COPY AND PASTE your CHANGELOG update here as summary bullet points
* NOTE Pull request WILL NOT be approved without appropriate updates added to the CHANGELOG
   * CHANGELOG updates should come before the most recent version header
   *     a new version header will be added during the next version release cycle
   * Please see https://github.com/NRLMMD-GEOIPS/geoips/blob/dev/CHANGELOG_TEMPLATE.md
   *     for appropriate CHANGELOG update formatting
--->

Bug Fixes
=========

Don't rely on environment variables in unit tests
-------------------------------------------------

*From issue NRLMMD-GEOIPS/geoips#156: 2023-04-06, Don't rely on environment variables in unit tests*

* Switched from using GEOIPS_PACKAGES_DIR to importlib.resources.files

::

    modified: tests/test_pytest/test_yaml_plugins.py

