### PR TITLE
Updating release notes to support 1.10.0a0 release

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,7 +22,7 @@ Version 1.10
 .. toctree::
    :maxdepth: 1
 
-   v1_10_0a00
+   v1_10_0a0
 
 Version 1.9
 -----------

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,7 +22,7 @@ Version 1.10
 .. toctree::
    :maxdepth: 1
 
-   v1_10_0_dev0
+   v1_10_0a00
 
 Version 1.9
 -----------

--- a/docs/source/releases/v1_10_0a0.rst
+++ b/docs/source/releases/v1_10_0a0.rst
@@ -1,8 +1,5 @@
-Version 1.10.0a00 (2023-04-04)
-******************************
-
-Once all 1.10.0aN PRs are merged, open another PR *just* to move the release
-notes so this becomes 1.10.0a0, and others are incremented.
+Version 1.10.0a0 (2023-04-04)
+*****************************
 
 First attempt at YAML-based plugin interfaces.  These updates will be superseded
 by later alpha releases of v1.10.0. Tagging this version for reference.

--- a/docs/source/releases/v1_10_0a00.rst
+++ b/docs/source/releases/v1_10_0a00.rst
@@ -1,5 +1,11 @@
-Version 1.10.0.dev0 (2023-04-04)
-********************************
+Version 1.10.0a00 (2023-04-04)
+******************************
+
+Once all 1.10.0aN PRs are merged, open another PR *just* to move the release
+notes so this becomes 1.10.0a0, and others are incremented.
+
+First attempt at YAML-based plugin interfaces.  These updates will be superseded
+by later alpha releases of v1.10.0. Tagging this version for reference.
 
 * Improve output from estimate area extent script
 * Add YAML-based plugin validator


### PR DESCRIPTION
I accidentally started all the plugins reorg PRs with 1.10.0a0. Making this one 1.10.0a0, and will increment the others BEFORE merging (no other changes besides moving the release notes for each approved 1.10.0aN PR)

Note 1.10.0.dev0 DOES NOT work with setuptools_scm, thus the switch to 1.10.0a0.  Unclear exactly what will and will not work, but I know this does, and it is concise.