### PR TITLE
Fix regex for bad_family tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see geoips/CHANGELOG_TEMPLATE.rst for instructions on updating
-CHANGELOG appropriately with each PR
+Bug Fixes
+=========
 
-Release notes for previous/upcoming versions can be found in
-docs/source/releases, for reference
+Update error messages in "bad" product_defaults tests
+-----------------------------------------------------
+
+*From NRLMMD-GEOIPS/geoips#255: 2023-08-09, Fix error matching regex*
+
+* jsonschema changed their error messages to add additional quotes. This just modifies
+  our test regex to ignore more of the error.
+
+::
+
+    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_colormapper.yaml
+    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_interpolator_colormapper.yaml
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,19 +10,8 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Bug Fixes
-=========
+Please see geoips/CHANGELOG_TEMPLATE.rst for instructions on updating
+CHANGELOG appropriately with each PR
 
-Update error messages in "bad" product_defaults tests
------------------------------------------------------
-
-*From NRLMMD-GEOIPS/geoips#255: 2023-08-09, Fix error matching regex*
-
-* jsonschema changed their error messages to add additional quotes. This just modifies
-  our test regex to ignore more of the error.
-
-::
-
-    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_colormapper.yaml
-    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_interpolator_colormapper.yaml
-
+Release notes for previous/upcoming versions can be found in
+docs/source/releases, for reference

--- a/docs/source/releases/v1_11_1a0.rst
+++ b/docs/source/releases/v1_11_1a0.rst
@@ -1,0 +1,29 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Bug Fixes
+=========
+
+Update error messages in "bad" product_defaults tests
+-----------------------------------------------------
+
+*From NRLMMD-GEOIPS/geoips#255: 2023-08-09, Fix error matching regex*
+
+* jsonschema changed their error messages to add additional quotes. This just modifies
+  our test regex to ignore more of the error.
+
+::
+
+    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_colormapper.yaml
+    modified: tests/test_plugin_schema/bad/product_defaults/algorithm_interpolator_colormapper.yaml
+
+

--- a/tests/test_pytest/test_plugin_schema/bad/product_defaults/algorithm_colormapper.yaml
+++ b/tests/test_pytest/test_plugin_schema/bad/product_defaults/algorithm_colormapper.yaml
@@ -1,6 +1,6 @@
 ---
 error: ValidationError
-error_pattern: ".*No validator found for product_defaults.bad_family.*"
+error_pattern: ".*No validator found for .*bad_family.*"
 interface: product_defaults
 family: bad_family
 name: good_test

--- a/tests/test_pytest/test_plugin_schema/bad/product_defaults/algorithm_interpolator_colormapper.yaml
+++ b/tests/test_pytest/test_plugin_schema/bad/product_defaults/algorithm_interpolator_colormapper.yaml
@@ -1,6 +1,6 @@
 ---
 error: ValidationError
-error_pattern: ".*No validator found for product_defaults.bad_family.*"
+error_pattern: ".*No validator found for .*bad_family.*"
 interface: product_defaults
 family: bad_family
 name: good_test


### PR DESCRIPTION
<!-- PULL REQUEST REQUIREMENTS FOR APPROVAL
* **Title format**: <Short description>
    * Default title based on Issue title can be sufficient if the Issue was named succinctly and appropriately
* Appropriate tags / attributes added along right-hand side of pull request
    * **Reviewers**: Add at least 2 reviewers
    * **Assignees**: Assign person who is responsible for finalizing the PR and resolving comments
    * **Label**: Add appropriate descriptors
    * **Projects**: GeoIPS - All Repos and All Functionality
        * Other projects allowed as appropriate
* Ensure Related Issue is finalized appropriately (follow link below)
--->

# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/geoips#255
<!--- This can point to an issue in another repository if appropriate --->

# Testing Instructions
<!---
* Link to ticket with testing instructions
OR
* Note that no exhaustive testing is required (if you have sufficient output below to demonstrate success, and it will be fully tested with next release)
OR
* include testing instructions directly here if appropriate
--->
Just run `pytest ./tests/test_pytest/`. It should return 0.

# Summary
<!---
* COPY AND PASTE your CHANGELOG update here as summary bullet points
* NOTE Pull request WILL NOT be approved without appropriate updates added to the
  CHANGELOG

  * Please see
    https://raw.githubusercontent.com/NRLMMD-GEOIPS/geoips/main/CHANGELOG_TEMPLATE.rst
    for appropriate CHANGELOG update formatting
--->
See #255 for a full description. This just fixes regexes used for checking that we get the error that we expect when the requested family doesn't exist for a plugin.
