### PR TITLE
Resolve typos in installation instructions

### DIFF
--- a/docs/source/starter/installation.rst
+++ b/docs/source/starter/installation.rst
@@ -94,33 +94,15 @@ Next we'll create a conda environment named ``geoips`` that contains all system
 requirements for GeoIPS. Many of these may already be installed on your system,
 but this command will ensure that for everyone.
 
-
-    .. code:: bash
-
-        # Note geos no longer required for cartopy >= 0.22
-        # gcc < 10 required for seviri wavelet transform build
-        # openblas / gcc required for recenter_tc / akima build.
-        # imagemagick required for image comparisons
-        # git required for -C commands
-        # rclone required for NOAA AWS ABI/AHI downloads
-        conda create -y -n geoips -c conda-forge python=3.10 gcc<10 gxx<10 openblas imagemagick git git-lfs rclone
-        conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
-        git lfs install
-
-    **Note:** You will need to run ``conda activate geoips`` every time you want to
-    run or work on GeoIPS.
-
-Next run the GeoIPS command to create and activate a new
-``geoips_conda`` environment.  This command ensures all requirements
-are available (wget, imagemagick, openblas, rclone, etc).
-
-This GeoIPS setup command will run
-"conda create --name geoips_conda" and "conda activate geoips_conda"
-with the appropriate required system packages included.
-
 .. code:: bash
 
-    conda create -y -n geoips -c conda-forge python=3.10 gcc gxx geos openblas imagemagick git git-lfs rclone
+    # Note geos no longer required for cartopy >= 0.22
+    # gcc < 10 required for seviri wavelet transform build
+    # openblas / gcc required for recenter_tc / akima build.
+    # imagemagick required for image comparisons
+    # git required for -C commands
+    # rclone required for NOAA AWS ABI/AHI downloads
+    conda create -y -n geoips -c conda-forge python=3.10 gcc<10 gxx<10 openblas imagemagick git git-lfs rclone
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
     git lfs install
 

--- a/docs/source/starter/installation.rst
+++ b/docs/source/starter/installation.rst
@@ -117,7 +117,7 @@ This command installs all GeoIPS Python dependencies, and GeoIPS itself.
 .. code:: bash
 
     # Ensure geoips python environment enabled before installing geoips
-    pip install -e "$GEOIPS_PACKAGES_DIR/geoips"[doc,lint,test]
+    pip install -e "$GEOIPS_PACKAGES_DIR/geoips"[doc,lint,test,debug]
 
 6. Test your installation
 -------------------------

--- a/docs/source/starter/installation.rst
+++ b/docs/source/starter/installation.rst
@@ -102,7 +102,7 @@ but this command will ensure that for everyone.
     # imagemagick required for image comparisons
     # git required for -C commands
     # rclone required for NOAA AWS ABI/AHI downloads
-    conda create -y -n geoips -c conda-forge python=3.10 gcc<10 gxx<10 openblas imagemagick git git-lfs rclone
+    conda create -y -n geoips -c conda-forge python=3.10 "gcc<10" "gxx<10" openblas imagemagick git git-lfs rclone
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
     git lfs install
 


### PR DESCRIPTION
Accidentally had duplicate instructions for conda create command.
Also, forgot the quotes around the gcc<10 options
Also added the debug option back in to geoips pip install.

Package: geoips_base
Total run time: 191 seconds
Number data types run: 3
Number data types failed: 0