### PR TITLE
Add 1.11.3a0 to release note index

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,7 @@ Version 1.11
 .. toctree::
    :maxdepth: 1
 
+   v1_11_3a0
    v1_11_1
    v1_11_1a0
    v1_11_0

--- a/docs/source/releases/v1_11_3a0.rst
+++ b/docs/source/releases/v1_11_3a0.rst
@@ -10,13 +10,23 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.3a0 (2023-08-18)
+Version 1.11.3a0 (2023-08-19)
 *****************************
 
 * Require sphinx<7.2 due to bugs introduced 2023-08-17 7.2.x release
+* Bug fixes
 
 Bug Fixes
 =========
+
+Add v1_11_3a0 to release note index
+-----------------------------------
+
+Documentation build fails when RST files are missing from the index.
+
+::
+
+  modified: docs/source/releases/index.rst
 
 Require sphinx<7.2 in pyproject.toml
 ------------------------------------


### PR DESCRIPTION
Successful build_docs.sh run:

Sat Aug 19 07:00:26 PDT 2023  Running build_docs.sh
./tests/integration_tests/../..//docs/build_docs.sh ./tests/integration_tests/../../ geoips html_only
$HOME/geoips/outdirs/logs/20230819/20230819.135942_geoips_full/test_all_geoips_full.log_build_docs.sh__._tests_integration_tests_.._..__geoips_html_only.log
        Return: 0