### PR TITLE
Add .vscode repository to full_install.sh

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,7 @@ Version 1.11
 .. toctree::
    :maxdepth: 1
 
+   v1_11_3a0
    v1_11_1
    v1_11_1a0
    v1_11_0

--- a/docs/source/releases/v1_11_3a0.rst
+++ b/docs/source/releases/v1_11_3a0.rst
@@ -10,13 +10,23 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.3a0 (2023-08-18)
+Version 1.11.3a0 (2023-08-19)
 *****************************
 
 * Require sphinx<7.2 due to bugs introduced 2023-08-17 7.2.x release
+* Bug fixes
 
 Bug Fixes
 =========
+
+Add v1_11_3a0 to release note index
+-----------------------------------
+
+Documentation build fails when RST files are missing from the index.
+
+::
+
+  modified: docs/source/releases/index.rst
 
 Require sphinx<7.2 in pyproject.toml
 ------------------------------------

--- a/docs/source/releases/v1_11_3a0.rst
+++ b/docs/source/releases/v1_11_3a0.rst
@@ -14,6 +14,7 @@ Version 1.11.3a0 (2023-08-19)
 *****************************
 
 * Require sphinx<7.2 due to bugs introduced 2023-08-17 7.2.x release
+* Add .vscode settings repository to "full_install.sh"
 * Bug fixes
 
 Bug Fixes
@@ -39,3 +40,19 @@ has been resolved.
 
   modified: pyproject.toml
 
+Installation Updates
+====================
+
+Add .vscode repository to full Installation
+-------------------------------------------
+
+When running full_install.sh/full_test.sh, ensure the .vscode repository is
+cloned along with other source repos.
+
+Also added "settings_repo" option to check_system_requirements (only clones,
+does not attempt to pip install or uncompress test data)
+
+::
+
+  modified: tests/integration_tests/full_install.sh
+  modified: setup/check_system_requirements.sh

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -156,6 +156,39 @@ if [[ "$1" == "matplotlib" ]]; then
     fi
 fi
 
+if [[ "$1" == "settings_repo" ]]; then
+    repo_name=$2
+    repo_name_string="settings repo $repo_name"
+    repo_dir=$GEOIPS_PACKAGES_DIR/$repo_name
+    repo_url=$GEOIPS_REPO_URL/${repo_name}.git
+    ls $repo_dir/* >> $install_log 2>&1
+    retval=$?
+    if [[ "$retval" != "0" ]]; then
+        if [[ "$exit_on_missing" == "true" ]]; then
+            echo "FAILED: Missing $repo_name_string"
+            echo "        Please run install script, then rerun test script. "
+            echo "        $install_script"
+            echo "        $test_script"
+            exit 1
+        fi
+        echo "Installing $repo_name_string .... "
+        echo "  $repo_dir/"
+        echo "git clone $repo_url $repo_dir" >> $install_log 2>&1
+        git clone $repo_url $repo_dir >> $install_log 2>&1
+        clone_retval=$?
+        if [[ "$clone_retval" == "0" ]]; then
+            echo "SUCCESS: Cloned $repo_name_string"
+        else
+            echo "FAILED: $repo_name_string clone returned non-zero"
+            echo "        try deleting directory and re-running"
+            exit 1
+        fi
+    else
+        echo "SUCCESS: $repo_name_string appears to be installed successfully"
+        echo "    "`ls -ld $repo_dir`
+    fi
+fi
+
 if [[ "$1" == "test_repo" || "$1" == "source_repo" ]]; then
     repo_name=$2
 

--- a/tests/integration_tests/full_install.sh
+++ b/tests/integration_tests/full_install.sh
@@ -31,6 +31,7 @@ fi
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh source_repo geoips_plugin_example $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh source_repo template_basic_plugin $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh source_repo template_fusion_plugin $test_exit $install_script
+. $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh settings_repo .vscode $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_repo test_data_amsr2 $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_repo test_data_clavrx $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_repo test_data_gpm $test_exit $install_script


### PR DESCRIPTION
Include clone of ".vscode" repository by default during full install/test.  This will ensure consistent VSCode settings are enabled for GeoIPS developers.

```
> full_test.sh
...
Install log: $HOME/geoips/outdirs/logs/20230819.141531_install.log
FAILED: Missing settings repo .vscode
        Please run install script, then rerun test script. 
        $HOME/geoips/geoips/tests/integration_tests/full_install.sh
...

> full_install.sh
...
Install log: $HOME/geoips/outdirs/logs/20230819.141623_install.log
Installing settings repo .vscode .... 
  $HOME/geoips/.vscode/
SUCCESS: Cloned settings repo .vscode
...

> full_test.sh
...
Install log: $HOME/geoips/outdirs/logs/20230819.135942_install.log
SUCCESS: settings repo .vscode appears to be installed successfully
    drwxrwxr-x. 3 surratt surratt 4096 Aug 19 06:49 $HOME/geoips/.vscode
...
```