### PR TITLE
56 compare images with python and mpl

### DIFF
--- a/docs/source/releases/v1_11_3a0.rst
+++ b/docs/source/releases/v1_11_3a0.rst
@@ -18,6 +18,7 @@ Version 1.11.3a0 (2023-08-19)
 * Add script to enable geoips environment
 * Replace xRITDecompress with pyPublicDecompWT for seviri_hrit reader
 * Use matplotlib_linear_norm colormapper for tpw_cimss and tpw_purple
+* Replace Imagemagick with PIL and Numpy based comparison
 * Bug fixes
 
 Bug Fixes
@@ -158,3 +159,16 @@ future.
     modified: geoips/geoips/plugins/yaml/product_defaults/tpw/TPW-CIMSS.yaml
     modified: geoips/geoips/plugins/yaml/product_defaults/tpw/TPW-PURPLE.yaml
     modified: geoips/pyproject.toml
+
+Replace Imagemagick with PIL and Numpy Based comparison
+-------------------------------------------------------
+
+The previous comparison method failed for annotated imagery, using Imagemagick. to
+circumvent this problem, we've replaced the usage of Imagemagick with a PIL and Numpy
+based method, which not only removes a dependency, but can be configured to our own
+needs as well.
+
+::
+
+    modified: geoips/geoips/compare_outputs.py
+

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -214,37 +214,55 @@ def images_match(output_product, compare_product, fuzz="5%"):
     bool
         Return True if images match, False if they differ
     """
-    out_diffimg = get_out_diff_fname(compare_product, output_product)
-    exact_out_diffimg = get_out_diff_fname(
-        compare_product, output_product, flag="exact_"
-    )
+    # out_diffimg = get_out_diff_fname(compare_product, output_product)
+    # exact_out_diffimg = get_out_diff_fname(
+    #     compare_product, output_product, flag="exact_"
+    # )
 
-    call_list = [
-        "compare",
-        "-verbose",
-        "-quiet",
-        "-metric",
-        "ae",
-        "-fuzz",
-        fuzz,
-        output_product,
-        compare_product,
-        out_diffimg,
-    ]
+    # call_list = [
+    #     "compare",
+    #     "-verbose",
+    #     "-quiet",
+    #     "-metric",
+    #     "ae",
+    #     "-fuzz",
+    #     fuzz,
+    #     output_product,
+    #     compare_product,
+    #     out_diffimg,
+    # ]
 
-    exact_call_list = [
-        "compare",
-        "-verbose",
-        "-quiet",
-        "-metric",
-        "ae",
-        output_product,
-        compare_product,
-        exact_out_diffimg,
-    ]
+    # exact_call_list = [
+    #     "compare",
+    #     "-verbose",
+    #     "-quiet",
+    #     "-metric",
+    #     "ae",
+    #     output_product,
+    #     compare_product,
+    #     exact_out_diffimg,
+    # ]
+    import numpy as np
+    from PIL import Image
+    from matplotlib import pyplot as plt
 
-    LOG.info("**Running %s", " ".join(call_list))
-    fullimg_retval = subprocess.call(call_list)
+    LOG.info("**Comparing output_product vs. compare product")
+    comp_img = np.asarray(Image.open(output_product))
+    out_img = np.asarray(Image.open(compare_product))
+    diff_images = comp_img - out_img
+    fullimg_retval = 0 if np.all(diff_images == 0) else 1
+    fig = plt.figure()
+    fig_shape = np.shape(diff_images)
+    fig.set_size_inches(fig_shape[2], fig_shape[1])
+    left_margin = 0.0
+    right_margin = 1.0
+    bottom_margin = 0.0
+    top_margin = 1.0
+    main_ax = plt.Axes(fig,
+                       [left_margin, bottom_margin,
+                        right_margin - left_margin,
+                        top_margin - bottom_margin,],)
+    # fullimg_retval = subprocess.call(call_list)
     LOG.info("**Done running compare")
 
     # call_list = ['compare', '-verbose', '-quiet',
@@ -275,14 +293,8 @@ def images_match(output_product, compare_product, fuzz="5%"):
         LOG.info("    *** BAD Images do NOT match exactly ***")
         LOG.info("    ***   output_product: %s ***", output_product)
         LOG.info("    ***   compare_product: %s ***", compare_product)
-        LOG.info("    ***   out_diffimg: %s ***", out_diffimg)
-        LOG.info("    ***   exact_out_diffimg: %s ***", exact_out_diffimg)
         LOG.info("    ***************************************")
         return False
-
-    LOG.info("**Running exact %s", " ".join(exact_call_list))
-    fullimg_retval = subprocess.call(exact_call_list)
-    LOG.info("**Done running exact compare")
 
     if fullimg_retval != 0:
         LOG.info("    ******************************************")
@@ -293,9 +305,9 @@ def images_match(output_product, compare_product, fuzz="5%"):
         LOG.info("    *** GOOD Images match exactly ***")
         LOG.info("    *********************************")
     # Remove the image if they matched so we don't have extra stuff to sort through.
-    from os import unlink as osunlink
+    # from os import unlink as osunlink
 
-    osunlink(out_diffimg)
+    # osunlink(out_diffimg)
     return True
 
 

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -226,7 +226,7 @@ def images_match(output_product, compare_product, fuzz="5%"):
     out_img = Image.open(output_product)
     comp_img = Image.open(compare_product)
     diff_img = Image.new(mode="RGB", size=comp_img.size)
-    diff_arr = np.asarray(comp_img) - np.asarray(out_img)
+    diff_arr = np.abs(np.array(comp_img) - np.array(out_img))
     num_pix_mismatched = pixelmatch(out_img, comp_img, diff_img, includeAA=True,
                                     alpha=0.33, threshold=0.05)
     fullimg_retval = 0 if np.all(diff_arr == 0) and num_pix_mismatched == 0 else 1

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -219,15 +219,17 @@ def images_match(output_product, compare_product, fuzz="5%"):
         compare_product, output_product, flag="exact_"
     )
     from PIL import Image
+    import numpy as np
     from pixelmatch.contrib.PIL import pixelmatch
 
     LOG.info("**Comparing output_product vs. compare product")
     out_img = Image.open(output_product)
     comp_img = Image.open(compare_product)
     diff_img = Image.new(mode="RGB", size=comp_img.size)
+    diff_arr = np.asarray(comp_img) - np.asarray(out_img)
     num_pix_mismatched = pixelmatch(out_img, comp_img, diff_img, includeAA=True,
                                     alpha=0.33, threshold=0.05)
-    fullimg_retval = 0 if num_pix_mismatched == 0 else 1
+    fullimg_retval = 0 if np.all(diff_arr == 0) and num_pix_mismatched == 0 else 1
     LOG.info("**Saving exact difference image")
     diff_img.save(exact_out_diffimg)
     LOG.info("**Done running compare")

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -221,13 +221,14 @@ def images_match(output_product, compare_product, fuzz="5%"):
     from PIL import Image
     from pixelmatch.contrib.PIL import pixelmatch
 
-    LOG.info("\n\n\n**Comparing output_product vs. compare product\n\n\n")
+    LOG.info("**Comparing output_product vs. compare product")
     out_img = Image.open(output_product)
     comp_img = Image.open(compare_product)
     diff_img = Image.new(mode="RGB", size=comp_img.size)
     num_pix_mismatched = pixelmatch(out_img, comp_img, diff_img, includeAA=True,
                                     alpha=0.33, threshold=0.05)
     fullimg_retval = 0 if num_pix_mismatched == 0 else 1
+    LOG.info("**Saving exact difference image")
     diff_img.save(exact_out_diffimg)
     LOG.info("**Done running compare")
 

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -252,16 +252,10 @@ def images_match(output_product, compare_product, fuzz="5%"):
     diff_images = comp_img - out_img
     fullimg_retval = 0 if np.all(diff_images == 0) else 1
     fig = plt.figure()
-    fig_shape = np.shape(diff_images)
-    fig.set_size_inches(fig_shape[2], fig_shape[1])
-    left_margin = 0.0
-    right_margin = 1.0
-    bottom_margin = 0.0
-    top_margin = 1.0
-    main_ax = plt.Axes(fig,
-                       [left_margin, bottom_margin,
-                        right_margin - left_margin,
-                        top_margin - bottom_margin,],)
+    fig.suptitle("test_figure")
+    plt.imshow(diff_images)
+    # plt.imsave("test_figure.png", diff_images, cmap="jet")
+    plt.savefig("test_figure.png")
     # fullimg_retval = subprocess.call(call_list)
     LOG.info("**Done running compare")
 

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -246,16 +246,18 @@ def images_match(output_product, compare_product, fuzz="5%"):
     from PIL import Image
     from matplotlib import pyplot as plt
 
-    LOG.info("**Comparing output_product vs. compare product")
+    LOG.info("\n\n\n**Comparing output_product vs. compare product\n\n\n")
     comp_img = np.asarray(Image.open(output_product))
     out_img = np.asarray(Image.open(compare_product))
-    diff_images = comp_img - out_img
-    fullimg_retval = 0 if np.all(diff_images == 0) else 1
+    LOG.info("SHAPE: " + str(np.shape(out_img)) + "\n")
+    diff_pixels = comp_img - out_img
+    diff_img = Image.new(mode="L", size=(2000, 2000))
+    fullimg_retval = 0 if np.all(diff_pixels == 0) else 1
     fig = plt.figure()
     fig.suptitle("test_figure")
-    plt.imshow(diff_images)
+    # plt.imshow(diff_images)
     # plt.imsave("test_figure.png", diff_images, cmap="jet")
-    plt.savefig("test_figure.png")
+    plt.imsave("test_figure.png", diff_img)
     # fullimg_retval = subprocess.call(call_list)
     LOG.info("**Done running compare")
 

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -242,23 +242,17 @@ def images_match(output_product, compare_product, fuzz="5%"):
     #     compare_product,
     #     exact_out_diffimg,
     # ]
-    import numpy as np
     from PIL import Image
-    from matplotlib import pyplot as plt
+    from pixelmatch.contrib.PIL import pixelmatch
 
     LOG.info("\n\n\n**Comparing output_product vs. compare product\n\n\n")
-    comp_img = np.asarray(Image.open(output_product))
-    out_img = np.asarray(Image.open(compare_product))
-    LOG.info("SHAPE: " + str(np.shape(out_img)) + "\n")
-    diff_pixels = comp_img - out_img
-    diff_img = Image.new(mode="L", size=(2000, 2000))
-    fullimg_retval = 0 if np.all(diff_pixels == 0) else 1
-    fig = plt.figure()
-    fig.suptitle("test_figure")
-    # plt.imshow(diff_images)
-    # plt.imsave("test_figure.png", diff_images, cmap="jet")
-    plt.imsave("test_figure.png", diff_img)
-    # fullimg_retval = subprocess.call(call_list)
+    out_img = Image.open(output_product)
+    comp_img = Image.open(compare_product)
+    diff_img = Image.new(mode="RGB", size=comp_img.size)
+    num_pix_mismatched = pixelmatch(out_img, comp_img, diff_img, includeAA=True,
+                                    alpha=0.33, threshold=0.05)
+    fullimg_retval = 0 if num_pix_mismatched == 0 else 1
+    diff_img.save("diff.png")
     LOG.info("**Done running compare")
 
     # call_list = ['compare', '-verbose', '-quiet',

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -215,33 +215,9 @@ def images_match(output_product, compare_product, fuzz="5%"):
         Return True if images match, False if they differ
     """
     # out_diffimg = get_out_diff_fname(compare_product, output_product)
-    # exact_out_diffimg = get_out_diff_fname(
-    #     compare_product, output_product, flag="exact_"
-    # )
-
-    # call_list = [
-    #     "compare",
-    #     "-verbose",
-    #     "-quiet",
-    #     "-metric",
-    #     "ae",
-    #     "-fuzz",
-    #     fuzz,
-    #     output_product,
-    #     compare_product,
-    #     out_diffimg,
-    # ]
-
-    # exact_call_list = [
-    #     "compare",
-    #     "-verbose",
-    #     "-quiet",
-    #     "-metric",
-    #     "ae",
-    #     output_product,
-    #     compare_product,
-    #     exact_out_diffimg,
-    # ]
+    exact_out_diffimg = get_out_diff_fname(
+        compare_product, output_product, flag="exact_"
+    )
     from PIL import Image
     from pixelmatch.contrib.PIL import pixelmatch
 
@@ -252,32 +228,9 @@ def images_match(output_product, compare_product, fuzz="5%"):
     num_pix_mismatched = pixelmatch(out_img, comp_img, diff_img, includeAA=True,
                                     alpha=0.33, threshold=0.05)
     fullimg_retval = 0 if num_pix_mismatched == 0 else 1
-    diff_img.save("diff.png")
+    diff_img.save(exact_out_diffimg)
     LOG.info("**Done running compare")
 
-    # call_list = ['compare', '-verbose', '-quiet',
-    #              '-metric', 'rmse',
-    #              '-dissimilarity-threshold', '{0:0.15f}'.format(threshold),
-    #              '-subimage-search',
-    #              output_product,
-    #              compare_product,
-    #              out_diffimg]
-
-    # LOG.info('Running %s', ' '.join(call_list))
-
-    # subimg_retval = subprocess.call(call_list)
-    # if subimg_retval != 0 and fullimg_retval != 0:
-    #     call_list = ['compare', '-verbose', '-quiet',
-    #                  '-metric', 'rmse',
-    #                  '-subimage-search',
-    #                  output_product,
-    #                  compare_product,
-    #                  out_diffimg]
-    #     subprocess.call(call_list)
-    #     LOG.info('    ***************************************')
-    #     LOG.info('    *** BAD Images do NOT match exactly ***')
-    #     LOG.info('    ***************************************')
-    #     return False
     if fullimg_retval != 0:
         LOG.info("    ***************************************")
         LOG.info("    *** BAD Images do NOT match exactly ***")

--- a/geoips/compare_outputs.py
+++ b/geoips/compare_outputs.py
@@ -214,7 +214,6 @@ def images_match(output_product, compare_product, fuzz="5%"):
     bool
         Return True if images match, False if they differ
     """
-    # out_diffimg = get_out_diff_fname(compare_product, output_product)
     exact_out_diffimg = get_out_diff_fname(
         compare_product, output_product, flag="exact_"
     )
@@ -250,10 +249,7 @@ def images_match(output_product, compare_product, fuzz="5%"):
         LOG.info("    *********************************")
         LOG.info("    *** GOOD Images match exactly ***")
         LOG.info("    *********************************")
-    # Remove the image if they matched so we don't have extra stuff to sort through.
-    # from os import unlink as osunlink
 
-    # osunlink(out_diffimg)
     return True
 
 


### PR DESCRIPTION
# Related Issues
fixes NRLMMD-GEOIPS/geoips #56 

# Testing Instructions
To test these changes, I've been using the two files listed below to compare annotated imagery. However, any test script which compares imagery will be fine for this purpose. They pass without any problems.

  - geoips/tests/scripts/abi.static.Infrared.imagery_annotated.sh
  - geoips/tests/scripts/amsr2.tc.89H-Physical.imagery_annotated.sh

# Summary
Previously, the functionality in GeoIPS to compare imagery used 'imagemagick compare' methods. This would work for all clean imagery, however sometimes failed for annotated imagery. To circumvent this problem and allow for more flexibility on our side, we've implemented comparisons using PIL and Numpy, which result in the same figures, without having an extra dependency. While it takes a slight amount longer, this should be beneficial in the long run.

  - modified: geoips/geoips/compare_outputs.py

# Output
The output shown below was captured after running 'geoips/tests/scripts/amsr2.tc.89H-Physical.imagery_annotated.sh'.

<img width="860" alt="Screenshot 2023-09-06 at 12 41 25 PM" src="https://github.com/NRLMMD-GEOIPS/geoips/assets/62626811/38004dbb-c240-4a08-bfaf-be51d82efcc2">


![diff_test_output_exact_20200518_073601_IO012020_amsr2_gcom-w1_89H-Physical_140kts_100p00_res1p0-cr300](https://github.com/NRLMMD-GEOIPS/geoips/assets/62626811/d740c9ae-b9d5-4f31-b83d-fc790ab34771)