### PR TITLE
Remove flake8 docstring only option

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -82,7 +82,7 @@ jobs:
             tests/utils
       - name: Run code check script flake8
         run: |
-          ret=$(bash geoips_dev_utils/tests/utils/check_code.sh flake8 . flake8_docstring_only)
+          ret=$(bash geoips_dev_utils/tests/utils/check_code.sh flake8 .)
           echo "::group::flake8_analysis"
           echo "FLAKE8 analysis of flake8_docstring_only"
           echo "${ret}"


### PR DESCRIPTION
In preparation for flake8 updates being complete, remove the docstring only option from the flake8 command.

