### PR TITLE
Create default v1_11_5a0.rst in geoips repo

### DIFF
--- a/docs/source/releases/v1_11_5a0.rst
+++ b/docs/source/releases/v1_11_5a0.rst
@@ -1,0 +1,26 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.11.5a0 (2023-09-27)
+*****************************
+
+* Update "update_this_release_note" to v1_11_5a0.rst
+
+Release Updates
+===============
+
+Update "update_this_release_note" to docs/source/releases/v1_11_5a0.rst
+-----------------------------------------------------------------------
+
+::
+
+  modified: update_this_release_note


### PR DESCRIPTION
Create default release note in geoips repo

This will be part of the release process going forward, since we are already changing the "update_this_release_note" file, we know geoips repo will always have changes on every version release, so we are safe to auto-generate the new release note itself.

Other repos we do not want to auto-generate the release note, because they will not necessarily have changes / be tagged on every release, but should be safe with geoips repo.

