### PR TITLE
Remove circular imports and handle products correctly in create_plugin_registry

### DIFF
--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -207,9 +207,19 @@ geoips_utils and the base interfaces were updated to use this new plugin registr
 rather than the deprecated "plugin cache" (which was created a runtime, every
 time geoips was imported).
 
+Note create_plugin_registry is NOT auto-called from within geoips_utils,
+if the plugin registry is not found, a PluginRegistryError is raised, prompting
+the user to run "create_plugin_registry"
+
+Also note tuple-based interfaces (ie, products, which are stored as
+(source_name, product_name)) are expanded out into each full tuple within
+the plugin registry, and are accessed directly by their tuple from within
+the geoips interfaces.
+
 ::
 
     modified: geoips/geoips/geoips_utils.py
+    modified: geoips/geoips/errors.py
     modified: geoips/geoips/interfaces/base.py
     modified: geoips/geoips/interfaces/yaml_based/products.py
 

--- a/geoips/create_plugin_registry.py
+++ b/geoips/create_plugin_registry.py
@@ -73,12 +73,12 @@ def create_plugin_registry(plugin_packages):
             # "schemas": schema_yamls,
             "pyfiles": python_files,
         }
-        parse_plugin_paths(plugin_paths, package, plugins)
+        parse_plugin_paths(plugin_paths, package, pkg_dir, plugins)
         LOG.debug("Available Plugin Interfaces:\n" + str(plugins.keys()))
         write_registered_plugins(pkg_dir, plugins)
 
 
-def parse_plugin_paths(plugin_paths, package, plugins):
+def parse_plugin_paths(plugin_paths, package, package_dir, plugins):
     """Parse the plugin_paths provided from the current installed GeoIPS package.
 
     Then, add them to the plugins dictionary based on the path of the plugin.
@@ -91,6 +91,8 @@ def parse_plugin_paths(plugin_paths, package, plugins):
         A dictionary of filepaths, with keys referring to the type of plugin
     package: str
         The current GeoIPS package being parsed
+    package_dir: str
+        The path to the current GeoIPS package (for determining relative paths)
     plugins: dict
         A dictionary object of all installed GeoIPS package plugins
     """
@@ -98,7 +100,8 @@ def parse_plugin_paths(plugin_paths, package, plugins):
         for filepath in plugin_paths[interface_key]:
             filepath = str(filepath)
             abspath = os.path.abspath(filepath)
-            relpath = os.path.relpath(filepath)
+            # Path relative to the package directory
+            relpath = os.path.relpath(filepath, start=package_dir)
             if interface_key == "yamls":  # yaml based plugins
                 add_yaml_plugin(filepath, abspath, relpath, package, plugins)
             # elif interface_key == "schemas":  # schema based yamls

--- a/geoips/create_plugin_registry.py
+++ b/geoips/create_plugin_registry.py
@@ -57,12 +57,12 @@ def create_plugin_registry(plugin_packages):
     plugins: dict
         A dictionary object of all installed GeoIPS package plugins
     """
-    plugins = {
-        # "schemas": {},
-        "yaml_based": {},
-        "module_based": {},
-    }
     for pkg in plugin_packages:
+        plugins = {
+            # "schemas": {},
+            "yaml_based": {},
+            "module_based": {},
+        }
         # Track sets of plugins by plugin type
         # (schemas, yaml_based, and module_based)
         package = pkg.value
@@ -183,11 +183,16 @@ def add_yaml_plugin(filepath, abspath, relpath, package, plugins):
                 # Give each one its own entry in the plugin registry for easy
                 # access.
                 for subplg_name in subplg_names:
-                    plugins[interface_name][str(subplg_name)] = {
-                        "package": plugin["package"],
-                        "relpath": plugin["relpath"],
-                        "abspath": plugin["abspath"],
-                    }
+                    if str(subplg_name[0]) not in list(plugins[interface_name].keys()):
+                        plugins[interface_name][str(subplg_name[0])] = {
+                            "package": plugin["package"],
+                            "relpath": plugin["relpath"],
+                            "abspath": plugin["abspath"],
+                            "products": {},
+                        }
+                    plugins[interface_name][str(subplg_name[0])]["products"][
+                        str(subplg_name[1])
+                    ] = str(subplg_name[1])
             # If the plugin was not found, issue a warning and continue.
             # Do not fail catastrophically for a bad plugin.
             except KeyError as resp:

--- a/geoips/create_plugin_registry.py
+++ b/geoips/create_plugin_registry.py
@@ -1,10 +1,9 @@
 """Generates all available plugins from all installed GeoIPS packages.
 
-After all plugins have been generated, they are written to a registered_plugins.py
-file which contains a dictionary of all the registered GeoIPS plugins. This dictionary
-is called 'registered_plugins'.
+After all plugins have been generated, they are written to a registered_plugins.yaml
+file which contains a dictionary of all the registered GeoIPS plugins.
 
-To use this module, simply call 'create_registered_plugins'.
+To use this module, simply call 'python create_plugin_registry.py'.
 The main function will do the rest!
 """
 
@@ -125,7 +124,7 @@ def parse_plugin_paths(plugin_paths, package, package_dir, plugins):
             #         filepath, abspath, relpath, package, plugins["schemas"]
             #     )
             else:  # module based plugins
-                add_module_plugin(abspath, relpath, package, plugins["module_based"])
+                add_module_plugin(abspath, plugins["module_based"])
 
 
 def add_yaml_plugin(filepath, abspath, relpath, package, plugins):
@@ -241,17 +240,13 @@ def add_yaml_plugin(filepath, abspath, relpath, package, plugins):
 #     # )
 
 
-def add_module_plugin(abspath, relpath, package, plugins):
+def add_module_plugin(abspath, plugins):
     """Add the yaml plugin associated with the filepaths and package to plugins.
 
     Parameters
     ----------
     abspath: str
         The absolute path to the module plugin
-    relpath: str
-        The relative path to the module plugin
-    package: str
-        The current GeoIPS package being parsed
     plugins: dict
         A dictionary object of all installed GeoIPS package plugins
     """

--- a/geoips/create_plugin_registry.py
+++ b/geoips/create_plugin_registry.py
@@ -184,15 +184,14 @@ def add_yaml_plugin(filepath, abspath, relpath, package, plugins):
                 # access.
                 for subplg_name in subplg_names:
                     if str(subplg_name[0]) not in list(plugins[interface_name].keys()):
-                        plugins[interface_name][str(subplg_name[0])] = {
-                            "package": plugin["package"],
-                            "relpath": plugin["relpath"],
-                            "abspath": plugin["abspath"],
-                            "products": {},
-                        }
-                    plugins[interface_name][str(subplg_name[0])]["products"][
+                        plugins[interface_name][str(subplg_name[0])] = {}
+                    plugins[interface_name][str(subplg_name[0])][
                         str(subplg_name[1])
-                    ] = str(subplg_name[1])
+                    ] = {
+                        "package": plugin["package"],
+                        "relpath": plugin["relpath"],
+                        "abspath": plugin["abspath"],
+                    }
             # If the plugin was not found, issue a warning and continue.
             # Do not fail catastrophically for a bad plugin.
             except KeyError as resp:

--- a/geoips/errors.py
+++ b/geoips/errors.py
@@ -25,6 +25,12 @@ class PluginError(Exception):
     pass
 
 
+class PluginRegistryError(Exception):
+    """Exception to be raised when there is an error in a plugin module."""
+
+    pass
+
+
 class CoverageError(Exception):
     """Raise exception on data coverage error."""
 

--- a/geoips/geoips_utils.py
+++ b/geoips/geoips_utils.py
@@ -17,11 +17,9 @@ from copy import deepcopy
 import sys
 import yaml
 import logging
-from glob import glob
 from importlib import metadata, resources
 
-from geoips.errors import EntryPointError
-from geoips.filenames.base_paths import PATHS as gpaths
+from geoips.errors import EntryPointError, PluginRegistryError
 
 LOG = logging.getLogger(__name__)
 
@@ -36,6 +34,38 @@ def get_entry_point_group(group):
         return metadata.entry_points()[group]
 
 
+def find_ascii_palette(name):
+    """Find ASCII palette named "name".
+
+    Search the plugins/txt/ascii_palettes directory for ASCII palettes to use
+    as colormaps.
+    """
+    all_plugins = find_all_txt_plugins("txt/ascii_palettes")
+
+    for plugin in all_plugins:
+        if name == os.path.splitext(os.path.basename(plugin))[0]:
+            return plugin
+    raise ValueError(f"Non-existent txt plugin: {name}")
+
+
+def find_all_txt_plugins(subdir=""):
+    """Find all txt plugins in registered plugin packages.
+
+    Search the ``plugins`` directory of each registered plugin package for files ending
+    in ``.txt``. Return list of files
+    """
+    # Load all entry points for plugin packages
+    plugin_packages = get_entry_point_group("geoips.plugin_packages")
+
+    # Loop over the plugin packages and load all of their yaml plugins
+    txt_files = []
+    for pkg in plugin_packages:
+        pkg_plugin_path = resources.files(pkg.value) / "plugins" / subdir
+        txt_files += pkg_plugin_path.rglob("*.txt")
+
+    return txt_files
+
+
 def load_all_yaml_plugins():
     """Find all YAML plugins in registered plugin packages.
 
@@ -46,9 +76,10 @@ def load_all_yaml_plugins():
 
     reg_plug_path = resources.files("geoips") / "registered_plugins.yaml"
     if not os.path.exists(reg_plug_path):
-        from . import create_plugin_registry
-
-        create_plugin_registry.main()
+        raise PluginRegistryError(
+            f"Plugin registry {reg_plug_path} did not exist, "
+            "please run 'create_plugin_registry'"
+        )
     plugin_packages = get_entry_point_group("geoips.plugin_packages")
     plugins = {}
     yaml_interfaces = [

--- a/geoips/geoips_utils.py
+++ b/geoips/geoips_utils.py
@@ -95,8 +95,9 @@ def load_all_yaml_plugins():
                         interface
                     ]
                 else:
-                    yaml_plugins[interface].update(
-                        registered_plugins["yaml_based"][interface]
+                    merge_nested_dicts(
+                        yaml_plugins[interface],
+                        registered_plugins["yaml_based"][interface],
                     )
         except TypeError:
             raise PluginRegistryError(f"Failed reading {pkg_plug_path}.")

--- a/geoips/geoips_utils.py
+++ b/geoips/geoips_utils.py
@@ -36,38 +36,6 @@ def get_entry_point_group(group):
         return metadata.entry_points()[group]
 
 
-def find_ascii_palette(name):
-    """Find ASCII palette named "name".
-
-    Search the plugins/txt/ascii_palettes directory for ASCII palettes to use
-    as colormaps.
-    """
-    all_plugins = find_all_txt_plugins("txt/ascii_palettes")
-
-    for plugin in all_plugins:
-        if name == os.path.splitext(os.path.basename(plugin))[0]:
-            return plugin
-    raise ValueError(f"Non-existent txt plugin: {name}")
-
-
-def find_all_txt_plugins(subdir=""):
-    """Find all txt plugins in registered plugin packages.
-
-    Search the ``plugins`` directory of each registered plugin package for files ending
-    in ``.txt``. Return list of files
-    """
-    # Load all entry points for plugin packages
-    plugin_packages = get_entry_point_group("geoips.plugin_packages")
-
-    # Loop over the plugin packages and load all of their yaml plugins
-    txt_files = []
-    for pkg in plugin_packages:
-        pkg_plugin_path = resources.files(pkg.value) / "plugins" / subdir
-        txt_files += pkg_plugin_path.rglob("*.txt")
-
-    return txt_files
-
-
 def load_all_yaml_plugins():
     """Find all YAML plugins in registered plugin packages.
 
@@ -100,56 +68,6 @@ def load_all_yaml_plugins():
                 else:
                     plugins[interface].update(registered_plugins[interface])
     return plugins
-
-
-def find_config(subpackage_name, config_basename, txt_suffix=".yaml"):
-    """Find matching config file within GEOIPS packages.
-
-    Given 'subpackage_name', 'config_basename', and txt_suffix, find matching
-    text file within GEOIPS packages.
-
-    Parameters
-    ----------
-    subpackage_name : str
-        subdirectory under GEOIPS package to look for text file
-        ie text_fname = geoips/<subpackage_name>/<config_basename><txt_suffix>
-    config_basename : str
-        text basename to look for,
-        ie text_fname = geoips/<subpackage_name>/<config_basename><txt_suffix>
-    txt_suffix : str
-        suffix to look for on config file, defaults to ".yaml"
-        ie text_fname = geoips/<subpackage_name>/<config_basename><txt_suffix>
-
-    Returns
-    -------
-    text_fname : str
-        Full path to text filename
-    """
-    text_fname = None
-
-    for package_name in gpaths["GEOIPS_PACKAGES"]:
-        fname = os.path.join(
-            os.getenv("GEOIPS_PACKAGES_DIR"),
-            package_name,
-            subpackage_name,
-            config_basename + txt_suffix,
-        )
-        # LOG.info('Trying %s', fname)
-        if os.path.exists(fname):
-            LOG.info("FOUND %s", fname)
-            text_fname = fname
-        fname = os.path.join(
-            os.getenv("GEOIPS_PACKAGES_DIR"),
-            package_name,
-            package_name,
-            subpackage_name,
-            config_basename + txt_suffix,
-        )
-        # LOG.info('Trying %s', fname)
-        if os.path.exists(fname):
-            LOG.info("FOUND %s", fname)
-            text_fname = fname
-    return text_fname
 
 
 def find_entry_point(namespace, name, default=None):
@@ -420,70 +338,6 @@ def get_required_geoips_xarray_attrs():
         "end_datetime",
     ]
     return required_xarray_attrs
-
-
-def list_product_specs_dict_yamls():
-    """List all YAML files containing product params in all geoips packages.
-
-    Returns
-    -------
-    list
-        List of all product params dict YAMLs in all geoips packages
-    """
-    all_files = []
-    for package_name in gpaths["GEOIPS_PACKAGES"]:
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/*/yaml_configs/product_params/*/*.yaml"
-        )
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/yaml_configs/product_params/*/*.yaml"
-        )
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/*/yaml_configs/product_params/*.yaml"
-        )
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/yaml_configs/product_params/*.yaml"
-        )
-    return [fname for fname in all_files if "__init__" not in fname]
-
-
-def list_product_source_dict_yamls():
-    """List all YAML files containing product source specifications.
-
-    Search in all geoips packages.
-
-    Returns
-    -------
-    list
-        List of all product source dict YAMLs in all geoips packages
-    """
-    all_files = []
-    for package_name in gpaths["GEOIPS_PACKAGES"]:
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/*/yaml_configs/product_inputs/*.yaml"
-        )
-        all_files += glob(
-            gpaths["GEOIPS_PACKAGES_DIR"]
-            + "/"
-            + package_name
-            + "/yaml_configs/product_inputs/*.yaml"
-        )
-    return [fname for fname in all_files if "__init__" not in fname]
 
 
 def merge_nested_dicts(dest, src, in_place=True):

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -330,9 +330,6 @@ class BaseYamlInterface(BaseInterface):
 
     def __init__(self):
         """YAML plugin interface init method."""
-        # self._unvalidated_plugins = self._create_unvalidated_plugins_cache(
-        #     load_all_yaml_plugins()
-        # )
         self._unvalidated_plugins = load_all_yaml_plugins()
 
     @classmethod
@@ -387,9 +384,6 @@ class BaseYamlInterface(BaseInterface):
         plugin_type = f"{plugin_interface_name}Plugin"
 
         plugin_base_class = BaseYamlPlugin
-        # from IPython import embed as shell
-
-        # shell()
         if hasattr(cls, "plugin_class") and cls.plugin_class:
             plugin_base_class = cls.plugin_class
 

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -370,6 +370,7 @@ class BaseYamlInterface(BaseInterface):
         obj_attrs["yaml"] = yaml_plugin
 
         missing = []
+
         for attr in [
             "package",
             "relpath",
@@ -397,7 +398,6 @@ class BaseYamlInterface(BaseInterface):
         plugin_base_class = BaseYamlPlugin
         if hasattr(cls, "plugin_class") and cls.plugin_class:
             plugin_base_class = cls.plugin_class
-
         return type(plugin_type, (plugin_base_class,), obj_attrs)(yaml_plugin)
 
     def __repr__(self):
@@ -421,9 +421,7 @@ class BaseYamlInterface(BaseInterface):
                 # These are stored in the yaml as str(name),
                 # ie "('viirs', 'Infrared')"
                 plugin = yaml.safe_load(
-                    open(
-                        self._unvalidated_plugins[self.name][str(name)]["abspath"], "r"
-                    )
+                    open(self._unvalidated_plugins[self.name][name[0]]["abspath"], "r")
                 )
                 for product in plugin["spec"]["products"]:
                     if (
@@ -433,13 +431,13 @@ class BaseYamlInterface(BaseInterface):
                         plugin = product
                         break
                 plugin["interface"] = "products"
-                plugin["abspath"] = self._unvalidated_plugins[self.name][str(name)][
+                plugin["abspath"] = self._unvalidated_plugins[self.name][name[0]][
                     "abspath"
                 ]
-                plugin["relpath"] = self._unvalidated_plugins[self.name][str(name)][
+                plugin["relpath"] = self._unvalidated_plugins[self.name][name[0]][
                     "relpath"
                 ]
-                plugin["package"] = self._unvalidated_plugins[self.name][str(name)][
+                plugin["package"] = self._unvalidated_plugins[self.name][name[0]][
                     "package"
                 ]
             else:

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -421,25 +421,36 @@ class BaseYamlInterface(BaseInterface):
                 # These are stored in the yaml as str(name),
                 # ie "('viirs', 'Infrared')"
                 plugin = yaml.safe_load(
-                    open(self._unvalidated_plugins[self.name][name[0]]["abspath"], "r")
+                    open(
+                        self._unvalidated_plugins[self.name][name[0]][name[1]][
+                            "abspath"
+                        ],
+                        "r",
+                    )
                 )
+                plugin_found = False
                 for product in plugin["spec"]["products"]:
                     if (
                         product["name"] == name[1]
                         and name[0] in product["source_names"]
                     ):
+                        plugin_found = True
                         plugin = product
                         break
+                if not plugin_found:
+                    raise PluginError(
+                        "There is no plugin that has " + name[1] + " included in it."
+                    )
                 plugin["interface"] = "products"
                 plugin["abspath"] = self._unvalidated_plugins[self.name][name[0]][
-                    "abspath"
-                ]
+                    name[1]
+                ]["abspath"]
                 plugin["relpath"] = self._unvalidated_plugins[self.name][name[0]][
-                    "relpath"
-                ]
+                    name[1]
+                ]["relpath"]
                 plugin["package"] = self._unvalidated_plugins[self.name][name[0]][
-                    "package"
-                ]
+                    name[1]
+                ]["package"]
             else:
                 plugin = yaml.safe_load(
                     open(self._unvalidated_plugins[self.name][name]["abspath"], "r")

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -332,6 +332,14 @@ class BaseYamlInterface(BaseInterface):
         """YAML plugin interface init method."""
         self._unvalidated_plugins = load_all_yaml_plugins()
 
+    def _create_registered_plugin_names(self, yaml_plugin):
+        """Create a plugin name for plugin registry.
+
+        Some interfaces need to override this (e.g. products) because they
+        need a more complex name for retrieval.
+        """
+        return [yaml_plugin["name"]]
+
     @classmethod
     def _plugin_yaml_to_obj(cls, name, yaml_plugin, obj_attrs={}):
         """Convert a yaml plugin to an object.

--- a/geoips/interfaces/yaml_based/products.py
+++ b/geoips/interfaces/yaml_based/products.py
@@ -95,6 +95,17 @@ class ProductsInterface(BaseYamlInterface):
     name = "products"
     validator = ProductsPluginValidator()
 
+    def _create_registered_plugin_names(self, yaml_plugin):
+        """Create a plugin name for plugin registry.
+
+        This name is a tuple containing source_name and name.
+        Overrides the same method from YamlPluginValidator.
+        """
+        names = []
+        for source_name in yaml_plugin["source_names"]:
+            names += [(source_name, yaml_plugin["name"])]
+        return names
+
     def get_plugin(self, source_name, name, product_spec_override=None):
         """Retrieve a Product plugin by source_name, name, and product_spec_override.
 

--- a/geoips/interfaces/yaml_based/products.py
+++ b/geoips/interfaces/yaml_based/products.py
@@ -137,15 +137,10 @@ class ProductsInterface(BaseYamlInterface):
 
     def get_plugins(self):
         """Retrieve a plugin by name."""
-        import yaml
-
         plugins = []
         for source_name in self._unvalidated_plugins[self.name].keys():
-            plugin = yaml.safe_load(
-                open(self._unvalidated_plugins[self.name][source_name]["abspath"], "r")
-            )
-            for subplg in plugin["spec"]["products"]:
-                plugins.append(self.get_plugin(source_name, subplg["name"]))
+            for subplg_name in self._unvalidated_plugins[self.name][source_name].keys():
+                plugins.append(self.get_plugin(source_name, subplg_name))
         return plugins
 
     def plugin_is_valid(self, source_name, name):


### PR DESCRIPTION
Updated create_plugin_registry to use the interface methods in order to properly account for the compound product names for product plugins (ie, source_name, product_name).

Note this caused circular imports if attempting to auto-run create_plugin_registry directly from geoips on runtime (since we are now using geoips functions within create_plugin_registry).  I got around this by no longer attempting to auto-run - just raise a PluginRegistryError if no registered plugins are found.  We could probably figure out how to auto-run it again at runtime if we wanted.