### PR TITLE
387 add text plugins to registries

### DIFF
--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -23,6 +23,7 @@ Version 1.11.7a0 (2023-10-11)
 * Create "output_checker_kwargs" commandline argument
 * Convert base.py: plugin_module_to_obj to class-based method
 * Fixed from scipy.ndimage.interpolation import zoom deprecation warning
+* Add text plugins to package registries
 
 Enhancements
 ============
@@ -175,6 +176,18 @@ require changes to the output products as well.
     modified: tests/scripts/abi.static.Visible.imagery_annotated.sh
     modified: tests/yaml_configs/abi_test.yaml
     modified: tests/yaml_configs/abi_test_low_memory.yaml
+
+Add text plugins to package registries
+--------------------------------------
+
+With the addition of create_plugin_registries, we can access module-based and yaml-based
+plugins via those registries. However, that PR did not include text-based plugins, which
+are currently found in the GeoIPS package, and others may be added in new packages in
+the future. We need to modify this process to include text based plugins.
+
+::
+
+    modified: geoips/geoips/create_plugin_registries.py
 
 Efficiency Improvements
 =======================

--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -10,7 +10,7 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.7a0 (2023-10-27)
+Version 1.11.7a0 (2023-10-26)
 *****************************
 
 * Added documentation for windows installation

--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -10,7 +10,7 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.7a0 (2023-10-11)
+Version 1.11.7a0 (2023-10-27)
 *****************************
 
 * Added documentation for windows installation

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -60,6 +60,7 @@ def create_plugin_registries(plugin_packages):
     for pkg in plugin_packages:
         plugins = {
             # "schemas": {},
+            "text_based": {},
             "yaml_based": {},
             "module_based": {},
         }
@@ -71,10 +72,12 @@ def create_plugin_registries(plugin_packages):
         pkg_dir = str(resources.files(package))
         yaml_files = pkg_plugin_path.rglob("*.yaml")
         python_files = pkg_plugin_path.rglob("*.py")
+        text_files = pkg_plugin_path.rglob("*.txt")
         # schema_yaml_path = resources.files(package) / "schema"
         # schema_yamls = schema_yaml_path.rglob("*.yaml")
         plugin_paths = {
             "yamls": yaml_files,
+            "text": text_files,
             # "schemas": schema_yamls,
             "pyfiles": python_files,
         }
@@ -108,14 +111,15 @@ def parse_plugin_paths(plugin_paths, package, package_dir, plugins):
     plugins: dict
         A dictionary object of all installed GeoIPS package plugins
     """
-    for interface_key in plugin_paths:
-        for filepath in plugin_paths[interface_key]:
+    for plugin_type in plugin_paths:
+        for filepath in plugin_paths[plugin_type]:
             filepath = str(filepath)
             # Path relative to the package directory
             relpath = os.path.relpath(filepath, start=package_dir)
-            if interface_key == "yamls":  # yaml based plugins
+            if plugin_type == "yamls":  # yaml based plugins
                 add_yaml_plugin(filepath, relpath, package, plugins["yaml_based"])
-            # elif interface_key == "schemas":  # schema based yamls
+            elif plugin_type == "text":
+            # elif plugin_type == "schemas":  # schema based yamls
             #     add_schema_plugin(
             #         filepath, abspath, relpath, package, plugins["schemas"]
             #     )
@@ -200,6 +204,10 @@ def add_yaml_plugin(filepath, relpath, package, plugins):
             "relpath": relpath,
             "package": package,
         }
+
+
+def add_text_plugin(package, relpath, plugins):
+    pass
 
 
 # def add_schema_plugin(filepath, abspath, relpath, package, plugins):

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -119,6 +119,7 @@ def parse_plugin_paths(plugin_paths, package, package_dir, plugins):
             if plugin_type == "yamls":  # yaml based plugins
                 add_yaml_plugin(filepath, relpath, package, plugins["yaml_based"])
             elif plugin_type == "text":
+                add_text_plugin(package, relpath, plugins["text_based"])
             # elif plugin_type == "schemas":  # schema based yamls
             #     add_schema_plugin(
             #         filepath, abspath, relpath, package, plugins["schemas"]
@@ -207,7 +208,21 @@ def add_yaml_plugin(filepath, relpath, package, plugins):
 
 
 def add_text_plugin(package, relpath, plugins):
-    pass
+    """Add all txt plugins into plugin registries.
+
+    Parameters
+    ----------
+    package: str
+        The current GeoIPS package being parsed
+    relpath: str
+        The relpath path to the module plugin
+    plugins: dict
+        A dictionary object of all installed GeoIPS package plugins
+    """
+    from os.path import basename, splitext
+
+    text_name = splitext(basename(relpath))[0]
+    plugins[text_name] = {"package": package, "relpath": relpath}
 
 
 # def add_schema_plugin(filepath, abspath, relpath, package, plugins):
@@ -255,9 +270,11 @@ def add_module_plugin(package, relpath, plugins):
     plugins: dict
         A dictionary object of all installed GeoIPS package plugins
     """
+    from os.path import basename, splitext
+
     if "__init__.py" in relpath:
         return
-    module_name = str(relpath).split("/")[-1][:-3]
+    module_name = splitext(basename(relpath))[0]
     abspath = resources.files(package) / relpath
     spec = util.spec_from_file_location(module_name, abspath)
     try:


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes #387

# Testing Instructions
You can run create_plugin_registries in the geoips package and review registered_plugins.yaml to ensure it's included in the yaml file. Asides from this, you can also run geoips/tests/integration_tests/full_test.sh and get an output of 0 to ensure this functionality performs correctly.

# Summary
With the addition of create_plugin_registries, we can access module-based and yaml-based
plugins via those registries. However, that PR did not include text-based plugins, which
are currently found in the GeoIPS package, and others may be added in new packages in
the future. We need to modify this process to include text based plugins.

    modified: geoips/geoips/create_plugin_registries.py

# Output
Text-based portion found in registered_plugins.yaml for the geoips package:

```
text_based:
  tpw_cimss:
    package: geoips
    relpath: plugins/txt/ascii_palettes/tpw_cimss.txt
  tpw_purple:
    package: geoips
    relpath: plugins/txt/ascii_palettes/tpw_purple.txt
  tpw_pwat:
    package: geoips
    relpath: plugins/txt/ascii_palettes/tpw_pwat.txt
```
