### PR TITLE
Add function to list all geoips interfaces of a certain interface 'family'

### DIFF
--- a/docs/source/releases/v1_12_0.rst
+++ b/docs/source/releases/v1_12_0.rst
@@ -34,6 +34,7 @@ Version 1.12.0 (2023-12-07)
   * Rename JPSS-01/02 platform name to noaa-20/21 in ATMS reader
   * Add hy-2d platform to scat knmi winds reader
   * Allow filtering products based on platform name
+  * Add function to list all available interfaces for each interface 'family'
 * Release updates
 
   * Update 'update_this_release_note'
@@ -129,6 +130,20 @@ reader. Maps internal attributes to GeoIPS platform and source name.
 ::
 
   geoips/plugins/modules/readers/scat_knmi_winds_netcdf.py
+
+Add function to list all available interfaces for each interface 'family'
+-------------------------------------------------------------------------
+
+*From GEOIPS#397: 2023-11-02, Add function to geoips.interfaces to list all interfaces of each type*
+
+Added a function which lists all interfaces found for each interface family. Rather than
+referring to a hard-coded list of interfaces that currently exist, we make assumptions
+on the directory structure of the geoips package and list the corresponding interface
+modules via the members of 'geoips.interfaces'.
+
+::
+
+    modified: geoips/interfaces/__init__.py
 
 Bug Fixes
 =========

--- a/geoips/interfaces/__init__.py
+++ b/geoips/interfaces/__init__.py
@@ -72,3 +72,26 @@ yaml_based_interfaces = [
     "sectors",
 ]
 __all__ = module_based_interfaces + yaml_based_interfaces
+
+def list_available_interfaces():
+    """Collect and return every available interface for each interface 'family'."""
+    import inspect
+    from geoips import interfaces
+
+    all_interfaces = {
+        "module_based": [],
+        "text_based": [],
+        "yaml_based": [],
+    }
+    for interface_type in ["module", "text", "yaml"]:
+        try:
+            available_interfaces = [
+                str(mod_info[0]) for mod_info in inspect.getmembers(
+                    getattr(interfaces, f"{interface_type}_based"), inspect.ismodule,
+                )
+            ]
+            all_interfaces[f"{interface_type}_based"] = available_interfaces
+        except AttributeError:
+            continue
+
+    return all_interfaces


### PR DESCRIPTION
# Reviewer Checklist

* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [ ] NO REQUIRED ***unit tests*** (explain why not required)
* [ ] NO REQUIRED ***integration tests*** (explain why not required)
* [ ] Required ***documentation*** added for new/modified functionality
* [ ] Required ***release notes*** added for new/modified functionality
* [ ] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#397

# Testing Instructions
Open up IPython, call ``from geoips import interfaces``, then run ``interfaces.list_available_interfaces`` to see all available interfaces within geoips at this moment.

# Summary
*From GEOIPS#397: 2023-11-02, Add function to geoips.interfaces to list all interfaces of each type*

Added a function which lists all interfaces found for each interface family. Rather than
referring to a hard-coded list of interfaces that currently exist, we make assumptions
on the directory structure of the geoips package and list the corresponding interface
modules via the members of 'geoips.interfaces'.

    - modified: geoips/interfaces/__init__.py

