### PR TITLE
JSON Plugin Registries Should Be Readable

### DIFF
--- a/docs/source/releases/v1_12_0.rst
+++ b/docs/source/releases/v1_12_0.rst
@@ -540,3 +540,16 @@ All geoips_db plugins now accessed through class-based geoips_db interface.
 ::
 
   modified: geoips/plugins/modules/procflows/single_source.py
+
+Make JSON Plugin Registries Readable
+
+*From GEOIPS#429: 2024-02-02, Plugin Registries Should Be Readable*
+
+Currently, the JSON output of the plugin registries is a hodge-podge full of text. We
+should refactor the way in which these plugin registries are outputted, so that they are
+in a human readable, interpretable format. To do so, we need to add the argument
+``indent=4`` to the ``json.dump`` call in ``write_plugin_registries``.
+
+::
+
+    modified: geoips/create_plugin_registries.py

--- a/docs/source/releases/v1_12_0.rst
+++ b/docs/source/releases/v1_12_0.rst
@@ -542,6 +542,7 @@ All geoips_db plugins now accessed through class-based geoips_db interface.
   modified: geoips/plugins/modules/procflows/single_source.py
 
 Make JSON Plugin Registries Readable
+------------------------------------
 
 *From GEOIPS#429: 2024-02-02, Plugin Registries Should Be Readable*
 

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -293,7 +293,7 @@ def write_registered_plugins(pkg_dir, plugins, save_type):
         reg_plug_abspath = osjoin(pkg_dir, "registered_plugins.json")
         with open(reg_plug_abspath, "w") as plugin_registry:
             LOG.interactive("Writing %s", reg_plug_abspath)
-            json.dump(plugins, plugin_registry)
+            json.dump(plugins, plugin_registry, indent=4)
 
 
 def create_plugin_registries(plugin_packages, save_type):


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#429

# Testing Instructions
Run ``create_plugin_registries`` and check the output of registered_plugins.json for each directory. Make sure it's readable, which it is on my end.

# Summary
*From GEOIPS#429: 2024-02-02, Plugin Registries Should Be Readable*

Currently, the JSON output of the plugin registries is a hodge-podge full of text. We
should refactor the way in which these plugin registries are outputted, so that they are
in a human readable, interpretable format. To do so, we need to add the argument
``indent=4`` to the ``json.dump`` call in ``write_plugin_registries``.

    - modified: geoips/create_plugin_registries.py
