### PR TITLE
448: Remove unnecessary requirement for imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ WORKDIR $GEOIPS_PACKAGES_DIR
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        imagemagick wget libsqlite3-0 libtiff5 libcurl4 libcurl3-gnutls libgeos-3.9.0 libgeos-dev \
+        wget libsqlite3-0 libtiff5 libcurl4 libcurl3-gnutls libgeos-3.9.0 libgeos-dev \
         python3 python3-pip git git-lfs \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -67,6 +67,24 @@ useful. Now, only useful AttributeErrors should be raised.
     modified: geoips/commandline/log_setup.py
     added: tests/unit_tests/commandline/log_setup.py
 
+Remove unnessesary checks for and mentions of imagemagick
+---------------------------------------------------------
+..
+  *From NRLMMD-GEOIPS/geoips#: YYYY-MM-DD, Removed unnecessary requirement for imagemagick*
+
+In v1.11.3a0 imagemagick functionality was replaced with other libraries. As such,
+imagemagick was no longder a dependancy. However, the installation docs, Dockerfile, 
+and setup scripts were not updated to reflect this change at the time. This fixes a 
+bug during installation where the user is forced to install imagemagick to pass tests
+despite it no longer being used. It also updates the documentation accordingly.
+
+::
+
+    modified: Dockerfile
+    modified: setup.sh
+    modified: setup/check_system_requirements.sh
+    modified: docs/source/starter/expert_installation.rst
+    modified: docs/source/starter/mac_installation.rst
 
 Refactor
 ========

--- a/docs/source/starter/expert_installation.rst
+++ b/docs/source/starter/expert_installation.rst
@@ -37,7 +37,6 @@ Required (**included in**
 
 * wget (Miniconda installation)
 * git >= 2.19.1 (git -C commands in complete installation)
-* imagemagick (required for test output comparisons)
 * openblas (required for scipy pip install)
 * Python >= 3.9 (3.9 required for entry points)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR

--- a/docs/source/starter/mac_installation.rst
+++ b/docs/source/starter/mac_installation.rst
@@ -96,11 +96,10 @@ but this command will ensure that for everyone.
 
 .. code:: bash
 
-    # imagemagick required for image comparisons
     # git required for pulling from git and for -C commands
     # pyhdf and pykdtree don't have wheels for mac and don't build cleanly
     #   best to install via conda
-    conda create -y -n geoips -c conda-forge python=3.10 openblas imagemagick git pyhdf pykdtree
+    conda create -y -n geoips -c conda-forge python=3.10 openblas git pyhdf pykdtree
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
 
 **Note:** You will need to run ``conda activate geoips`` every time you want to

--- a/setup.sh
+++ b/setup.sh
@@ -154,7 +154,6 @@ elif [[ "$1" == "create_geoips_conda_env" ]]; then
     # cartopy >= 0.22 no longer requires geos.
     # openblas/gcc required for recenter_tc / akima build.
     # gcc<10 required for seviri wavelet transform build
-    # imagemagick required for image comparisons
     # git required for -C commands
     # rclone required for NOAA AWS ABI/AHI downloads
     if [[ "$2" == "conda_defaults_channel" ]]; then

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -55,7 +55,6 @@ test_data_urls=(
 
 # Requirements to run base geoips tests
 if [[ "$1" == "geoips_base" ]]; then
-    . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh imagemagick
     . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh git
     . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh python
 fi
@@ -66,19 +65,6 @@ if [[ "$1" == "geoips_full" ]]; then
     . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh gcc
     . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh g++
     . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh openblas
-fi
-
-# Required for image comparisons
-if [[ "$1" == "imagemagick" ]]; then
-    compare --version >> $install_log 2>&1
-    retval=$?
-    if [[ "$retval" != "0" ]]; then
-        echo "WARNING: 'compare --version' failed, please install imagemagick before proceeding"
-        exit 1
-    else
-        echo "SUCCESS: 'imagemagick' appears to be installed successfully"
-        echo "    "`which compare`
-    fi
 fi
 
 # Required for using the -C option since some people apparently have git older than


### PR DESCRIPTION
# Summary
* Removed unnecessary checks and mentions of imagemagick from the codebase, including Dockerfile, setup.sh, and setup/check_system_requirements.sh. ✏️ 
* Updated documentation to reflect the removal of imagemagick requirement, specifically in docs/source/starter/expert_installation.rst and docs/source/starter/mac_installation.rst. 📝 
* Added entry to release notes highlighting the removal of imagemagick dependency for installation and setup. 🥇 

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality

* [x] NO REQUIRED ***unit tests*** (Modification does not introduce new functionality that requires new tests)
* [x] NO REQUIRED ***integration tests*** (No new integration with other components, see issue #449 issue with install integration testing)
* [x] NO REQUIRED ***updates to other repos*** (Changes are self-contained within this repo)

# Related Issue(s)
Fixes NRLMMD-GEOIPS/geoips#448

# Testing Instructions
* Follow the installation guide on a fresh machine without imagemagick installed to verify that the error no longer occurs.
* Ensure the install completes successfully and matches the expected output
* Run tests from install instructions:

``` bash
# Ensure geoips python environment enabled

# Download the test data
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_install.sh

# Create the plugin registries
create_plugin_registries

# Run integration tests
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_test.sh
```

# Output
* Followed revised installation instructions on a fresh Linux installation without imagemagick, confirmed successful installation and tests

![image](https://github.com/NRLMMD-GEOIPS/geoips/assets/9918036/cdf325c9-ce90-482b-8d8a-ac09a6e956b7)

```bash
Tue Mar 5 16:30:01 MST 2024  Running post, final results in /home/gwynu/geoips/outdirs/logs/20240305/20240305.232824_geoips_base/test_all_geoips_base.log

  

Package: geoips_base

Total run time: 97 seconds

Number data types run: 3

Number data types failed: 0

Tue Mar  5 23:30:01 UTC 2024
```

