### PR TITLE
Add make to expert installation dependencies

### DIFF
--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -19,6 +19,7 @@ Version 1.12.2a0 (2024-02-21)
   * Ensure that log.interactive works from plugins when imported independently.
   * Make add_log_level a callable class to fix AttributeErrors.
   * Modify algorithm_interpolator_colormapper to only provide input xarray
+  * Re-write Dockerfile to restore functionality (installing geoips/passing tests)
 
 
 * Refactor
@@ -85,6 +86,21 @@ despite it no longer being used. It also updates the documentation accordingly.
     modified: setup/check_system_requirements.sh
     modified: docs/source/starter/expert_installation.rst
     modified: docs/source/starter/mac_installation.rst
+
+
+Add make to expert installation dependencies
+--------------------------------------------
+..
+  *From NRLMMD-GEOIPS/geoips#454: 2024-03-15, Add make to expert installation dependencies*
+
+
+`pypublicdecompwt` is a dependency of geoips. `make` is a dependency of `pypublicdecompwt`. 
+To install `pypublicdecompwt` you need `make`, but it's not listed as a dependency on 
+the expert installation instructions. It was added.
+
+::
+
+    modified: docs/source/starter/expert_installation.rst
 
 Refactor
 ========

--- a/docs/source/starter/expert_installation.rst
+++ b/docs/source/starter/expert_installation.rst
@@ -38,6 +38,7 @@ Required (**included in**
 * wget (Miniconda installation)
 * git >= 2.19.1 (git -C commands in complete installation)
 * openblas (required for scipy pip install)
+* make (required for pypublicdecompwt)
 * Python >= 3.9 (3.9 required for entry points)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR
   (required for tests to pass)


### PR DESCRIPTION
# Description

`pypublicdecompwt` is a dependency of geoips. `make` is a dependency of `pypublicdecompwt`. To install `pypublicdecompwt` you need `make`, but it's not listed as a dependency on the expert installation instructions. It needs added. Found when updating the Dockerfile. Re: #449 and #452 

# Reviewer Checklist

* [x] Required ***documentation*** added (this is an addition to documentation)

This is an update to the documentation so:

* [x] NO REQUIRED ***existing tests*** (explain why not required)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
Fixes #453 
