### PR TITLE
468 log with emphasis wraps filenames poorly

### DIFF
--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -23,6 +23,7 @@ Version 1.12.2a0 (2024-02-21)
   * Remove inconsistent unit test test_log_interactive_non_geoips
   * Modify algorithm_interpolator_colormapper to only provide input xarray
   * Re-write Dockerfile to restore functionality (installing geoips/passing tests)
+  * Fix bad filename wrapping with log_with_emphasis
 * Refactor
 
   * Make JSON Plugin Registries Readable
@@ -149,6 +150,15 @@ the expert installation instructions. It was added.
 ::
 
     modified: docs/source/starter/expert_installation.rst
+
+Fix bad filename wrapping with log_with_emphasis
+------------------------------------------------
+
+*From issue GEOIPS#468*
+
+Fixes poor wrapping for long filenames when logged with emphasis. Now does not auto-wrap
+long filenames and prints as is. Additionally, any word logged over 74 chars will not be 
+broken.
 
 Refactor
 ========

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -14,7 +14,6 @@
 
 import logging
 import sys
-import re
 from textwrap import wrap
 
 

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -14,6 +14,7 @@
 
 import logging
 import sys
+import re
 from textwrap import wrap
 
 
@@ -22,7 +23,8 @@ def log_with_emphasis(print_func, *messages):
 
     Print one or more messages using the specified print function. The messages
     will be surrounded in asterisks. Long messages will be word wrapped to fit
-    within a maximum width of 74 characters.
+    within a maximum width of 74 characters, save for any individual words that
+    are over 74 characters which will not be broken.
 
     Parameters
     ----------
@@ -35,7 +37,7 @@ def log_with_emphasis(print_func, *messages):
     wrapped_messages = []
     for message in messages:
         # wrap the message to a specified length
-        wrapped_messages += wrap(message, width=74)
+        wrapped_messages += wrap(message, width=74, break_long_words=False)
     max_message_len = min(74, max([len(wmessage) for wmessage in wrapped_messages]))
     # adding +6 to max_message_len as we add '** ' and ' **' pre/post-fixes (6 chars)
     print_func("*" * (max_message_len + 6))

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -10,7 +10,6 @@ import pytest
 import os
 import random
 import string
-from textwrap import wrap
 from geoips import logging
 from glob import glob
 from geoips.commandline.log_setup import log_with_emphasis
@@ -23,7 +22,21 @@ def generate_random_string(length):
     return "".join(random.choices(string.ascii_letters, k=length))
 
 
-def insert_word_like_space_to_string(str):
+def insert_word_like_spaces_to_string(str):
+    """
+    Modify the input string by inserting spaces at random locations to make
+    "words" of length 2-8.
+
+    Parameters:
+    - str (str): The input string to be modified.
+
+    Returns:
+    - str: The modified string with spaces inserted at random locations.
+
+    Example:
+    >>> insert_word_like_spaces_to_string("HelloWorld")
+    'He lloW or ld'
+    """
     loc = random.randint(2, 3)
     while loc < len(str):
         str = str[:loc] + " " + str[loc + 1 :]
@@ -35,7 +48,9 @@ def generate_random_messages():
     """Generate a random amount of messages with random length."""
     num_messages = 20
     messages = [
-        insert_word_like_space_to_string(generate_random_string(random.randint(5, 110)))
+        insert_word_like_spaces_to_string(
+            generate_random_string(random.randint(5, 110))
+        )
         for _ in range(num_messages)
     ]
     return messages
@@ -45,7 +60,6 @@ def generate_random_messages():
 def test_log_with_emphasis(message, caplog):
     """Pytest function for testing the output of 'log_with_emphasis'."""
     caplog.set_level(logging.INFO)
-    max_message_len = min(74, len(message))
     log_with_emphasis(LOG.info, message)
     assert (  # top/bottom of box is formmated correctly
         "*" * 9  # three for boarders, and min of 5 for string length

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -103,20 +103,19 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     """
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
-    assert (  # top/bottom of box is formmated correctly
-        "*" * 9 in caplog.text  # three for borders, and min of 5 for string length
+    assert (  # top of box is formmated correctly
+        "*" * 9
+        in caplog.messages[0]  # three for borders, and min of 5 for string length
     )
     assert message[0:5] in caplog.text  # test for first section of text
     assert "\n" in caplog.text  # assert log output is multi-lined
 
-    assert "** " in caplog.text  # test for left side of box
-    assert " **" in caplog.text  # test for right side of box
+    assert caplog.messages[1].startswith("** ")  # test for left side of box
+    assert caplog.messages[1].endswith(" **")  # test for left side of box
 
     if test_all_lines_same_length:
         assert (
-            len(set(map(len, caplog.text.split("\n"))))
-            == 3  # why 3 ???????
-            # 2 makes sense . maybe a blank line . but why 3? 2 are > len()== 0
+            len(set(map(len, caplog.messages[:-1]))) == 1  # last line is blank
         )  # all logged lines are the same length
 
 
@@ -124,7 +123,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
 def test_log_with_emphasis_long_word(message, caplog):
     """Pytest function for testing the output of 'log_with_emphasis'.
 
-    The expected output of log_with_emphasis looks like this:
+    The expected output of log_with_emphasis usually looks like this:
 
     ***************
     ** hello     **
@@ -145,11 +144,10 @@ def test_log_with_emphasis_long_word(message, caplog):
     """
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
-    log_lines = caplog.text.split("\n")[1 : len(caplog.text) - 1]
+    log_lines = caplog.messages[1 : len(caplog.text) - 1]
 
-    assert not (
-        len(set(map(len, log_lines))) == 1
-    )  # all logged lines are NOT the same length (because we didn't wrap)
+    # all logged lines are NOT the same length (because we didn't wrap)
+    assert not (len(set(map(len, log_lines[:-1]))) == 1)
 
     # find at least one line that is longer than 80 chars (aka not wrapped)
     assert any(map(lambda line: len(line) > 80, log_lines))

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -64,7 +64,7 @@ def test_log_with_emphasis(message, caplog):
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
     assert (  # top/bottom of box is formmated correctly
-        "*" * 9  # three for boarders, and min of 5 for string length
+        "*" * 9  # three for borders, and min of 5 for string length
     )
     assert "** " in caplog.text
     assert " **" in caplog.text

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -23,10 +23,22 @@ def generate_random_string(length):
     return "".join(random.choices(string.ascii_letters, k=length))
 
 
+def insert_word_like_space_to_string(str):
+    loc = random.randint(2, 3)
+    while loc < len(str):
+        str = str[:loc] + " " + str[loc + 1 :]
+        loc += random.randint(2, 8)
+    return str
+
+
 def generate_random_messages():
     """Generate a random amount of messages with random length."""
-    num_messages = random.randint(1, 50)
-    return [generate_random_string(random.randint(5, 110)) for _ in range(num_messages)]
+    num_messages = 20
+    messages = [
+        insert_word_like_space_to_string(generate_random_string(random.randint(5, 110)))
+        for _ in range(num_messages)
+    ]
+    return messages
 
 
 @pytest.mark.parametrize("message", generate_random_messages())
@@ -34,12 +46,13 @@ def test_log_with_emphasis(message, caplog):
     """Pytest function for testing the output of 'log_with_emphasis'."""
     caplog.set_level(logging.INFO)
     max_message_len = min(74, len(message))
-    assert max_message_len <= 80, "Max emphasis in '*' is longer than 80 chars."
     log_with_emphasis(LOG.info, message)
-    assert "*" * (max_message_len + 6) in caplog.text
-    for wmessage in wrap(message, width=74):
-        assert "** " + wmessage in caplog.text
-    assert "*" * (max_message_len + 6) in caplog.text
+    assert (  # top/bottom of box is formmated correctly
+        "*" * 9  # three for boarders, and min of 5 for string length
+    )
+    assert "** " in caplog.text
+    assert " **" in caplog.text
+    assert message[0:5] in caplog.text
     assert "\n" in caplog.text
 
 

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -22,7 +22,7 @@ def generate_random_string(length):
     return "".join(random.choices(string.ascii_letters, k=length))
 
 
-def insert_word_like_spaces_to_string(str):
+def insert_word_like_spaces_to_string(string):
     """Modify the input string by inserting spaces to make "words" of length 2-8.
 
     Parameters
@@ -40,10 +40,10 @@ def insert_word_like_spaces_to_string(str):
     'He lloW or ld'
     """
     loc = random.randint(2, 3)
-    while loc < len(str):
-        str = str[:loc] + " " + str[loc + 1 :]
+    while loc < len(string):
+        string = string[:loc] + " " + string[loc + 1 :]
         loc += random.randint(2, 8)
-    return str
+    return string
 
 
 def generate_random_messages():

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -101,7 +101,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     ** howdy     **
     ** what's up **
     ***************
-    """
+    """  # noqa RST212
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
 

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -102,6 +102,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     ** what's up **
     ***************
     """  # noqa RST212
+    # ignoring check because flake8 flags the codeblocks as underlines
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
 

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -96,7 +96,6 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     """Pytest function for testing the output of 'log_with_emphasis'.
 
     The expected output of log_with_emphasis looks similar to this:
-
     ***************
     ** hello     **
     ** howdy     **
@@ -130,17 +129,14 @@ def test_log_with_emphasis_long_word(message, caplog):
     """Pytest function for testing the output of 'log_with_emphasis'.
 
     The expected output of log_with_emphasis usually looks like this:
-
     ***************
     ** hello     **
     ** howdy     **
     ** what's up **
     ***************
-
     However, by default we don't wrap long words. If a "long word" (string of chars
     surrounded by spaces of length >74) is present, the expected output of
     log_with_emphasis looks like this:
-
     ***********************************************************************************
     ** hello                                                                         **
     ** howdy                                                                         **

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -25,11 +25,15 @@ def generate_random_string(length):
 def insert_word_like_spaces_to_string(str):
     """Modify the input string by inserting spaces to make "words" of length 2-8.
 
-    Parameters:
-    - str (str): The input string to be modified.
+    Parameters
+    ----------
+    str (str):
+        The input string to be modified.
 
-    Returns:
-    - str: The modified string with spaces inserted at random locations.
+    Returns
+    -------
+    str (str):
+        The modified string with spaces inserted at random locations.
 
     Example:
     >>> insert_word_like_spaces_to_string("HelloWorld")

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -143,7 +143,9 @@ def test_log_with_emphasis_long_word(message, caplog):
     ** what's up                                                                     **
     ** this is a very long string that we are not going to match at the top or bottom because it really is too long ok I think this is long enough **
     ***********************************************************************************
-    """  # noqa: E501
+    """  # noqa: E501,RST212
+    # ignoring line length check, and the section underline check because
+    # flake8 flags the codeblocks as underlines
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
     log_lines = caplog.messages[1 : len(caplog.text) - 1]

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -23,9 +23,7 @@ def generate_random_string(length):
 
 
 def insert_word_like_spaces_to_string(str):
-    """
-    Modify the input string by inserting spaces at random locations to make
-    "words" of length 2-8.
+    """Modify the input string by inserting spaces to make "words" of length 2-8.
 
     Parameters:
     - str (str): The input string to be modified.

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -35,7 +35,8 @@ def insert_word_like_spaces_to_string(string):
     str (str):
         The modified string with spaces inserted at random locations.
 
-    Example:
+    Example
+    -------
     >>> insert_word_like_spaces_to_string("HelloWorld")
     'He lloW or ld'
     """
@@ -47,7 +48,7 @@ def insert_word_like_spaces_to_string(string):
 
 
 def insert_random_string_randomly(s, length):
-    """Inserts a randomly generated string of a given length at a random position
+    """Insert a randomly generated string of a given length at a random position.
 
     Parameters
     ----------
@@ -62,7 +63,7 @@ def insert_random_string_randomly(s, length):
         The modified string with a randomly generated string of length `length`
         inserted at a random position.
 
-    Examples
+    Example
     --------
     >>> insert_random_string_randomly("hello", 3)
     'helXyZlo'
@@ -81,9 +82,10 @@ def generate_random_messages(add_long_word=False):
         for _ in range(num_messages)
     ]
     if add_long_word:
-        f = lambda s: insert_random_string_randomly(
-            s, 88
-        )  # insert string 88 chars long
+
+        def f(s):
+            insert_random_string_randomly(s, 88)  # insert string 88 chars long
+
         return map(f, messages)
     else:
         return messages
@@ -145,7 +147,7 @@ def test_log_with_emphasis_long_word(message, caplog):
     ** what's up                                                                     **
     ** this is a very long string that we are not going to match at the top or bottom because it really is too long ok I think this is long enough **
     ***********************************************************************************
-    """
+    """  # noqa: E501
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
     log_lines = caplog.messages[1 : len(caplog.text) - 1]

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -103,7 +103,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     """
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)
-    
+
     assert (  # top of box is formmated correctly
         "*" * 9
         in caplog.messages[0]  # three for borders, and min of 5 for string length
@@ -118,7 +118,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
         assert (
             len(set(map(len, caplog.messages[:-1]))) == 1  # last line is blank
         )  # all logged lines are the same length
-        
+
     with pytest.raises(ValueError):
         log_with_emphasis(LOG.info, "")
 
@@ -155,7 +155,6 @@ def test_log_with_emphasis_long_word(message, caplog):
 
     # find at least one line that is longer than 80 chars (aka not wrapped)
     assert any(map(lambda line: len(line) > 80, log_lines))
-    
 
 
 def test_log_interactive_geoips(caplog):

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -101,7 +101,7 @@ def test_log_with_emphasis(message, caplog, test_all_lines_same_length=True):
     ** howdy     **
     ** what's up **
     ***************
-    """  # noqa RST212
+    """  # noqa: RST212
     # ignoring check because flake8 flags the codeblocks as underlines
     caplog.set_level(logging.INFO)
     log_with_emphasis(LOG.info, message)


### PR DESCRIPTION
* [x] NO REQUIRED **existing tests** (explain why not required)
* [x] Required **unit tests** added and pass for new/modified functionality
* [x] NO REQUIRED **integration tests** (explain why not required)
* [x] NO REQUIRED **documentation** (explain why not required)
* [x] Required **release notes** added for new/modified functionality
* [x] NO REQUIRED **updates to other repos** (explain why not required)
# Related Issues
fixes NRLMMD-GEOIPS/geoips#468

# Testing Instructions
* No exhaustive testing required beyond existing and unit tests, as functionality hasn't changed that would impact these

# Summary
* Fixed an issue with log_with_emphasis() function that poorly wrapped file paths over 74 characters in length.
* Used existing wrap() function's functionality for breaking long filenames.
* Added/updated unit tests
* Updated release notes to reflect the fix.