### PR TITLE
Implementing Standards for Placing Imports

### DIFF
--- a/docs/dev/coding_standards.rst
+++ b/docs/dev/coding_standards.rst
@@ -1,26 +1,40 @@
-===============================
+=================================
 🖍️ Coding Standards Reference Doc
-===============================
+=================================
 
-*"Although that way may not be obvious at first unless you're Dutch."* - the Zen of Python
+*"Although that way may not be obvious at first unless you're Dutch."*
+- the Zen of Python
 
+
+.. contents::
 
 Summary
 =======
 
-The goal is consistency. In style, we're in the right even if we're all wrong together. GeoIPS code is meant to be re-used by many, and we expect that the code will be read much more than it is written. The goal of this document is to help us spend less time on conventions and more time making GeoIPS better.
+The goal is consistency. In style, we're in the right even if we're all wrong together.
+GeoIPS code is meant to be re-used by many, and we expect that the code will be read
+much more than it is written. The goal of this document is to help us spend less time
+on conventions and more time making GeoIPS better.
 
-We use - in order of supremacy - a few Internal Standards, followed by the numpy docstring standards and the python style guide laid out in PEP 8.
+We use - in order of supremacy - a few Internal Standards, followed by the numpy
+docstring standards and the python style guide laid out in PEP 8.
 
-This document will detail internal standard conventions and include some of the external standards for easy reference. For external standards, the primary source is always right in the case of a conflict with this document.
-
-.. contents::
+This document will detail internal standard conventions and include some of the external
+standards for easy reference. For external standards, the primary source is always
+right in the case of a conflict with this document.
 
 External Style Standards
 ------------------------
 
 Internal Style Standards
 -------------------------
+
+Imports Shouldn't Be Buried Without a Reason
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If an import needs to be buried for efficiency reasons or namespace conflicts,
+this should be documented in the docstrings.
+
 
 Linting/Formatting
 -------------------

--- a/docs/dev/coding_standards.rst
+++ b/docs/dev/coding_standards.rst
@@ -39,11 +39,51 @@ this should be documented in the docstrings.
 Linting/Formatting
 -------------------
 
+The GeoIPS project makes use of several linting tools to help maintain code quality. The
+full suite of linters can be installed by installing the "test" dependencies via pip.
+For example, if you installed GeoIPS using `pip install .` the linters can be installed
+using `pip install .[test]` the following tools to ensure code quality:
+
 Black
 ~~~~~
+We use the `Black formatter <https://github.com/psf/black>`_ with its default
+settings. As stated in the Black documentation, it is an uncompromizing code
+formatter, but it has resulted in significantly more readable code. Applying it
+automatically while writing code has also reduced development time since
+developers don't need to think about formatting.
 
 Flake8
 ~~~~~~
+We use the `Flake8 linter <https://flake8.pycqa.org/en/latest/>`_ to enforce
+PEP8 code standards. We also add several plugins to Flake8 to enforce additional
+standards for GeoIPS code. Plugins used include:
+
+- `flake8-docstrings <https://github.com/pycqa/flake8-docstrings>`_ is used to enforce
+  the numpy docstring standard.
+- `flake8-rst-docstrings <https://github.com/peterjc/flake8-rst-docstrings>`_ is
+  used to ensure that docstrings are valid reStructuredText.
+- `flake8-rst <https://github.com/flake8-docs/flake8-rst>` runs flake8 on code
+  snippets in reStructuredText files to ensure proper formatting in
+  documentation.
+  
+We modify the default behavior of flake8 slightly to make it work well with Black,
+ignore specific errors, and configure plugins. GeoIPS specific settings for
+flake8 include the following:
+
+```toml
+[flake8]
+max-line-length=88
+count=True
+ignore=E203,W503,E712
+extend-exclude=_version.py,lib,*_docs,geoips_dev_utils
+docstring-convention=numpy
+rst-roles=class,func,ref
+rst-directives=envvar,exception
+rst-substitutions=version
+statistics=True
+per-file-ignores =
+  /*/interfaces/__init__.py:F401
+```
 
 Github Conventions
 ------------------

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -18,6 +18,7 @@ Version 1.12.2a0 (2024-02-21)
   * Added log with emphasis function
   * Introduced a documentation for coding standards within the build/dev directory.
   * Introduced documentation for coding standards for module imports.
+  * Added documentation for current linters and configuration.
 * Bug fixes
 
   * Ensure that log.interactive works from plugins when imported independently.
@@ -71,6 +72,16 @@ Introduced documentation for coding standards for module imports.
 Throughout GeoIPS, we have inconsistent module imports. These new standards (added to
 our documentation) will help us be more intentional in how we import modules going
 forward.
+
+::
+    modified: docs/dev/coding_standards.rst
+
+Added documentation for current linters and configuration.
+----------------------------------------------------------
+
+GeoIPS makes use of a number of different linters and linter plugins. This
+documentation lists and briefly describes each linter and gives configuration
+information.
 
 ::
     modified: docs/dev/coding_standards.rst

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -17,6 +17,7 @@ Version 1.12.2a0 (2024-02-21)
 
   * Added log with emphasis function
   * Introduced a documentation for coding standards within the build/dev directory.
+  * Introduced documentation for coding standards for module imports.
 * Bug fixes
 
   * Ensure that log.interactive works from plugins when imported independently.
@@ -26,7 +27,7 @@ Version 1.12.2a0 (2024-02-21)
   * Re-write Dockerfile to restore functionality (installing geoips/passing tests)
   * Fix bad filename wrapping with log_with_emphasis
   * Fix log_with_emphasis to deal with empty strings gracefully
-  
+
 * Refactor
 
   * Make JSON Plugin Registries Readable
@@ -63,6 +64,16 @@ is 'log_with_emphasis(LOG.<log_type>, message)', and it will do the rest for you
     modified: geoips/geoips/plugins/modules/output_checkers/text.py
     modified: geoips/geoips/plugins/modules/procflows/single_source.py
     added: geoips/tests/unit_tests/commandline/log_setup.py
+
+Introduced documentation for coding standards for module imports.
+-----------------------------------------------------------------
+
+Throughout GeoIPS, we have inconsistent module imports. These new standards (added to
+our documentation) will help us be more intentional in how we import modules going
+forward.
+
+::
+    modified: docs/dev/coding_standards.rst
 
 Bug Fixes
 =========
@@ -111,7 +122,11 @@ Update Dockerfile to install rasterio properly
 ..
     *From GEOIPS#NN: 2024-03-XX, TODO*
 
-Previously puilding the provided Dockerfile did not build a working image. It failed on the last step (installation of geoips) and hangs on installing rasterio. This fix updates the Dockerfile to install rasterio dependancies (``gdal-bin`` and ``libgdal-dev``) and additionally installs software-properties-common for access to add-apt-repository to aid in gdal installation.
+Previously building the provided Dockerfile did not build a working image.
+It failed on the last step (installation of geoips) and hangs on installing rasterio.
+This fix updates the Dockerfile to install rasterio dependancies (``gdal-bin`` and
+``libgdal-dev``) and additionally installs software-properties-common for access to
+add-apt-repository to aid in gdal installation.
 
 ::
     modified: Dockerfile
@@ -169,7 +184,7 @@ Fix bad filename wrapping with log_with_emphasis
 *From issue GEOIPS#468*
 
 Fixes poor wrapping for long filenames when logged with emphasis. Now does not auto-wrap
-long filenames and prints as is. Additionally, any word logged over 74 chars will not be 
+long filenames and prints as is. Additionally, any word logged over 74 chars will not be
 broken.
 
 Update log_with_emphasis to deal with empty strings
@@ -185,7 +200,8 @@ Refactor
 Modify create_plugin_registries to use argparse
 -----------------------------------------------
 
-*From issue GEOIPS#416: 2023-12-21, Replace create_plugin_registries 'sys.argv' calls with 'argparse' library'*
+*From issue GEOIPS#416: 2023-12-21,
+Replace create_plugin_registries 'sys.argv' calls with 'argparse' library'*
 
 Currently create_plugin_registries.py uses sys.argv calls to generate its arguments
 rather than argparse. This doesn't follow GeoIPS conventions nor that of the CLI that


### PR DESCRIPTION
* ❌ NO REQUIRED ***existing tests*** (This PR is a documentation update)
* ✅ Required ***documentation*** added for new/modified functionality
* ✅ Required ***release notes*** added for new/modified functionality
* ❌ NO REQUIRED ***unit tests*** (This PR involves a documentation update, not code functionality that requires unit testing)
* ❌ NO REQUIRED ***integration tests*** (Documentation updates do not require integration testing)
* ❌ NO REQUIRED ***updates to other repos*** (This is a standalone documentation enhancement)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#488

# Summary
* Updated the Python coding standards to require documentation of buried import statements. This ensures that any import not at the top of a file is accompanied by a justification in the docstring so that burying imports comes with intention.

We can use flake8 to help enforce: https://www.flake8rules.com/rules/E402.html