### PR TITLE
37 geoips only install

### DIFF
--- a/geoips/commandline/geoips_command.py
+++ b/geoips/commandline/geoips_command.py
@@ -294,9 +294,18 @@ class GeoipsExecutableCommand(GeoipsCommand):
               ("module_based", "yaml_based", "text_based")
         """
         if package_name == "all":
-            interface_registry = interface.plugin_registry.registered_plugins[
-                interface.interface_type
-            ][interface.name]
+            # If there are no plugins of current interface,
+            # just return None, do not fail catastrophically.
+            # This will fail on "sector_adjusters" interface
+            # during "geoips list plugins" if only geoips
+            # repo is installed (since there are no "sector_adjuster"
+            # plugins in the geoips repo)
+            if interface.name in interface.plugin_registry.registered_plugins[interface.interface_type]:
+                interface_registry = interface.plugin_registry.registered_plugins[
+                    interface.interface_type
+                ][interface.name]
+            else:
+                return None
         else:
             interface_registry = json.load(
                 open(resources.files(package_name) / "registered_plugins.json", "r")

--- a/tests/unit_tests/commandline/test_geoips_get_plugin.py
+++ b/tests/unit_tests/commandline/test_geoips_get_plugin.py
@@ -24,9 +24,16 @@ class TestGeoipsGetPlugin(BaseCliTest):
         if not hasattr(self, "_cmd_list"):
             self._cmd_list = []
             base_args = self._get_plugin_args
-            # validate all plugins from package geoips_clavrx
+            # validate all plugins from all packages
             for interface_name in interfaces.__all__:
                 interface = getattr(interfaces, interface_name)
+                # If there happen to be no plugins for a given
+                # interface, just skip, do not fail catastrophically.
+                # This allows defining interfaces in the geoips repo,
+                # even if there are no plugins of that interface
+                # directly in the main geoips repo.
+                if interface_name not in interface.plugin_registry.registered_plugins[interface.interface_type]:
+                    continue
                 interface_registry = interface.plugin_registry.registered_plugins[
                     interface.interface_type
                 ][interface_name]

--- a/tests/unit_tests/commandline/test_geoips_validate.py
+++ b/tests/unit_tests/commandline/test_geoips_validate.py
@@ -22,18 +22,19 @@ class TestGeoipsValidate(BaseCliTest):
         if not hasattr(self, "_cmd_list"):
             self._cmd_list = []
             base_args = self._validate_args
-            pkg_path = str(resources.files("geoips_clavrx") / "plugins")
-            # validate all plugins from package geoips_clavrx
-            for plugin_type in ["modules", "yaml"]:
-                if plugin_type == "modules":
-                    plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.py"
-                else:
-                    plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.yaml"
-                plugin_paths = sorted(glob(plugin_path_str, recursive=True))
-                for plugin_path in plugin_paths:
-                    self._cmd_list.append(base_args + [plugin_path])
-            # Add argument list to retrieve help message
-            self._cmd_list.append(base_args + ["-h"])
+            for plugin_package in self.plugin_packages:
+                pkg_path = str(resources.files(plugin_package) / "plugins")
+                # validate all plugins from package geoips_clavrx
+                for plugin_type in ["modules", "yaml"]:
+                    if plugin_type == "modules":
+                        plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.py"
+                    else:
+                        plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.yaml"
+                    plugin_paths = sorted(glob(plugin_path_str, recursive=True))
+                    for plugin_path in plugin_paths:
+                        self._cmd_list.append(base_args + [plugin_path])
+                # Add argument list to retrieve help message
+                self._cmd_list.append(base_args + ["-h"])
         return self._cmd_list
 
     def check_error(self, args, error):


### PR DESCRIPTION
Please see comments on "Files changed" tab.  A couple spots where if you only have geoips installed, things break on "sector_adjusters" (since no sector_adjuster plugins in geoips repo), or where there was a hard coded "geoips_clavrx" in the tests.

Note these updates were initially started when attempting to run "geoips test unit-test commandline" - we have since decided that unit test is intended to test the FULL geoips install, including all available plugin packages (since that is the only way to thoroughly test the CLI), but some of these changes I think are still applicable even if we are assuming the CLI unit test is exhaustive.

If this looks ok, we can just resolve the conversations here and merge directly to the 37-create-useful-geoips-CLI branch, before merging that one.