### PR TITLE
fixed bugs introduced by finish log with emphasis pr

### DIFF
--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -303,10 +303,11 @@ GeoIPS devs. This PR fixes those bugs and ensues that both the unit tests and ac
 scripts pass without failure. This fix changes a bug in test_log_setup.py where
 ``generate_random_messages(add_long_word=True)`` would return a ``map`` object rather
 than an iterable list of strings. ``map`` objects have no length attribute and caused
-failures within ``geoips/commandline/log_setup:log_with_emphasis``. We also added a new
-check in ``log_with_emphasis`` that raises a ``TypeError`` if one or more of the items
-in the unpacked list of ``*messages`` doesn't have a length attribute. Ie. None, map,
-etc.
+failures within ``geoips/commandline/log_setup:log_with_emphasis``. We also added a type
+cast in ``log_with_emphasis`` that prevents non-string objects from raising an error due
+to a ``len(object)`` call, where the object had no attribute length. Developers should
+think about what is sent to ``log_with_emphasis`` if they want to print something that
+is not a string.
 
 ::
 

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -30,17 +30,15 @@ Version 1.12.2a0 (2024-02-21)
   * Re-write Dockerfile to restore functionality (installing geoips/passing tests)
   * Fix bad filename wrapping with log_with_emphasis
   * Fix log_with_emphasis to deal with empty strings gracefully
-  * Fix log_with_emphasis to deal with empty strings gracefully 
+  * Fixed broken unit test in test_log_setup.py
 * Refactor
   * Make JSON Plugin Registries Readable
   * Modify create_plugin_registries to use argparse instead of sys.argv
 * Testing Updates
-
   * Move pytest validation from plugin_registry.py to unit tests.
 * Documentation
-
   * Add documentation about optional pdflatex dependency
-  
+
 Testing Updates
 ===============
 
@@ -62,7 +60,7 @@ will have to manually install pytest to validate from now on.
 
 Unit-Test validation of the plugin registry is performed to ensure it's in the correct
 state. This was initially automatically done when it was created, but since it invoked
-pytest and that's only a required dependency in the ``test`` extra, we have decided 
+pytest and that's only a required dependency in the ``test`` extra, we have decided
 to move this to a unit-test module so that end-users don't need to install pytest.
 All in all, the user doesn't really need to validate their own registry. It
 should not be created if an error occurs (eg. duplicate plugin names under the same
@@ -294,6 +292,26 @@ Update log_with_emphasis to deal with empty strings
 Previously, when calling log_with_emphasis(log, "test", "") an error is thrown.
 This is a problem if you're logging out a message that ends with "" for any reason,
 and log_with_emphasis has now been updated to gracefully deal with this case.
+
+Fixed broken unit test in test_log_setup.py
+-------------------------------------------
+
+*Stems from GEOIPS#464, 2024-04-15: Finish log with emphasis function*
+
+*Finish log with emphasis PR (#464)* introduced a couple of bugs that weren't caught by
+GeoIPS devs. This PR fixes those bugs and ensues that both the unit tests and accociated
+scripts pass without failure. This fix changes a bug in test_log_setup.py where
+``generate_random_messages(add_long_word=True)`` would return a ``map`` object rather
+than an iterable list of strings. ``map`` objects have no length attribute and caused
+failures within ``geoips/commandline/log_setup:log_with_emphasis``. We also added a new
+check in ``log_with_emphasis`` that raises a ``TypeError`` if one or more of the items
+in the unpacked list of ``*messages`` doesn't have a length attribute. Ie. None, map,
+etc.
+
+::
+
+    modified: geoips/commandline/log_setup.py
+    modified: tests/unit_tests/commandline/test_log_setup.py
 
 Refactor
 ========

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -35,7 +35,7 @@ def log_with_emphasis(print_func, *messages):
     """
     wrapped_messages = []
     # Cast as a string just in case something other than a string exists in messages
-    messages = filter(lambda s: len(str(s)), messages)
+    messages = filter(lambda s: len(str(s)) > 0, messages)
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -34,8 +34,12 @@ def log_with_emphasis(print_func, *messages):
         The messages to be logged with emphasis
     """
     wrapped_messages = []
-    # Cast as a string just in case something other than a string exists in messages
-    messages = filter(lambda s: len(s) > 0 or len(str(s)) > 0, messages)
+    # Handle potential typeerror by casting as a string
+    try:
+        messages = filter(lambda s: len(s) > 0, messages)
+    except TypeError:
+        messages = filter(lambda s: len(str(s)) > 0, messages)
+
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -34,7 +34,12 @@ def log_with_emphasis(print_func, *messages):
         The messages to be logged with emphasis
     """
     wrapped_messages = []
-    messages = filter(lambda s: len(s) > 0, messages)
+    try:
+        messages = filter(lambda s: len(s) > 0, messages)
+    except TypeError:
+        raise TypeError(
+            f"1+ words sent to log_with_emphasis doesn't have a length attr. {messages}"
+        )
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -38,7 +38,7 @@ def log_with_emphasis(print_func, *messages):
         messages = filter(lambda s: len(s) > 0, messages)
     except TypeError:
         raise TypeError(
-            f"1+ words sent to log_with_emphasis doesn't have a length attr. {messages}"
+            f"1+ words sent to log_with_emphasis don't have a length attr. {messages}"
         )
     for message in messages:
         # wrap the message to a specified length

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -34,11 +34,10 @@ def log_with_emphasis(print_func, *messages):
         The messages to be logged with emphasis
     """
     wrapped_messages = []
-    # Handle potential typeerror by casting as a string
-    try:
-        messages = filter(lambda s: len(s) > 0, messages)
-    except TypeError:
-        messages = filter(lambda s: len(str(s)) > 0, messages)
+    # Even though only strings should be passed here, we are going to allow any type of
+    # object to be passed for the time being. Best not to overthink the situation and
+    # just cast for the time being.
+    messages = filter(lambda s: len(str(s)) > 0, messages)
 
     for message in messages:
         # wrap the message to a specified length

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -34,12 +34,8 @@ def log_with_emphasis(print_func, *messages):
         The messages to be logged with emphasis
     """
     wrapped_messages = []
-    try:
-        messages = filter(lambda s: len(s) > 0, messages)
-    except TypeError:
-        raise TypeError(
-            f"1+ words sent to log_with_emphasis don't have a length attr. {messages}"
-        )
+    # Cast as a string just in case something other than a string exists in messages
+    messages = filter(lambda s: len(str(s)), messages)
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -35,7 +35,7 @@ def log_with_emphasis(print_func, *messages):
     """
     wrapped_messages = []
     # Cast as a string just in case something other than a string exists in messages
-    messages = filter(lambda s: len(str(s)) > 0, messages)
+    messages = filter(lambda s: len(s)>0 or len(str(s)) > 0, messages)
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/geoips/commandline/log_setup.py
+++ b/geoips/commandline/log_setup.py
@@ -35,7 +35,7 @@ def log_with_emphasis(print_func, *messages):
     """
     wrapped_messages = []
     # Cast as a string just in case something other than a string exists in messages
-    messages = filter(lambda s: len(s)>0 or len(str(s)) > 0, messages)
+    messages = filter(lambda s: len(s) > 0 or len(str(s)) > 0, messages)
     for message in messages:
         # wrap the message to a specified length
         wrapped_messages += wrap(message, width=74, break_long_words=False)

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -151,7 +151,6 @@ def test_log_with_emphasis_long_word(message, caplog):
     log_with_emphasis(LOG.info, message)
     log_lines = caplog.messages[1 : len(caplog.text) - 1]
 
-    print(f"LOG LINES = {log_lines}")
     # all logged lines are NOT the same length (because we didn't wrap)
     assert not (len(set(map(len, log_lines[:-1]))) == 1)
 

--- a/tests/unit_tests/commandline/test_log_setup.py
+++ b/tests/unit_tests/commandline/test_log_setup.py
@@ -84,9 +84,9 @@ def generate_random_messages(add_long_word=False):
     if add_long_word:
 
         def f(s):
-            insert_random_string_randomly(s, 88)  # insert string 88 chars long
+            return insert_random_string_randomly(s, 88)  # insert string 88 chars long
 
-        return map(f, messages)
+        return list(map(f, messages))
     else:
         return messages
 
@@ -151,6 +151,7 @@ def test_log_with_emphasis_long_word(message, caplog):
     log_with_emphasis(LOG.info, message)
     log_lines = caplog.messages[1 : len(caplog.text) - 1]
 
+    print(f"LOG LINES = {log_lines}")
     # all logged lines are NOT the same length (because we didn't wrap)
     assert not (len(set(map(len, log_lines[:-1]))) == 1)
 


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** added and pass for new/modified functionality
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] Required ***updates to other repos*** complete (see NRLMMD-GEOIPS/recenter_tc#33)

# Related Issues
stems from bugs introduced by NRLMMD-GEOIPS/geoips#464
see NRLMMD-GEOIPS/recenter_tc#33

# Testing Instructions
Run ``pytest -v geoips/tests/unit_tests/commandline/test_log_setup.py`` and ``./geoips/tests/integration_tests/full_test.sh``

# Summary
*Finish log with emphasis PR (#464)* introduced a couple of bugs that weren't caught by
GeoIPS devs. This PR fixes those bugs and ensues that both the unit tests and accociated
scripts pass without failure. This fix changes a bug in test_log_setup.py where
``generate_random_messages(add_long_word=True)`` would return a ``map`` object rather
than an iterable list of strings. ``map`` objects have no length attribute and caused
failures within ``geoips/commandline/log_setup:log_with_emphasis``. We also added a new
check in ``log_with_emphasis`` that raises a ``TypeError`` if one or more of the items
in the unpacked list of ``*messages`` doesn't have a length attribute. Ie. None, map,
etc.

    modified: geoips/commandline/log_setup.py
    modified: tests/unit_tests/commandline/test_log_setup.py

