### PR TITLE
Add PEP8 to Standards Doc

### DIFF
--- a/docs/dev/coding_standards.rst
+++ b/docs/dev/coding_standards.rst
@@ -26,18 +26,84 @@ right in the case of a conflict with this document.
 External Style Standards
 ------------------------
 
+`PEP 8 <https://peps.python.org/pep-0008/>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A nice version of PEP8 can be found at: `PEP8.org <https://pep8.org/>`
+
+Some highlights below for reference.
+
+Function Names
+""""""""""""""
+
+Function names should be lowercase, with words separated by
+underscores as necessary to improve readability.
+
+`PEP8 Names Standards <https://pep8.org/#naming-conventions>`__
+
+Class Names
+"""""""""""
+
+Class names should normally use the CapWords convention.
+
+`PEP8 Names Standards <https://pep8.org/#naming-conventions>`__
+
+Exception Names
+"""""""""""""""
+
+Because exceptions should be classes, the class naming convention applies here.
+However, you should use the suffix "Error" on your exception names
+(if the exception actually is an error).
+
+`PEP8 Names Standards <https://pep8.org/#naming-conventions>`__
+
+Module Names
+""""""""""""
+
+Modules should have **short**, **all-lowercase names**.
+Underscores can be used in the module name if it improves readability.
+`PEP8 Names Standards <https://pep8.org/#naming-conventions>`__
+
+Imports
+^^^^^^^
+Imports should usually be on separate lines, e.g.:
+
+Yes:
+
+.. code-block:: python
+
+    import os
+    import sys
+
+No:
+
+.. code-block:: python
+
+    import os, sys
+
+It's okay to say this though:
+
+.. code-block:: python
+
+    from subprocess import Popen, PIPE
+
+Imports are always put at the top of the file, just after any module comments and
+docstrings, and before module globals and constants.
+
+`PEP8 Imports Standards <https://pep8.org/#imports>`__
+
 Internal Style Standards
 -------------------------
 
 Imports Shouldn't Be Buried Without a Reason
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If an import needs to be buried for efficiency reasons or namespace conflicts,
 this should be documented in the docstrings.
 
 
 Linting/Formatting
--------------------
+^^^^^^^^^^^^^^^^^^
 
 The GeoIPS project makes use of several linting tools to help maintain code quality. The
 full suite of linters can be installed by installing the "test" dependencies via pip.
@@ -45,7 +111,8 @@ For example, if you installed GeoIPS using `pip install .` the linters can be in
 using `pip install .[test]` the following tools to ensure code quality:
 
 Black
-~~~~~
+^^^^^
+
 We use the `Black formatter <https://github.com/psf/black>`_ with its default
 settings. As stated in the Black documentation, it is an uncompromizing code
 formatter, but it has resulted in significantly more readable code. Applying it
@@ -53,7 +120,8 @@ automatically while writing code has also reduced development time since
 developers don't need to think about formatting.
 
 Flake8
-~~~~~~
+^^^^^^
+
 We use the `Flake8 linter <https://flake8.pycqa.org/en/latest/>`_ to enforce
 PEP8 code standards. We also add several plugins to Flake8 to enforce additional
 standards for GeoIPS code. Plugins used include:
@@ -65,7 +133,7 @@ standards for GeoIPS code. Plugins used include:
 - `flake8-rst <https://github.com/flake8-docs/flake8-rst>` runs flake8 on code
   snippets in reStructuredText files to ensure proper formatting in
   documentation.
-  
+
 We modify the default behavior of flake8 slightly to make it work well with Black,
 ignore specific errors, and configure plugins. GeoIPS specific settings for
 flake8 include the following:
@@ -89,14 +157,14 @@ Github Conventions
 ------------------
 
 Pull Request Workflow
-~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^
 
 `https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-github-pull-request-workflow <https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-github-pull-request-workflow>`__
 
 `https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-merge-pr-and-close-issue-workflow <https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-merge-pr-and-close-issue-workflow>`__
 
 Issue Workflow
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 `https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-github-issue-creation-workflow <https://nrlmmd-geoips.github.io/geoips/devguide/git_workflow.html#geoips-github-issue-creation-workflow>`__
 

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -20,6 +20,7 @@ Version 1.12.2a0 (2024-02-21)
   * Added log with emphasis function
   * Introduced a documentation for coding standards within the build/dev directory.
   * Introduced documentation for coding standards for module imports.
+  * Introduced documentation for PEP8 standards.
   * Added documentation for current linters and configuration.
 * Bug fixes
   * Fix polar data not showing up in imagery
@@ -129,6 +130,16 @@ Introduced documentation for coding standards for module imports.
 Throughout GeoIPS, we have inconsistent module imports. These new standards (added to
 our documentation) will help us be more intentional in how we import modules going
 forward.
+
+::
+    modified: docs/dev/coding_standards.rst
+
+Introduced documentation for PEP8 standards.
+--------------------------------------------
+
+Throughout GeoIPS, we have inconsistent coding standards. PEP8 (added to
+our documentation) is an external standard we already use, and so we want
+that to be explicit in our documentation.
 
 ::
     modified: docs/dev/coding_standards.rst


### PR DESCRIPTION
✅ Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
✅ Required ***documentation*** added for new/modified functionality
✅ Required ***release notes*** added for new/modified functionality
❌ NO REQUIRED ***updates to other repos*** (This documentation update does not necessitate changes in other repositories.)
❌ NO REQUIRED ***unit tests*** (This is a documentation update, hence no unit tests are required.)
❌ NO REQUIRED ***integration tests*** (Since this is a documentation change, no integration tests are needed.)

# Related Issues
Related to NRLMMD-GEOIPS/geoips#502

# Summary
I wrote that we will be following PEP-8 guidelines - nothing should be surprising in here.

Added some easy references for function names, class names, exception names, module names, and module import conventions. 

Included a link to a cute (✨) version PEP-8 for further reference.
