### PR TITLE
507 documentation for developer assisted package creation

### DIFF
--- a/docs/source/devguide/dev_assisted_package_creation.rst
+++ b/docs/source/devguide/dev_assisted_package_creation.rst
@@ -15,37 +15,50 @@
 Developer Assisted Package Creation
 ===================================
 
+If you are a user, developer, or researcher that has software related to geospatial data
+processing and are unable to integrate that functionality into GeoIPS, you've come to
+the right place. Some of our developers for GeoIPS (specifically CIRA-based), might be
+able to help you integrate your functionality into GeoIPS. Please continue reading if
+you think this may be of use!
+
 Why We Assist With Package Creation
 -----------------------------------
 
 The GeoIPS Development team is committed to integrating a variety of geospatial
-processing routines into GeoIPS, or as a standalone packages that can interact with
-GeoIPS. Specifically we developers at CIRA are tasked with integrating proprietary
-software developed by researchers to work alongside GeoIPS. If you have access, see the
+processing routines into GeoIPS, or as standalone packages that can interact with
+GeoIPS. This can be as simple as adding your algorithm or reader to the main GeoIPS
+code, or it can be more complex in creating a completely separate GeoIPS plugin-package
+specific for your use case. If you have access, see the
 `GeoIPS GLM Package <https://bear.cira.colostate.edu/overcast/geoips_glm>`_ for an
 example of a standalone package that implements GREMLIN and GLM
 (Global Lightning Mapper) routines working alongside GeoIPS.
 
+If you don't have access to that, please feel free to view any of our
+`public repositories <https://github.com/orgs/NRLMMD-GEOIPS/repositories>`_ for a
+general idea of what we can help you with.
+
 The purpose of integrating software like this is to elevate GeoIPS as a package that can
-process nearly any type of geospatial data, and output it in a variety of formats. For
-each standalone package that we create, we only elevate the capabilities of GeoIPS as a
-whole. Eventually, we'd like to see GeoIPS be the only package you need to handle your
-geospatial data routines.
+process nearly any type of satellite, in-situ, geo-located -derived data, and output it
+in a variety of formats. For each standalone package that we create, we only elevate the
+capabilities of GeoIPS as a whole. Eventually, we'd like to see GeoIPS be one, if not
+the package you need to handle your geospatial processing routines.
 
 Use Cases That We'll Support
 ----------------------------
 
-If you are a user, developer, or researcher that has software related to geospatial data
-processing and are unable to integrate that functionality into GeoIPS, you've come to
-the right place. We first request that the data processing you've implemented doesn't
-already exist in GeoIPS, or any of its corresponding packages. For a full list of public
-repositories that NRLMMD-GEOIPS supports, see
+We first request that the data processing you've implemented doesn't already exist in
+GeoIPS, or any of its corresponding packages. If you have processing routines that are
+similar, it is likely you'll just have to reformat your inputs to integrate correctly
+with the GeoIPS system. We are happy to help with that if needed. For a full list of
+public repositories that NRLMMD-GEOIPS supports, see
 `GeoIPS Repositories <https://github.com/orgs/NRLMMD-GEOIPS/repositories>`_.
 
 If the data routines you've created don't match any of the repositories linked above,
 then we've likely found a use case worth creating a separate GeoIPS package for.
-Assuming you've found a developer able to help you to get your processing routines
-integrated alongside GeoIPS, here's what we'll need from you.
+
+Please either submit an issue `here <https://github.com/NRLMMD-GEOIPS/geoips/issues/new/choose>`_,
+or contact us at ``geoips@nrlmry.navy.mil`` specifying your use case and the assistance
+needed. Here's what we'll need from you for either method.
 
 Information Needed for Developers
 ---------------------------------
@@ -57,13 +70,15 @@ GeoTIFF, or NetCDF / HDF5 file.
 
 #. ``Data``
 
-   a. We'll take on any and all data that is needed to produce your expected output. The
-      more data you provide, the better chance we have at testing and producing accurate
-      outputs that match your current routines.
+   a. We'll take on most datasets that iares needed to produce your expected output. The
+      more data and types of data which you provide, the better chance we have at
+      testing and producing accurate outputs that match your current routines. Please
+      don't provide us with Terabytes of data, only that which is necessary to produce
+      your product in its entirety.
 
 #. ``Code``
 
-   a. The code provided should encapsulate every thing you've indiviually created to get
+   a. The code provided should encapsulate everything you or your group created to get
       your processing routines working. This does not include code from dependent 3rd
       party software packages, but a list of software dependencies would be appreciated
       so we know what to install. Code included could be any of the following bullet

--- a/docs/source/devguide/dev_assisted_package_creation.rst
+++ b/docs/source/devguide/dev_assisted_package_creation.rst
@@ -1,0 +1,104 @@
+ .. dropdown:: Distribution Statement
+
+    | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+    | # # #
+    | # # # Author:
+    | # # # Naval Research Laboratory, Marine Meteorology Division
+    | # # #
+    | # # # This program is free software: you can redistribute it and/or modify it under
+    | # # # the terms of the NRLMMD License included with this program. This program is
+    | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+    | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+    | # # # for more details. If you did not receive the license, for more information see:
+    | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Developer Assisted Package Creation
+===================================
+
+Why We Assist With Package Creation
+-----------------------------------
+
+The GeoIPS Development team is committed to integrating a variety of geospatial
+processing routines into GeoIPS, or as a standalone packages that can interact with
+GeoIPS. Specifically we developers at CIRA are tasked with integrating proprietary
+software developed by researchers to work alongside GeoIPS. If you have access, see the
+`GeoIPS GLM Package <https://bear.cira.colostate.edu/overcast/geoips_glm>`_ for an
+example of a standalone package that implements GREMLIN and GLM
+(Global Lightning Mapper) routines working alongside GeoIPS.
+
+The purpose of integrating software like this is to elevate GeoIPS as a package that can
+process nearly any type of geospatial data, and output it in a variety of formats. For
+each standalone package that we create, we only elevate the capabilities of GeoIPS as a
+whole. Eventually, we'd like to see GeoIPS be the only package you need to handle your
+geospatial data routines.
+
+Use Cases That We'll Support
+----------------------------
+
+If you are a user, developer, or researcher that has software related to geospatial data
+processing and are unable to integrate that functionality into GeoIPS, you've come to
+the right place. We first request that the data processing you've implemented doesn't
+already exist in GeoIPS, or any of its corresponding packages. For a full list of public
+repositories that NRLMMD-GEOIPS supports, see
+`GeoIPS Repositories <https://github.com/orgs/NRLMMD-GEOIPS/repositories>`_.
+
+If the data routines you've created don't match any of the repositories linked above,
+then we've likely found a use case worth creating a separate GeoIPS package for.
+Assuming you've found a developer able to help you to get your processing routines
+integrated alongside GeoIPS, here's what we'll need from you.
+
+Information Needed for Developers
+---------------------------------
+
+In order to create a standalone GeoIPS Package implementing your routines, we'll need
+the following information to produce your expected output. This output could take on a
+variety of formats, but for this documentation, we'll assume it's some type of imagery,
+GeoTIFF, or NetCDF / HDF5 file.
+
+#. ``Data``
+
+   a. We'll take on any and all data that is needed to produce your expected output. The
+      more data you provide, the better chance we have at testing and producing accurate
+      outputs that match your current routines.
+
+#. ``Code``
+
+   a. The code provided should encapsulate every thing you've indiviually created to get
+      your processing routines working. This does not include code from dependent 3rd
+      party software packages, but a list of software dependencies would be appreciated
+      so we know what to install. Code included could be any of the following bullet
+      points.
+   b. Algorithms
+   c. Colormaps
+   d. Readers
+   e. Utility Modules
+   f. Any other code you wrote that's required to produce the expected output
+
+#. ``List of Input Variables`` needed to produce the desired output
+
+   a. Since the data you're using is geospatial, we'll need some context of what
+      variables we'll be dealing with. Please provide us with a list of variables needed
+      to produce your expected output. It should look something like what is shown below.
+   b. [``cloud_height_acha``, ``relative_humidity``, ``cloud_water_content``, ...]
+
+#. ``Examples of Accurate Outputs`` from your current routines.
+
+   a. Included alongside these outputs, please provide the data used to generate these
+      outputs. This way, we have a concrete test example to compare alongside to make
+      sure what we've implemented matches what you expect. Could Include:
+   b. Imagery
+   c. GeoTIFFs
+   d. NetCDF / HDF5 Files
+   e. Any other output that could assist with testing
+
+#. ``Description of your Geospatial Processing Routines``
+
+   a. In this description, you should include the following information:
+   b. What this software achieves
+   c. What outputs it creates
+   d. Why it's needed
+
+Once we have the aforementioned information, us developers will be able to venture
+forward in creating your standalone GeoIPS package based translated from your current
+geospatial processing routines. Once this package has been created, you'll be able to
+work alongside the GeoIPS environment to produce your personally tailored outputs.

--- a/docs/source/devguide/dev_assisted_package_creation.rst
+++ b/docs/source/devguide/dev_assisted_package_creation.rst
@@ -35,7 +35,11 @@ example of a standalone package that implements GREMLIN and GLM
 
 If you don't have access to that, please feel free to view any of our
 `public repositories <https://github.com/orgs/NRLMMD-GEOIPS/repositories>`_ for a
-general idea of what we can help you with.
+general idea of what we can help you with. For any standalone package that we'll be
+developing for users who have requested assistance, we'll largely be following the
+structure of the `template_basic_plugin package <https://github.com/NRLMMD-GEOIPS/template_basic_plugin>`_.
+The aforementioned package is a template for creating separate plugin packages that can
+interact with GeoIPS seamlessly.
 
 The purpose of integrating software like this is to elevate GeoIPS as a package that can
 process nearly any type of satellite, in-situ, geo-located -derived data, and output it

--- a/docs/source/devguide/dev_assisted_package_creation.rst
+++ b/docs/source/devguide/dev_assisted_package_creation.rst
@@ -98,7 +98,7 @@ GeoTIFF, or NetCDF / HDF5 file.
    c. What outputs it creates
    d. Why it's needed
 
-Once we have the aforementioned information, us developers will be able to venture
-forward in creating your standalone GeoIPS package based translated from your current
-geospatial processing routines. Once this package has been created, you'll be able to
-work alongside the GeoIPS environment to produce your personally tailored outputs.
+Once we have the aforementioned information, we'll be able to move foward in creating
+your standalone GeoIPS package, translated from your current geospatial processing
+routines. Once this package has been created, you'll be able to work alongside the
+GeoIPS environment to produce your personally tailored outputs.

--- a/docs/source/devguide/index.rst
+++ b/docs/source/devguide/index.rst
@@ -20,6 +20,7 @@ Developer Guide
    software_requirements_specification
    contributors
    dev_setup
+   dev_assisted_package_creation
    build_docs
    git_workflow
    documentation_strategy

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,14 @@ Version 1.12
 .. toctree::
    :maxdepth: 1
 
+   v1_13_0a0
+
+Version 1.12
+------------
+
+.. toctree::
+   :maxdepth: 1
+
    v1_12_2a0
    v1_12_0
 

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -30,14 +30,6 @@ Version 1.12
 .. toctree::
    :maxdepth: 1
 
-   v1_13_0a0
-
-Version 1.12
-------------
-
-.. toctree::
-   :maxdepth: 1
-
    v1_12_2a0
    v1_12_0
 

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -36,7 +36,7 @@ Version 1.12.2a0 (2024-02-21)
 * Documentation
 
   * Added documentation for create_plugin_registries and PluginRegistry Class
-  * Fix log_with_emphasis to deal with empty strings gracefully 
+  * Fix log_with_emphasis to deal with empty strings gracefully
 * Refactor
 
   * Make JSON Plugin Registries Readable
@@ -165,11 +165,12 @@ Introduced documentation for coding standards on how/when to bring code to stand
 -----------------------------------------------------------------------------------
 
 Throughout GeoIPS, we have inconsistent coding practices. These new standards (added to
-our documentation) will help us be more intentional in how we bring old code 
+our documentation) will help us be more intentional in how we bring old code
 up to date going forward.
 
 ::
     modified: docs/dev/coding_standards.rst
+
 Bug Fixes
 =========
 

--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -43,6 +43,7 @@ researchers' geospatial data processing routines into a GeoIPS Package.
 ::
 
     modified: docs/source/devguide/index.rst
+    modified: docs/source/releases/v1_12_2a0.rst
     modified: docs/source/releases/v1_13_0a0.rst
     added: docs/source/devguide/dev_assisted_package_creation.rst
 

--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -1,0 +1,44 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.13.0a0 (2024-04-24)
+*****************************
+
+* Documentation
+
+    * Developer Assisted Package Creation
+
+Documentation
+=============
+
+Developer Asisted Package Creation
+----------------------------------
+
+*From GEOIPS#507: 2024-04-24, Documentation Guideline for Developer-Assisted Package Creation*
+
+The aforementioned issue illustrates the need for a guideline which documents why,
+when, and how developers should work alongside users and researchers to get their
+geospatial data processing routines integrated alongside GeoIPS. Namely, here at CIRA,
+this is a large task for GeoIPS developers. We are expected to work alongside
+researchers to get their routines integrated alongside GeoIPS, and having this
+documentation layed out should streamline this process.
+
+The created guideline illustrates why we do this, what use cases we'll support, and what
+information we as developers will need to generate a standalone package containing the
+researchers' geospatial data processing routines into a GeoIPS Package.
+
+::
+
+    modified: docs/source/releases/index.rst
+    modified: docs/source/devguide/index.rst
+    added: docs/source/releases/v1_13_0a0.rst
+    added: docs/source/devguide/dev_assisted_package_creation.rst


### PR DESCRIPTION
# Reviewer Checklist

* [x] NO REQUIRED ***existing tests*** (only documentation, and documentation builds. No need for full test)
* [x] NO REQUIRED ***unit tests*** (Just documentation)
* [x] NO REQUIRED ***integration tests*** (Just documentation)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (Documenting a process, not code)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#507

# Testing Instructions
Run ``./docs/build_docs . geoips html_only``. Documentation will build without any errors.

# Summary
The aforementioned issue illustrates the need for a guideline which documents why,
when, and how developers should work alongside users and researchers to get their
geospatial data processing routines integrated alongside GeoIPS. Namely, here at CIRA,
this is a large task for GeoIPS developers. We are expected to work alongside
researchers to get their routines integrated alongside GeoIPS, and having this
documentation layed out should streamline this process.

The created guideline illustrates why we do this, what use cases we'll support, and what
information we as developers will need to generate a standalone package containing the
researchers' geospatial data processing routines into a GeoIPS Package.

    modified: docs/source/devguide/index.rst
    modified: docs/source/releases/v1_12_2a0.rst
    modified: docs/source/releases/v1_13_0a0.rst
    added: docs/source/devguide/dev_assisted_package_creation.rst

**(Change to v1_12_2a0.rst was needed as the documentation wouldn't build unless there was a blank line after a list)**

# Output
You can download ``geoips/build/sphinx/html`` directory and drag ``index.html`` into your browser to see the new documentation page.
