### PR TITLE
624 update nextcloud links

### DIFF
--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -26,6 +26,10 @@ Version 1.13.0a0 (2024-04-24)
 
   * Fix color table application in geotiff_standard output formatter
 
+* Testing Updates
+
+  * Updated portions of the code to use new NextCloud Data Links
+
 Enhancements
 ============
 
@@ -170,3 +174,38 @@ array is written.
   modified: docs/source/releases/v1_13_0a0.rst
   modified: geoips/plugins/modules/output_formatters/geotiff_standard.py
   modified: pyproject.toml
+
+Testing Updates
+===============
+
+Updated portions of the code to use new NextCloud Data Links
+------------------------------------------------------------
+
+*From GEOIPS#624: 2024-05-29, Update Code and Documentation to reflect new NextCloud Test Data Location*
+*From GEOIPS#625: 2024-05-29, Fix Bug In ``setup/download_test_data.py``*
+
+Portions ``setup/check_system_requirements.sh`` test data install code was outdated due
+to the old instance of NextCloud being taken down recently. We've created a new instance
+of NextCloud which hosts a large majority of the data used for testing GeoIPS, and this
+required updating portions of the code which used the old links to the new link
+locations.
+
+As we were making those changes, we also found that ``setup/download_test_data.py``
+would not work for non ``.git`` hosted datsets. This is because a change was made to
+``setup/check_system_requirements.sh`` which sent the output of the raw repsonse from
+``requests.get`` to a logfile rather than piping it to tar extraction then a logfile. To
+fix this, we added a conditional in ``setup/check_system_requirements.sh`` which
+determined the source of the dataset, and either send the output of
+``setup/download_test_data.py`` directly to a logfile (``.git``-based), or piped it to
+tar extraction then to a log file.
+
+These changes address the new data locations and the bug introduced to
+``setup/check_system_requirements.sh``.
+
+::
+
+    modified: geoips/commandline/ancillary_info/test_data.py
+    modified: geoips/commandline/geoips_config.py
+    modified: setup/check_system_requirements.sh
+    modified: tests/integration_tests/full_install.sh
+    modified: tests/unit_tests/commandline/cli_top_level_tester.py

--- a/geoips/commandline/ancillary_info/test_data.py
+++ b/geoips/commandline/ancillary_info/test_data.py
@@ -20,13 +20,14 @@ Mapping goes {"test_dataset_name": "test_dataset_url"}
 interface = None  # denotes that this is not a plugin module
 
 test_dataset_dict = {
-    "test_data_viirs": "https://io.cira.colostate.edu/s/mQ2HbE2Js4E9rba/download/test_data_viirs.tgz",  # noqa
-    "test_data_smap": "https://io.cira.colostate.edu/s/CezXWwXg4qR2b94/download/test_data_smap.tgz",  # noqa
-    "test_data_scat": "https://io.cira.colostate.edu/s/HyHLZ9F8bnfcTcd/download/test_data_scat.tgz",  # noqa
-    "test_data_sar": "https://io.cira.colostate.edu/s/snxx8S5sQL3AL7f/download/test_data_sar.tgz",  # noqa
-    "test_data_noaa_aws": "https://io.cira.colostate.edu/s/fkiPS3jyrQGqgPN/download/test_data_noaa_aws.tgz",  # noqa
-    "test_data_gpm": "https://io.cira.colostate.edu/s/LT92NiFSA8ZSNDP/download/test_data_gpm.tgz",  # noqa
-    "test_data_fusion": "https://io.cira.colostate.edu/s/DSz2nZsiPMDeLEP/download/test_data_fusion.tgz",  # noqa
-    "test_data_clavrx": "https://io.cira.colostate.edu/s/ACLKdS2Cpgd2qkc/download/test_data_clavrx.tgz",  # noqa
-    "test_data_amsr2": "https://io.cira.colostate.edu/s/FmWwX2ft7KDQ8N9/download/test_data_amsr2.tgz",  # noqa
+    "test_data_fusion": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_fusion.tgz",  # NOQA
+    "test_data_noaa_aws": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_noaa_aws.tgz",  # NOQA
+    "test_data_amsr2": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_amsr2_1.6.0.tgz",  # NOQA
+    "test_data_clavrx": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_clavrx_1.10.0.tgz",  # NOQA
+    "test_data_gpm": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_gpm_1.6.0.tgz",  # NOQA
+    "test_data_sar": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_sar_1.12.2.tgz",  # NOQA
+    "test_data_scat_1.11.2": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.2.tgz",  # NOQA
+    "test_data_scat_1.11.3": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.3.tgz",  # NOQA
+    "test_data_smap": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_smap_1.6.0.tgz",  # NOQA
+    "test_data_viirs": r"https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_viirs_1.6.0.tgz",  # NOQA
 }

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -3,6 +3,7 @@
 Various configuration-based commands for setting up your geoips environment.
 """
 
+from numpy import any
 from os import listdir, environ
 from os.path import abspath, join
 import requests
@@ -48,10 +49,14 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
         """
         test_dataset_name = args.test_dataset_name
         test_dataset_url = test_dataset_dict[test_dataset_name]
-        if test_dataset_name in listdir(self.geoips_testdata_dir):
+        if (
+            any(
+                [test_dataset_name in fol for fol in listdir(self.geoips_testdata_dir)]
+            )
+        ):
             print(
                 f"Test dataset '{test_dataset_name}' already exists under "
-                f"'{join(self.geoips_testdata_dir, test_dataset_name)}'. See that "
+                f"'{join(self.geoips_testdata_dir, test_dataset_name)}*/'. See that "
                 "location for the contents of the test dataset."
             )
         else:

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -49,11 +49,7 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
         """
         test_dataset_name = args.test_dataset_name
         test_dataset_url = test_dataset_dict[test_dataset_name]
-        if (
-            any(
-                [test_dataset_name in fol for fol in listdir(self.geoips_testdata_dir)]
-            )
-        ):
+        if any([test_dataset_name in fol for fol in listdir(self.geoips_testdata_dir)]):
             print(
                 f"Test dataset '{test_dataset_name}' already exists under "
                 f"'{join(self.geoips_testdata_dir, test_dataset_name)}*/'. See that "

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -391,7 +391,10 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
             # to rename the top folder of it to test_data_name. This way full_install.sh will
             # not download the data again as it's able to identify that it's installed.
             folder_name=$(echo "$matching_folders")
-            mv $GEOIPS_TESTDATA_DIR/$folder_name $test_data_dir
+            if [[ "$folder_name" != "$test_data_name" ]]; then
+                # if folder_name doesn't equal test_data_name then rename that folder
+                mv $GEOIPS_TESTDATA_DIR/$folder_name $test_data_dir
+            fi
             retval=$?
             if  [[ "$retval" == "0" ]]; then
                 echo "SUCCESS: Decompressed ${test_data_name}"

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -382,7 +382,7 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
             # check to see how many folders in GEOIPS_TESTDATA_DIR match test_data_name
             matching_folders=$(ls $GEOIPS_TESTDATA_DIR | grep $test_data_name)
             folder_count=$(echo "$matching_folders" | wc -l)
-            if [ "$folder_count" -ne 1]; then
+            if [[ "$folder_count" -ne 1 ]]; then
                 echo "Error: Expected exactly one matching folder starting with $test_data_name but found $folder_count."
                 echo "Please delete or rename folders starting with $test_data_name in $GEOIPS_TESTDATA_DIR before running this script again."
                 exit 1

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -379,6 +379,19 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
             echo "DOWNLOADING: NextCloud Dataset $test_data_name @ $test_data_url"
             echo "tar -xz -C $GEOIPS_TESTDATA_DIR >> $install_log 2>&1"
             python $SCRIPT_DIR/download_test_data.py $test_data_url $test_data_dir | tar -xz -C $GEOIPS_TESTDATA_DIR >> $install_log 2>&1
+            # check to see how many folders in GEOIPS_TESTDATA_DIR match test_data_name
+            matching_folders=$(ls $GEOIPS_TESTDATA_DIR | grep $test_data_name)
+            folder_count=$(echo "$matching_folders" | wc -l)
+            if [ "$folder_count" -ne 1]; then
+                echo "Error: Expected exactly one matching folder starting with $test_data_name but found $folder_count."
+                echo "Please delete or rename folders starting with $test_data_name in $GEOIPS_TESTDATA_DIR before running this script again."
+                exit 1
+            fi
+            # if only one match was found, this was the installed dataset and we are good
+            # to rename the top folder of it to test_data_name. This way full_install.sh will
+            # not download the data again as it's able to identify that it's installed.
+            folder_name=$(echo "$matching_folders")
+            mv $GEOIPS_TESTDATA_DIR/$folder_name $test_data_dir
             retval=$?
             if  [[ "$retval" == "0" ]]; then
                 echo "SUCCESS: Decompressed ${test_data_name}"

--- a/setup/check_system_requirements.sh
+++ b/setup/check_system_requirements.sh
@@ -46,15 +46,16 @@ echo "Install log: $install_log"
 
 # These are the download locations used by the test_data function
 test_data_urls=(
-    "https://io.cira.colostate.edu/s/mQ2HbE2Js4E9rba/download/test_data_viirs.tgz"
-    "https://io.cira.colostate.edu/s/CezXWwXg4qR2b94/download/test_data_smap.tgz"
-    "https://io.cira.colostate.edu/s/HyHLZ9F8bnfcTcd/download/test_data_scat.tgz"
-    "https://io.cira.colostate.edu/s/snxx8S5sQL3AL7f/download/test_data_sar.tgz"
-    "https://io.cira.colostate.edu/s/fkiPS3jyrQGqgPN/download/test_data_noaa_aws.tgz"
-    "https://io.cira.colostate.edu/s/LT92NiFSA8ZSNDP/download/test_data_gpm.tgz"
-    "https://io.cira.colostate.edu/s/DSz2nZsiPMDeLEP/download/test_data_fusion.tgz"
-    "https://io.cira.colostate.edu/s/ACLKdS2Cpgd2qkc/download/test_data_clavrx.tgz"
-    "https://io.cira.colostate.edu/s/FmWwX2ft7KDQ8N9/download/test_data_amsr2.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_fusion.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_noaa_aws.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_amsr2_1.6.0.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_clavrx_1.10.0.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_gpm_1.6.0.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_sar_1.12.2.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.2.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.3.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_smap_1.6.0.tgz"
+    "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_viirs_1.6.0.tgz"
 )
 
 # Requirements to run base geoips tests
@@ -336,7 +337,7 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
     test_data_url="$GEOIPS_REPO_URL/${test_data_name}.git"
     if [[ "$test_data_source_location" != "github" ]]; then
         for url in ${test_data_urls[@]}; do
-            if [[ "${url}" == *"${test_data_name}.tgz" ]]; then
+            if [[ "${url}" == *"${test_data_name}"*".tgz" ]]; then
                 test_data_url="${url}"
                 break
             fi
@@ -364,18 +365,20 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
         fi
         echo "Installing $test_data_name_string .... "
         echo "  $test_data_dir/ from $test_data_url via $test_data_source_location"
-        python $SCRIPT_DIR/download_test_data.py $test_data_url $test_data_dir >> $install_log 2>&1
-        retval=$?
-        if  [[ "$retval" == "0" ]]; then
-            echo "SUCCESS: Pulled ${test_data_name} from ${test_data_url}"
+        if [[ "$test_data_source_location" == "github" ]]; then
+            python $SCRIPT_DIR/download_test_data.py $test_data_url $test_data_dir >> $install_log 2>&1
+            retval=$?
+            if  [[ "$retval" == "0" ]]; then
+                echo "SUCCESS: Pulled ${test_data_name} from ${test_data_url}"
+            else
+                echo "FAILED: Failed to pull ${test_data_name} from ${test_data_url}"
+                echo "        try deleting and re-running"
+                exit 1
+            fi
         else
-            echo "FAILED: Failed to pull ${test_data_name} from ${test_data_url}"
-            echo "        try deleting and re-running"
-            exit 1
-        fi
-        if [[ "$test_data_source_location" != "github" ]]; then
+            echo "DOWNLOADING: NextCloud Dataset $test_data_name @ $test_data_url"
             echo "tar -xz -C $GEOIPS_TESTDATA_DIR >> $install_log 2>&1"
-            tar -xz -C $GEOIPS_TESTDATA_DIR >> $install_log 2>&1
+            python $SCRIPT_DIR/download_test_data.py $test_data_url $test_data_dir | tar -xz -C $GEOIPS_TESTDATA_DIR >> $install_log 2>&1
             retval=$?
             if  [[ "$retval" == "0" ]]; then
                 echo "SUCCESS: Decompressed ${test_data_name}"
@@ -384,7 +387,6 @@ if [[ "$1" == "test_data" || "$1" == "test_data_github" ]]; then
                 echo "        try deleting and re-running"
                 exit 1
             fi
-		else
             # If this is a github repo, then check if current-branch exists
             # and switch to it if so. Allow branch not existing.
             if [[ "$switch_to_branch" != "" ]]; then

--- a/tests/integration_tests/full_install.sh
+++ b/tests/integration_tests/full_install.sh
@@ -34,7 +34,8 @@ fi
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_clavrx $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_gpm $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_sar $test_exit $install_script
-. $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_scat $test_exit $install_script
+. $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_scat_1.11.2 $test_exit $install_script
+. $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_scat_1.11.3 $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_smap $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_viirs $test_exit $install_script
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_fusion $test_exit $install_script

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -70,7 +70,8 @@ class BaseCliTest(abc.ABC):
                 "test_data_gpm",
                 "test_data_noaa_aws",
                 "test_data_sar",
-                "test_data_scat",
+                "test_data_scat_1.11.2",
+                "test_data_scat_1.11.3",
                 "test_data_smap",
                 "test_data_viirs",
             ]


### PR DESCRIPTION
# Reviewer Checklist

* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] Required ***integration tests*** modified and pass for new functionality
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#624
fixes NRLMMD-GEOIPS/geoips#625

# Testing Instructions
Run ``./tests/integration_tests/full_install.sh`` to make sure your test data gets installed. Please let me know what you think about the folder renaming in ``check_system_requirements.sh``. This was needed as some datasets installed as ``test_data_<ds_name>_<version_number>_github.com`` and we needed them to be either ``test_data_<ds_name>`` or ``test_data_<ds_name>_<version_number>``.

# Summary
Portions ``setup/check_system_requirements.sh`` test data install code was outdated due
to the old instance of NextCloud being taken down recently. We've created a new instance
of NextCloud which hosts a large majority of the data used for testing GeoIPS, and this
required updating portions of the code which used the old links to the new link
locations.

As we were making those changes, we also found that ``setup/download_test_data.py``
would not work for non ``.git`` hosted datsets. This is because a change was made to
``setup/check_system_requirements.sh`` which sent the output of the raw repsonse from
``requests.get`` to a logfile rather than piping it to tar extraction then a logfile. To
fix this, we added a conditional in ``setup/check_system_requirements.sh`` which
determined the source of the dataset, and either send the output of
``setup/download_test_data.py`` directly to a logfile (``.git``-based), or piped it to
tar extraction then to a log file.

These changes address the new data locations and the bug introduced to
``setup/check_system_requirements.sh``.

    modified: geoips/commandline/ancillary_info/test_data.py
    modified: geoips/commandline/geoips_config.py
    modified: setup/check_system_requirements.sh
    modified: tests/integration_tests/full_install.sh
    modified: tests/unit_tests/commandline/cli_top_level_tester.py

# Output
```bash
geoips) (base) [evan@spring integration_tests]$ ./full_install.sh 

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'git' appears to be installed successfully
    /home/evan/anaconda3/envs/geoips/bin/git

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'python' appears to be installed successfully
    /home/evan/anaconda3/envs/geoips/bin/python

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'gcc' appears to be installed successfully
    /home/evan/anaconda3/envs/geoips/bin/gcc

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'gfortran' appears to be installed successfully
    /usr/bin/gfortran

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'g++' appears to be installed successfully
    /home/evan/anaconda3/envs/geoips/bin/g++

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193607_install.log
SUCCESS: 'scipy/openblas' appear to be installed successfully

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: cartopy_shapefiles appear to be successfully installed
         if you are having comparison errors, you can try
         deleting the contents of $CARTOPY_DATA_DIR, and
         rerunning check_system_requirements.sh cartopy_shapefiles
drwxr-xr-x 2 evan evan 65536 Jan 12 16:37 /home/evan/geoips/geoips_packages/test_data/cartopy/shapefiles/natural_earth/cultural
drwxr-xr-x 2 evan evan 36864 Jan 12 16:37 /home/evan/geoips/geoips_packages/test_data/cartopy/shapefiles/natural_earth/physical

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo geoips appears to be installed successfully
    drwxr-xr-x 12 evan evan 4096 May 29 20:32 /home/evan/geoips/geoips_packages/geoips

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo data_fusion appears to be installed successfully
    drwxr-xr-x 9 evan evan 4096 May 28 15:31 /home/evan/geoips/geoips_packages/data_fusion

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo recenter_tc appears to be installed successfully
    drwxr-xr-x 9 evan evan 4096 May 15 20:18 /home/evan/geoips/geoips_packages/recenter_tc

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo geoips_clavrx appears to be installed successfully
    drwxr-xr-x 8 evan evan 4096 May 15 20:19 /home/evan/geoips/geoips_packages/geoips_clavrx

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo geoips_plugin_example appears to be installed successfully
    drwxr-xr-x 9 evan evan 4096 May 20 15:34 /home/evan/geoips/geoips_packages/geoips_plugin_example

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo template_basic_plugin appears to be installed successfully
    drwxr-xr-x 9 evan evan 4096 May 20 15:35 /home/evan/geoips/geoips_packages/template_basic_plugin

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: source repo template_fusion_plugin appears to be installed successfully
    drwxr-xr-x 9 evan evan 4096 Feb 6 19:15 /home/evan/geoips/geoips_packages/template_fusion_plugin

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: settings repo .vscode appears to be installed successfully
    drwxr-xr-x 3 evan evan 4096 Jan 12 16:55 /home/evan/geoips/geoips_packages/.vscode

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: tests data repo test_data_noaa_aws appears to be installed successfully
    drwxr-xr-x 3 evan evan 4096 Apr 4 2023 /home/evan/geoips/geoips_packages/test_data/test_data_noaa_aws

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: tests data repo test_data_amsr2 appears to be installed successfully
    drwxr-xr-x 5 evan evan 4096 Apr 4 2023 /home/evan/geoips/geoips_packages/test_data/test_data_amsr2

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: tests data repo test_data_clavrx appears to be installed successfully
    drwxr-xr-x 3 evan evan 4096 Mar 13 16:59 /home/evan/geoips/geoips_packages/test_data/test_data_clavrx

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: tests data repo test_data_gpm appears to be installed successfully
    drwxr-xr-x 5 evan evan 4096 Apr 4 2023 /home/evan/geoips/geoips_packages/test_data/test_data_gpm

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
SUCCESS: tests data repo test_data_sar appears to be installed successfully
    drwxr-xr-x 5 evan evan 4096 Apr 25 2023 /home/evan/geoips/geoips_packages/test_data/test_data_sar

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log
Installing tests data repo test_data_scat_1.11.2 .... 
  /home/evan/geoips/geoips_packages/test_data/test_data_scat_1.11.2/ from https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.2.tgz via cira
DOWNLOADING: NextCloud Dataset test_data_scat_1.11.2 @ https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.2.tgz
tar -xz -C /home/evan/geoips/geoips_packages/test_data >> /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193608_install.log 2>&1
SUCCESS: Decompressed test_data_scat_1.11.2

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193632_install.log
Installing tests data repo test_data_scat_1.11.3 .... 
  /home/evan/geoips/geoips_packages/test_data/test_data_scat_1.11.3/ from https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.3.tgz via cira
DOWNLOADING: NextCloud Dataset test_data_scat_1.11.3 @ https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.3.tgz
tar -xz -C /home/evan/geoips/geoips_packages/test_data >> /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193632_install.log 2>&1
SUCCESS: Decompressed test_data_scat_1.11.3

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193650_install.log
SUCCESS: tests data repo test_data_smap appears to be installed successfully
    drwxr-xr-x 5 evan evan 4096 Apr 4 2023 /home/evan/geoips/geoips_packages/test_data/test_data_smap

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193650_install.log
SUCCESS: tests data repo test_data_viirs appears to be installed successfully
    drwxr-xr-x 4 evan evan 4096 Aug 14 2023 /home/evan/geoips/geoips_packages/test_data/test_data_viirs

Install log: /home/evan/geoips/geoips_packages/outdirs/logs/20240530.193650_install.log
SUCCESS: tests data repo test_data_fusion appears to be installed successfully
    drwxr-xr-x 3 evan evan 4096 May 8 2023 /home/evan/geoips/geoips_packages/test_data/test_data_fusion
```