### PR TITLE
fixed bug introduced by matplotlib versions >=3.9

### DIFF
--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -25,6 +25,7 @@ Version 1.13.0a0 (2024-04-24)
 * Bug fixes
 
   * Fix color table application in geotiff_standard output formatter
+  * Fix bug introduced by matplotlib versions ``>=3.9``
 
 Enhancements
 ============
@@ -170,3 +171,18 @@ array is written.
   modified: docs/source/releases/v1_13_0a0.rst
   modified: geoips/plugins/modules/output_formatters/geotiff_standard.py
   modified: pyproject.toml
+
+Fix bug introduced by matplotlib versions ``>=3.9``
+---------------------------------------------------
+
+Prior to matplotlib versions ``>=3.9`` we were able to use ``matplotlib.cm.get_cmap``
+without any problem. After 3.9 was introduced, this failed because
+``cm had no attribute called 'get_cmap'``. To fix this, we've migrated such calls from
+``cm.get_cmap`` to ``pyplot.get_cmap``, as that function still works for pyplot. It's
+weird that the same functionality was located in two different places, but at least it
+makes for an easy fix.
+
+::
+
+    modified: geoips/image_utils/colormap_utils.py
+    modified: geoips/plugins/modules/colormappers/matplotlib_linear_norm.py

--- a/geoips/image_utils/colormap_utils.py
+++ b/geoips/image_utils/colormap_utils.py
@@ -74,10 +74,10 @@ def set_matplotlib_colors_standard(
     """
     min_val = data_range[0]
     max_val = data_range[1]
-    from matplotlib import cm
+    from matplotlib import pyplot as plt
 
     # cmap = cm.ScalarMappable(norm=colors.NoNorm(), cm.get_cmap(cmap_name))
-    mpl_cmap = cm.get_cmap(cmap_name)
+    mpl_cmap = plt.get_cmap(cmap_name)
 
     LOG.info("Setting norm")
     from matplotlib.colors import Normalize

--- a/geoips/plugins/modules/colormappers/matplotlib_linear_norm.py
+++ b/geoips/plugins/modules/colormappers/matplotlib_linear_norm.py
@@ -14,7 +14,7 @@
 import logging
 
 from matplotlib.colors import Normalize
-from matplotlib import cm
+from matplotlib import pyplot as plt
 
 from geoips.image_utils.colormap_utils import from_ascii
 from geoips.geoips_utils import find_ascii_palette
@@ -103,7 +103,7 @@ def call(
 
     if cmap_source == "matplotlib":
         try:
-            mpl_cmap = cm.get_cmap(cmap_name)
+            mpl_cmap = plt.get_cmap(cmap_name)
         except ValueError:
             raise ValueError(f"Colormap {cmap_name} not found in source {cmap_source}")
     elif cmap_source == "geoips":


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionalitye
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#632

# Testing Instructions
I only tested on ``./base_test.sh`` and will run ``./full_test.sh`` once I can find the time.

# Summary
Prior to matplotlib versions ``>=3.9`` we were able to use ``matplotlib.cm.get_cmap``
without any problem. After 3.9 was introduced, this failed because
``cm had no attribute called 'get_cmap'``. To fix this, we've migrated such calls from
``cm.get_cmap`` to ``pyplot.get_cmap``, as that function still works for pyplot. It's
weird that the same functionality was located in two different places, but at least it
makes for an easy fix.

    modified: geoips/image_utils/colormap_utils.py
    modified: geoips/plugins/modules/colormappers/matplotlib_linear_norm.py
