### PR TITLE
634 incorrect capitalization on this error should be clierror

### DIFF
--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -22,9 +22,11 @@ Version 1.13.0a0 (2024-04-24)
 
   * Update update_this_release_note
   * Add v1_13_0a0.rst release note
+
 * Bug fixes
 
   * Fix color table application in geotiff_standard output formatter
+  * Fix spelling
 
 Enhancements
 ============
@@ -139,7 +141,11 @@ For an example of how to run the GeoIPS CLI, see the code section below.
 New Docs Structure + GitHub Actions
 -----------------------------------
 
-Created a new folder, docs/new-docs, for updated documentation structure. A new doc8 linting action will only check the contents of this folder. Additionally, a new action ensures that the "old docs" (all other docs except docs/new-docs) remain unchanged. All new documentation should be added to new-docs. Development will now occur in new-docs rather than a feature branch. Added a banner to the documentation site to inform readers that the old docs are frozen and to link them to the new docs as a preview. Note that no new functionality has been added to GeoIPS.
+Created a new folder, docs/new-docs, for updated documentation structure. A new doc8 linting action will only check the
+contents of this folder. Additionally, a new action ensures that the "old docs" (all other docs except docs/new-docs)
+remain unchanged. All new documentation should be added to new-docs. Development will now occur in new-docs rather than
+a feature branch. Added a banner to the documentation site to inform readers that the old docs are frozen and to link
+them to the new docs as a preview. Note that no new functionality has been added to GeoIPS.
 
 Release Updates
 ===============
@@ -157,6 +163,19 @@ Update "update_this_release_note" to v1_13_0a0
 
 Bug Fixes
 =========
+
+Fix spelling
+------------
+
+PEP8 says Class names should normally use the CapWords convention.
+
+The naming convention for functions may be used instead in cases where the interface is documented and used primarily as
+a callable.
+
+But also when using acronyms in CapWords, capitalize all the letters of the acronym. Thus HTTPServerError is better than
+HttpServerError.
+
+I have updated the CLI classes to reflect this.
 
 Fix color table application in geotiff_standard output formatter
 ----------------------------------------------------------------

--- a/geoips/errors.py
+++ b/geoips/errors.py
@@ -31,7 +31,7 @@ class CoverageError(Exception):
     pass
 
 
-class CliError(Exception):
+class CLIError(Exception):
     """Raise exception on command line interface error."""
 
     pass

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -6,7 +6,7 @@ import subprocess
 from geoips.geoips_utils import get_entry_point_group
 
 
-class BaseCliTest(abc.ABC):
+class BaseCLITest(abc.ABC):
     """Top-Level CLI Test Class which implements shared attributes for sub-commands."""
 
     _config_install_args = ["geoips", "config", "install"]

--- a/tests/unit_tests/commandline/test_geoips_config_install.py
+++ b/tests/unit_tests/commandline/test_geoips_config_install.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsConfigInstall(BaseCliTest):
+class TestGeoipsConfigInstall(BaseCLITest):
     """Unit Testing Class for Config Install Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_get_family.py
+++ b/tests/unit_tests/commandline/test_geoips_get_family.py
@@ -6,10 +6,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 import pytest
 
 from geoips import interfaces
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsGetFamily(BaseCliTest):
+class TestGeoipsGetFamily(BaseCLITest):
     """Unit Testing Class for Get Family Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_get_interface.py
+++ b/tests/unit_tests/commandline/test_geoips_get_interface.py
@@ -6,10 +6,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 import pytest
 
 from geoips import interfaces
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsGetInterface(BaseCliTest):
+class TestGeoipsGetInterface(BaseCLITest):
     """Unit Testing Class for Get Interface Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_get_package.py
+++ b/tests/unit_tests/commandline/test_geoips_get_package.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsGetPackage(BaseCliTest):
+class TestGeoipsGetPackage(BaseCLITest):
     """Unit Testing Class for Get Package Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_get_plugin.py
+++ b/tests/unit_tests/commandline/test_geoips_get_plugin.py
@@ -7,10 +7,10 @@ from numpy.random import rand
 import pytest
 
 from geoips import interfaces
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsGetPlugin(BaseCliTest):
+class TestGeoipsGetPlugin(BaseCLITest):
     """Unit Testing Class for Get Plugin Sub-Command."""
 
     rand_threshold = 0.10

--- a/tests/unit_tests/commandline/test_geoips_list_interface.py
+++ b/tests/unit_tests/commandline/test_geoips_list_interface.py
@@ -9,10 +9,10 @@ from pathlib import Path
 import pytest
 
 from geoips import interfaces
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListInterface(BaseCliTest):
+class TestGeoipsListInterface(BaseCLITest):
     """Unit Testing Class for List Interface Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_interfaces.py
+++ b/tests/unit_tests/commandline/test_geoips_list_interfaces.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListInterfaces(BaseCliTest):
+class TestGeoipsListInterfaces(BaseCLITest):
     """Unit Testing Class for List Interfaces Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_packages.py
+++ b/tests/unit_tests/commandline/test_geoips_list_packages.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListPackages(BaseCliTest):
+class TestGeoipsListPackages(BaseCLITest):
     """Unit Testing Class for List Packages Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_plugins.py
+++ b/tests/unit_tests/commandline/test_geoips_list_plugins.py
@@ -7,10 +7,10 @@ from importlib import resources
 import json
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListPlugins(BaseCliTest):
+class TestGeoipsListPlugins(BaseCLITest):
     """Unit Testing Class for List Plugins Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_scripts.py
+++ b/tests/unit_tests/commandline/test_geoips_list_scripts.py
@@ -8,10 +8,10 @@ from importlib import resources
 from os.path import basename
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListScripts(BaseCliTest):
+class TestGeoipsListScripts(BaseCLITest):
     """Unit Testing Class for List Scripts Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_test_datasets.py
+++ b/tests/unit_tests/commandline/test_geoips_list_test_datasets.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListTestDatasets(BaseCliTest):
+class TestGeoipsListTestDatasets(BaseCLITest):
     """Unit Testing Class for List Test Datasets Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_unit_tests.py
+++ b/tests/unit_tests/commandline/test_geoips_list_unit_tests.py
@@ -9,10 +9,10 @@ from os import listdir
 from os.path import basename
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsListUnitTests(BaseCliTest):
+class TestGeoipsListUnitTests(BaseCLITest):
     """Unit Testing Class for List Unit Tests Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_run.py
+++ b/tests/unit_tests/commandline/test_geoips_run.py
@@ -10,10 +10,10 @@ from os import listdir
 from os.path import basename
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsRun(BaseCliTest):
+class TestGeoipsRun(BaseCLITest):
     """Unit Testing Class for 'geoips run' Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_test_linting.py
+++ b/tests/unit_tests/commandline/test_geoips_test_linting.py
@@ -5,10 +5,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsTestLinting(BaseCliTest):
+class TestGeoipsTestLinting(BaseCLITest):
     """Unit Testing Class for Test Linting Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_test_script.py
+++ b/tests/unit_tests/commandline/test_geoips_test_script.py
@@ -5,11 +5,11 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 from tests.unit_tests.commandline.test_geoips_run import TestGeoipsRun
 
 
-class TestGeoipsTestScript(BaseCliTest):
+class TestGeoipsTestScript(BaseCLITest):
     """Unit Testing Class for Test Script Sub-Command."""
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_test_unit_test.py
+++ b/tests/unit_tests/commandline/test_geoips_test_unit_test.py
@@ -10,10 +10,10 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 # import pytest
 # from importlib.resources import files
 
-# from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+# from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-# class TestGeoipsTestUnitTest(BaseCliTest):
+# class TestGeoipsTestUnitTest(BaseCLITest):
 #     """Unit Testing Class for Test Unit Test Sub-Command."""
 
 #     @property

--- a/tests/unit_tests/commandline/test_geoips_validate.py
+++ b/tests/unit_tests/commandline/test_geoips_validate.py
@@ -8,10 +8,10 @@ from importlib import resources
 from numpy.random import rand
 import pytest
 
-from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
+from tests.unit_tests.commandline.cli_top_level_tester import BaseCLITest
 
 
-class TestGeoipsValidate(BaseCliTest):
+class TestGeoipsValidate(BaseCLITest):
     """Unit Testing Class for 'geoips validate' Command."""
 
     @property


### PR DESCRIPTION
No change to functionality, just changing `Cli` to `CLI` in class names as per PEP8.