### PR TITLE
Added optional argument to ``geoips config install`` to skip actually installation step for unit tests

### DIFF
--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -272,7 +272,7 @@ Improve error message when user missing ``pixelmatch``
 ------------------------------------------------------
 
 When a user uses the image output checker with ``--compare-path`` without
-``pixelmatch`` installed, an error is raised. The old error was confusing. 
+``pixelmatch`` installed, an error is raised. The old error was confusing.
 This change improves the error, and directs the user on how to ameliorate
 the issue.
 
@@ -335,6 +335,21 @@ implement those changes.
     modified: geoips/create_plugin_registries.py
     modified: geoips/plugin_registry.py
     modified: geoips/geoips_utils.py
+
+Refactored ``config install`` unit tests to run faster
+------------------------------------------------------
+
+Previously the ``config install`` unit tests actually installed test datasets if they
+were missing. This is completely uneccessary and shouldn't be performed in the unit
+tests, only if a user actually wants to install data. To fix this, we've added a hidden
+argument to ``config install``, called ``--test-mode``, which will skip the download
+portion of the code if specified. While not perfect, this ensures that the unit tests
+will run fast and output the correct information.
+
+::
+
+    modified: geoips/commandline/geoips_config.py
+    modified: tests/unit_tests/commandline/test_geoips_config_install.py
 
 Bug Fixes
 =========

--- a/geoips/commandline/geoips_command.py
+++ b/geoips/commandline/geoips_command.py
@@ -7,7 +7,7 @@ Will implement a plethora of commands, but for the meantime, we'll work on
 
 import abc
 import argparse
-from importlib import resources
+from importlib import metadata, resources
 import json
 from os.path import dirname
 from shutil import get_terminal_size
@@ -17,7 +17,6 @@ from tabulate import tabulate
 import yaml
 
 from geoips.commandline.cmd_instructions import cmd_instructions
-from geoips.geoips_utils import get_entry_point_group
 
 
 class PluginPackages:
@@ -38,11 +37,12 @@ class PluginPackages:
         get_plugin_packages() and get_plugin_package_paths() functions.
         """
         self.entrypoints = [
-            ep.value for ep in sorted(get_entry_point_group("geoips.plugin_packages"))
+            ep.value
+            for ep in sorted(metadata.entry_points(group="geoips.plugin_packages"))
         ]
         self.paths = [
             dirname(resources.files(ep.value))
-            for ep in sorted(get_entry_point_group("geoips.plugin_packages"))
+            for ep in sorted(metadata.entry_points(group="geoips.plugin_packages"))
         ]
 
 

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -3,6 +3,7 @@
 Various configuration-based commands for setting up your geoips environment.
 """
 
+import argparse
 from numpy import any
 from os import listdir, environ
 from os.path import abspath, join
@@ -38,6 +39,14 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
             choices=list(test_dataset_dict.keys()),
             help="GeoIPS Test Dataset to Install.",
         )
+        # The following argument has been added in case we want to test the output of
+        # this command without actually installing the real datasets
+        self.parser.add_argument(
+            "--test-mode",
+            action="store_true",
+            default=False,
+            help=argparse.SUPPRESS,
+        )
 
     def __call__(self, args):
         """Run the `geoips config install <test_dataset_name>` command.
@@ -59,7 +68,11 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
             print(
                 f"Installing {test_dataset_name} test dataset. This may take a while..."
             )
-            self.download_extract_test_data(test_dataset_url, self.geoips_testdata_dir)
+            if not args.test_mode:
+                self.download_extract_test_data(
+                    test_dataset_url,
+                    self.geoips_testdata_dir,
+                )
             out_str = f"Test dataset '{test_dataset_name}' has been installed under "
             out_str += f"{self.geoips_testdata_dir}/{test_dataset_name}/"
             print(out_str)

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -2,6 +2,7 @@
 
 import abc
 import contextlib
+from importlib import metadata
 import io
 from numpy import any
 import pytest
@@ -9,7 +10,7 @@ import subprocess
 import sys
 
 from geoips.commandline.commandline_interface import GeoipsCLI
-from geoips.geoips_utils import get_entry_point_group, is_editable
+from geoips.geoips_utils import is_editable
 
 
 gcli = GeoipsCLI()
@@ -64,7 +65,7 @@ class BaseCliTest(abc.ABC):
         """List of names of every installed GeoIPS package."""
         if not hasattr(self, "_plugin_package_names"):
             self._plugin_package_names = [
-                ep.value for ep in get_entry_point_group("geoips.plugin_packages")
+                ep.value for ep in metadata.entry_points(group="geoips.plugin_packages")
             ]
         return self._plugin_package_names
 

--- a/tests/unit_tests/commandline/test_geoips_config_install.py
+++ b/tests/unit_tests/commandline/test_geoips_config_install.py
@@ -22,7 +22,7 @@ class TestGeoipsConfigInstall(BaseCliTest):
             base_args = self._config_install_args
             # add argument lists to install available test datasets
             for test_dataset_name in self.test_datasets:
-                self._cmd_list.append(base_args + [test_dataset_name])
+                self._cmd_list.append(base_args + ["--test-mode", test_dataset_name])
             # Add argument list to retrieve help message
             self._cmd_list.append(base_args + ["-h"])
             # Add argument list with non existent test dataset


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** pass for new/modified functionality
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
No issue; quick fix to make config install unit tests pass faster.

# Testing Instructions
Run ``pytest -v tests/unit_tests/commandline/test_geoips_config_install.py`` without any test datasets installed. Shouldn't install anything but will test for correct output.

# Summary
Previously the ``config install`` unit tests actually installed test datasets if they
were missing. This is completely uneccessary and shouldn't be performed in the unit
tests, only if a user actually wants to install data. To fix this, we've added a hidden
argument to ``config install``, called ``--test-mode``, which will skip the download
portion of the code if specified. While not perfect, this ensures that the unit tests
will run fast and output the correct information.

    modified: geoips/commandline/geoips_config.py
    modified: tests/unit_tests/commandline/test_geoips_config_install.py
