### PR TITLE
Update to use latest instead of versions

### DIFF
--- a/.github/workflows/doc-lint-test.yaml
+++ b/.github/workflows/doc-lint-test.yaml
@@ -234,15 +234,16 @@ jobs:
         run: git config --global --add safe.directory $PWD
       - name: Detect new and modified release files
         run: |
-          update_this_file="$(cat update_this_release_note)"
-          release_notes_dir="$PWD/$(dirname $update_this_file)"
+          #update_this_file="$(cat update_this_release_note)"
+          release_notes_dir="$PWD/docs/source/releases" #/$(dirname $update_this_file)"
           echo "Checking for no edits to the .rst release note in dir $release_notes_dir"
           echo "git -C . diff --name-only --diff-filter=AM remotes/origin/main -- $release_notes_dir/*.rst"
           ret=$(git -C . diff --name-only --diff-filter=AM remotes/origin/main -- $release_notes_dir/*.rst)
           for file in ${ret[@]}; do
               echo "    $file"
           done
-          if [[ "${ret}" != *"$update_this_file"* ]]; then
+          # if [[ "${ret}" != *"$update_this_file"* ]]; then
+          if [[ "${ret}" != *"latest.rst"* ]]; then
               echo "PASSED"
           else
               echo "FAILED: Release note changes detected"
@@ -279,10 +280,10 @@ jobs:
       - name: Detect new and modified release files
         run: |
           echo "Checking for new and modified release note files in $PWD"
-          update_this_file="$(cat update_this_release_note)"
-          release_notes_dir="$(dirname $update_this_file)/$(basename $update_this_file .rst)"
+          #update_this_file="$(cat update_this_release_note)"
+          release_notes_dir="$PWD/docs/source/releases/latest" #/$(dirname $update_this_file)"
           ls $release_notes_dir
-          current_release_note=`cat update_this_release_note`
+          #current_release_note=`cat update_this_release_note`
           echo "git -C . diff --name-only --diff-filter=AM remotes/origin/main -- $release_notes_dir/*.yaml"
           ret=$(git -C . diff --name-only --diff-filter=AM remotes/origin/main -- $release_notes_dir/*.yaml)
           echo "Release note files modified this PR:"
@@ -325,13 +326,21 @@ jobs:
       - name: Build release notes from yaml files
         id: release-note-generator
         run: |
-          update_this_file="$(cat $BASE_GEOIPS_PATH/update_this_release_note)"
-          release_notes_dir="$(dirname $update_this_file)/$(basename $update_this_file .rst)"
-          release_version="$(basename $update_this_file .rst)"
+          # update_this_file="$(cat $BASE_GEOIPS_PATH/update_this_release_note)"
+          # release_notes_dir="$(dirname $update_this_file)/$(basename $update_this_file .rst)"
+          release_notes_dir="$PWD/docs/source/releases" #/$(dirname $update_this_file)"
+          #release_version="$(basename $update_this_file .rst)"
+          release_version="latest"
           echo "Running brassy on directory: $release_notes_dir"
           brassy --release-version $release_version --no-rich --output-file $update_this_file $release_notes_dir
           echo "release_note_file=$update_this_file" >> $GITHUB_OUTPUT
-          cat $update_this_file
+          if [ $release_version = "latest" ]; then
+             release_index="docs/source/releases/index.rst"
+             sed -i -e 's/*************/.. toctree::|    :maxdepth: 1|    |    latest.rst/g' $release_index | tr '|' '\n' > $release_index
+             cat $release_index
+          else
+            echo "try again"
+          fi
       - name: Pinken release note
         run: pink ${{ steps.release-note-generator.outputs.release_note_file }}
 

--- a/.github/workflows/doc-lint-test.yaml
+++ b/.github/workflows/doc-lint-test.yaml
@@ -329,6 +329,7 @@ jobs:
           # update_this_file="$(cat $BASE_GEOIPS_PATH/update_this_release_note)"
           # release_notes_dir="$(dirname $update_this_file)/$(basename $update_this_file .rst)"
           release_notes_dir="$PWD/docs/source/releases" #/$(dirname $update_this_file)"
+          update_this_file="$PWD/docs/source/releases/latest.rst"
           #release_version="$(basename $update_this_file .rst)"
           release_version="latest"
           echo "Running brassy on directory: $release_notes_dir"

--- a/.github/workflows/doc-lint-test.yaml
+++ b/.github/workflows/doc-lint-test.yaml
@@ -335,13 +335,6 @@ jobs:
           echo "Running brassy on directory: $release_notes_dir"
           brassy --release-version $release_version --no-rich --output-file $update_this_file $release_notes_dir
           echo "release_note_file=$update_this_file" >> $GITHUB_OUTPUT
-          if [ $release_version = "latest" ]; then
-             release_index="docs/source/releases/index.rst"
-             sed -i -e 's/*************/.. toctree::|    :maxdepth: 1|    |    latest.rst/g' $release_index | tr '|' '\n' > $release_index
-             cat $release_index
-          else
-            echo "try again"
-          fi
       - name: Pinken release note
         run: pink ${{ steps.release-note-generator.outputs.release_note_file }}
 

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,9 +5,16 @@
 
 .. _release_notes:
 
-*************
 Release Notes
 *************
+
+Latest (version on cutting edge of git)
+---------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   latest
 
 Version 1.14
 ------------
@@ -43,7 +50,6 @@ issues with create_plugin_registries, ATMS platform names, and pytest dependenci
    v1_12_2a0
    v1_12_1
    v1_12_0
-
 
 Version 1.11
 ------------

--- a/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
+++ b/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
@@ -1,5 +1,5 @@
 continuous_integration:
-  description: |
+- description: |
     Moved the yaml release files from ``docs/source/release/v(version number)/*`` to ``docs/source/release/latest/*``, which now builds to ``latest.rst``.
     Added ``latest.rst`` because brassy does not automatically build .rst files at the moment. 
     Ideally, brassy would create ``latest.rst``, which could be pulled down and built into the docs locally.

--- a/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
+++ b/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
@@ -1,0 +1,15 @@
+continuous integration:
+- description: 'test'
+  files:
+    added:
+    - ''
+    deleted:
+    - ''
+    modified:
+    - ''
+    moved:
+    - ''
+  related-issue:
+    number: 0
+    repo_url: ''
+  title: 'test'

--- a/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
+++ b/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
@@ -1,15 +1,18 @@
 continuous integration:
-- description: 'test'
+- description: |
+Moved the yaml release files from ``docs/source/release/v(version number)/*`` to ``docs/source/release/latest/*``, which now builds to ``latest.rst``.
+Added ``latest.rst`` because brassy does not automatically build .rst files at the moment. 
+Ideally, brassy would create ``latest.rst``, which could be pulled down and built into the docs locally.
+Without ``latest.rst`` the docs will not build. So adding a blank file serves as a placeholder until the CI automatically builds and commits a ``latest.rst`` file.
+Added latest to ``/docs/source/release/index.rst`` so docs build.
+The release note not edited check SHOULD NOT PASS, because.... it was edited 😄
   files:
     added:
-    - ''
-    deleted:
-    - ''
+    - 'docs/source/releases/latest.rst'
+    - 'docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml'
     modified:
-    - ''
-    moved:
-    - ''
+    - '.github/workflows/doc-lint-test.yaml'
+    - 'docs/source/releases/index.rst'
   related-issue:
-    number: 0
-    repo_url: ''
-  title: 'test'
+    number: 687
+  title: 'Change release note .yaml folder from version to latest'

--- a/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
+++ b/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
@@ -1,18 +1,18 @@
-continuous integration:
-- description: |
-Moved the yaml release files from ``docs/source/release/v(version number)/*`` to ``docs/source/release/latest/*``, which now builds to ``latest.rst``.
-Added ``latest.rst`` because brassy does not automatically build .rst files at the moment. 
-Ideally, brassy would create ``latest.rst``, which could be pulled down and built into the docs locally.
-Without ``latest.rst`` the docs will not build. So adding a blank file serves as a placeholder until the CI automatically builds and commits a ``latest.rst`` file.
-Added latest to ``/docs/source/release/index.rst`` so docs build.
-The release note not edited check SHOULD NOT PASS, because.... it was edited 😄
+continuous_integration:
+  description: |
+    Moved the yaml release files from ``docs/source/release/v(version number)/*`` to ``docs/source/release/latest/*``, which now builds to ``latest.rst``.
+    Added ``latest.rst`` because brassy does not automatically build .rst files at the moment. 
+    Ideally, brassy would create ``latest.rst``, which could be pulled down and built into the docs locally.
+    Without ``latest.rst`` the docs will not build. So adding a blank file serves as a placeholder until the CI automatically builds and commits a ``latest.rst`` file.
+    Added latest to ``/docs/source/release/index.rst`` so docs build.
+    The release note not edited check SHOULD NOT PASS, because.... it was edited 😄
   files:
     added:
-    - 'docs/source/releases/latest.rst'
-    - 'docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml'
+      - 'docs/source/releases/latest.rst'
+      - 'docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml'
     modified:
-    - '.github/workflows/doc-lint-test.yaml'
-    - 'docs/source/releases/index.rst'
-  related-issue:
+      - '.github/workflows/doc-lint-test.yaml'
+      - 'docs/source/releases/index.rst'
+  related_issue:
     number: 687
   title: 'Change release note .yaml folder from version to latest'

--- a/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
+++ b/docs/source/releases/latest/687-change-release-note-yaml-folder-from-version-to-latest.yaml
@@ -13,6 +13,6 @@ continuous_integration:
     modified:
       - '.github/workflows/doc-lint-test.yaml'
       - 'docs/source/releases/index.rst'
-  related_issue:
+  related-issue:
     number: 687
   title: 'Change release note .yaml folder from version to latest'


### PR DESCRIPTION
Moved the yaml release files from `docs/source/release/v(version number)/*` to `docs/source/release/latest/*`, which now builds to `latest.rst`.

Added `latest.rst` because brassy does not automatically build .rst file at the moment. Ideally, brassy would create `latest.rst`, which could be pulled down and built into the docs locally. Without latest.rst the docs will not build. So adding a blank file serves as a placeholder until the CI automatically builds _and_ commits a latest.rst file. 

Added `latest` to `/docs/source/release/index.rst` so docs build.

The release note not edited check SHOULD NOT PASS, because.... it was edited 😄 

## Relevant XKCD:

CI be like:
![image](https://github.com/user-attachments/assets/1dd9ccf9-ffad-477f-8aea-0280b0755852)
