### PR TITLE
WORKSHOP BUG FIX Updating pytest_long to be called via all_test_data

### DIFF
--- a/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-3.yaml
+++ b/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-3.yaml
@@ -7,4 +7,4 @@ testing:
   related-issue:
     number: 666
     repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
-  title: 'Turn off pytest_long temporarily from check_code.sh'
+  title: 'Call pytest_long from check_code.sh via all_test_data vs all'

--- a/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-3.yaml
+++ b/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-3.yaml
@@ -1,0 +1,10 @@
+testing:
+- description: |
+    Make pytest_long called via "all_test_data" vs "all"
+  files:
+    modified:
+    - 'tests/utils/check_code.sh'
+  related-issue:
+    number: 666
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
+  title: 'Turn off pytest_long temporarily from check_code.sh'

--- a/tests/utils/check_code.sh
+++ b/tests/utils/check_code.sh
@@ -176,7 +176,7 @@ if [[ "$test" == "pytest_short" || "$test" == "all" ]]; then
     fi
     echo "TEST COMPLETE pytest_short"
 fi
-if [[ "$test" == "pytest_long" || "$test" == "all" ]]; then
+if [[ "$test" == "pytest_long" || "$test" == "all_test_data" ]]; then
     echo ""
     echo "CALLING TEST:"
 


### PR DESCRIPTION
Since this test requires all test data being cloned locally, explicitly request via the "all_test_data" argument to tests/utils/check_code.sh.  Explicitly call ONLY if the full_install has happened.

Ensure this test does not cause unit tests to fail when all test data repos have not been installed.

Required to fix GEOIPS/geoips#666