### PR TITLE
WORKSHOP BUG FIX pip install package from build_docs.sh if it is not already installed

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -69,6 +69,13 @@ if [[ ! -d "$docbasepath/$pkgname" ]]; then
     exit 1
 fi
 echo "package path=$docbasepath/$pkgname"
+retval=`python -c "import $pkgname"`
+if [[ "$retval" != "0" ]]; then
+    echo "***************************************************************************"
+    echo "ERROR: Package $pkgname is not installed"
+    echo "For now, pip installing $docbasepath, in future will fail"
+    pip install -e $docbasepath
+fi
 
 pdf_required="True"
 html_required="True"

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -75,6 +75,11 @@ if [[ "$retval" != "0" ]]; then
     echo "ERROR: Package $pkgname is not installed"
     echo "For now, pip installing $docbasepath, in future will fail"
     pip install -e $docbasepath
+    echo "***************************************************************************"
+else
+    echo "***************************************************************************"
+    echo "Package $pkgname is already installed!"
+    echo "***************************************************************************"
 fi
 
 pdf_required="True"

--- a/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-5.yaml
+++ b/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-5.yaml
@@ -1,0 +1,14 @@
+bug fix:
+- description: |
+    Add pip install of plugin package to build_docs.sh to ensure package is
+    installed before attempting to build API docs.
+
+    Currently, build_docs.sh checks is the current package is installed, and if not
+    it pip installs it.  In the future will likely just error, and assume the
+    package is installed already if attempting to build documentation.
+  files:
+    modified:
+    - 'docs/build_docs.sh'
+  related-issue:
+    number: 666
+  title: 'Add pip install of plugin package to build_docs.sh'


### PR DESCRIPTION
This will ensure the plugin packages pass CI, since currently the build docs action does NOT pip install the package before calling build_docs.sh.

In the future we may not want to  support this, but just exit 1 if the package is not installed.  But for now, check if the package is installed, and pip install -e it if it is not installed already.