### PR TITLE
WORKSHOP BUG FIX: Ensure return value correctly captured from import package within build_docs.sh

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -170,7 +170,7 @@ fi
 # Release notes are ALWAYS written in the "latest" folder, whether we are
 # producing the generic "latest.rst" release note, or the specific
 # vX_Y_Z.rst release note for an actual version release.
-current_release_notes=`ls docs/source/releases/latest/*`
+current_release_notes=`ls $docbasepath/docs/source/releases/latest/*`
 # If we found any current YAML release notes, we need to generate the
 # release RST file, and update index.rst with the current release version.
 if [[ "$current_release_notes" != "" ]]; then

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -71,7 +71,9 @@ fi
 echo "package path=$docbasepath/$pkgname"
 # Attempt to import the current package.  If the import fails, we know
 # the doc build will fail, so pip install before attempting to build.
-retval=`python -c "import $pkgname"`
+which python
+python -c "import $pkgname"
+retval=$?
 if [[ "$retval" != "0" ]]; then
     # Likely in the future we will just exit 1 here if package is not installed.
     # For now, pip install to ensure GitHub Actions pass when plugin package

--- a/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-6.yaml
+++ b/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-6.yaml
@@ -1,0 +1,11 @@
+bug fix:
+- description: |
+    Ensure we capture return value from import mypkgname correctly
+    when determining if plugin package is installed. Previously
+    always failed, so always attempted to reinstall the plugin package.
+  files:
+    modified:
+    - 'docs/build_docs.sh'
+  related-issue:
+    number: 666
+  title: 'Ensure return value correctly captured when importing package in build_docs.sh'


### PR DESCRIPTION
Required to fix GEOIPS/geoips#666

Was reinstalling every single time... Because I did not actually capture the return value...