### PR TITLE
WORKSHOP BUG FIX: Revert docs/source/releases/index.rst after build_docs.sh

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -166,6 +166,15 @@ if [[ -d $docbasepath/build/sphinx ]]; then
     echo "***"
     echo ""
 fi
+git_status_index=`git -C $docbasepath status docs/source/releases/index.rst`
+if [[ "$git_status_index" == *"docs/source/releases/index.rst"* ]]; then
+    echo "***************************************************************************"
+    echo "ERROR: Do not modify docs/source/releases/index.rst directly"
+    echo "Auto-generated within build_docs.sh using brassy."
+    echo "Please revert your changes and try again."
+    echo "***************************************************************************"
+    exit 1
+fi
 
 # Release notes are ALWAYS written in the "latest" folder, whether we are
 # producing the generic "latest.rst" release note, or the specific
@@ -315,6 +324,9 @@ if [[ "$pdf_required" == "True" ]]; then
         echo "  try 'conda install latexcodec' if in anaconda"
         echo "  or re-run with html_only to only build"
         echo "  html documentation."
+        echo ""
+        echo "Reverting $docbasepath/docs/source/releases/index.rst"
+        git checkout -C $docbasepath docs/source/releases/index.rst
         exit 1
     fi
     # do not include release notes in the PDF
@@ -406,6 +418,11 @@ if [[ "$html_required" == "True" ]]; then
         cp -rp $docbasepath/build/sphinx/html/ $GEOIPS_DOCSDIR
     fi
 fi
+
+echo ""
+# git -C $docbasepath status docs/source/releases/index.rst
+echo "Reverting $docbasepath/docs/source/releases/index.rst"
+git -C $docbasepath checkout docs/source/releases/index.rst
 
 date -u
 echo "***"

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -166,6 +166,8 @@ if [[ -d $docbasepath/build/sphinx ]]; then
     echo "***"
     echo ""
 fi
+# Since we revert index.rst at the end of this script, make sure the
+# user does not have any local modifications before starting.
 git_status_index=`git -C $docbasepath status docs/source/releases/index.rst`
 if [[ "$git_status_index" == *"docs/source/releases/index.rst"* ]]; then
     echo "***************************************************************************"
@@ -420,10 +422,14 @@ if [[ "$html_required" == "True" ]]; then
 fi
 
 echo ""
+echo "***"
+# docs/source/releases/index.rst should only be auto-generated,
+# so revert the changes we just made.  Note we checked at the beginning
+# if this was already modified, and exited if there were any local modifications,
+# to ensure the user had not manually modified it.
 # git -C $docbasepath status docs/source/releases/index.rst
 echo "Reverting $docbasepath/docs/source/releases/index.rst"
 git -C $docbasepath checkout docs/source/releases/index.rst
-
 date -u
 echo "***"
 echo ""

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -328,7 +328,7 @@ if [[ "$pdf_required" == "True" ]]; then
         echo "  html documentation."
         echo ""
         echo "Reverting $docbasepath/docs/source/releases/index.rst"
-        git checkout -C $docbasepath docs/source/releases/index.rst
+        git -C $docbasepath checkout docs/source/releases/index.rst
         exit 1
     fi
     # do not include release notes in the PDF

--- a/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-7.yaml
+++ b/docs/source/releases/latest/666-final-bug-fixes-prior-to-workshop-7.yaml
@@ -1,0 +1,11 @@
+bug fix:
+- description: |
+    Revert index.rst back to original contents after build_docs.sh completes.
+    Since the intent is for index.rst to always be auto updated, and never manually
+    edited, we will ensure all changes are reverted after build_docs completes.
+  files:
+    modified:
+    - 'docs/build_docs.sh'
+  related-issue:
+    number: 666
+  title: 'Revert docs/source/releases/index.rst back after build_docs.sh'


### PR DESCRIPTION
Required to fix NRLMMD-GEOIPS/geoips#666

```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   docs/source/releases/index.rst

Resulted in:

***************************************************************************
ERROR: Do not modify docs/source/releases/index.rst directly
Auto-generated within build_docs.sh using brassy.
Please revert your changes and try again.
***************************************************************************
```

Note Jeremy points out this is not fool proof - if there are errors some random spot in build_docs.sh, then docs/source/releases/index.rst won't be reverted.  But that's ok, it doesn't really hurt anything.  This is really just for convenience so we (read: I) don't keep accidentally checking in index.rst.