### PR TITLE
CLI ``geoips describe data``

### DIFF
--- a/geoips/commandline/ancillary_info/cmd_instructions.yaml
+++ b/geoips/commandline/ancillary_info/cmd_instructions.yaml
@@ -116,6 +116,19 @@ instructions:
   #     - Interface Name
   #     - Interface Type
   #     - Supported Families
+  geoips_describe_data:
+    help_str: |
+      Retrieve a description of data files in the manner shown below. See output_info
+      for each datum provided when this command is called. For a listing of available
+      GeoIPS readers, run: `geoips list readers`.
+    usage_str: |
+      To use, type `geoips describe data <reader_name> <file_paths>`, where
+      <reader_name> is a valid GeoIPS reader plugin name.
+    output_info:
+      - Metadata
+      - Variables
+      - Composite Datasets
+      - Source Names
   geoips_describe_package:
     help_str: |
       Retrieve the appropriate GeoIPS Package alongside descriptive information of

--- a/geoips/commandline/commandline_interface.py
+++ b/geoips/commandline/commandline_interface.py
@@ -7,6 +7,7 @@ Will implement a plethora of commands, but for the meantime, we'll work on
 'geoips list' and 'geoips run'
 """
 
+from importlib.metadata import version
 from os.path import basename
 import sys
 
@@ -85,7 +86,12 @@ class GeoipsCLI(GeoipsCommand):
 
         # self.LOG = getattr(LOG, self.GEOIPS_ARGS.log_level)
         # self.LOG("LOG LEVEL = {self.GEOIPS_ARGS.log_level}")
-        if hasattr(self.GEOIPS_ARGS, "exe_command"):
+        if self.GEOIPS_ARGS.version:
+            # Print out the current installed version of GeoIPS
+            # This will only work when 'geoips --version' is called, and this is by
+            # design.
+            print(f"\nGeoIPS Version = {version('geoips')}")
+        elif hasattr(self.GEOIPS_ARGS, "exe_command"):
             # The command called is executable (child of GeoipsExecutableCommand)
             # so execute that command now.
             self.GEOIPS_ARGS.exe_command(self.GEOIPS_ARGS)

--- a/geoips/commandline/geoips_command.py
+++ b/geoips/commandline/geoips_command.py
@@ -203,6 +203,13 @@ class GeoipsCommand(abc.ABC):
                 parents=[ParentParsers.geoips_parser],
                 formatter_class=argparse.RawTextHelpFormatter,
             )
+            self.parser.add_argument(
+                "-v",
+                "--version",
+                default=False,
+                action="store_true",
+                help="Specify the version number of your current GeoIPS installation.",
+            )
             self.combined_name = self.name
 
         self.add_subparsers()

--- a/geoips/commandline/geoips_command.py
+++ b/geoips/commandline/geoips_command.py
@@ -322,7 +322,7 @@ class GeoipsExecutableCommand(GeoipsCommand):
         """
         pass
 
-    def _output_dictionary_highlighted(self, dict_entry):
+    def _output_dictionary_highlighted(self, dict_entry, new_line=True):
         """Print to terminal the yaml-dumped dictionary of a certain interface/plugin.
 
         Color the key, value pairs cyan, yellow to highlight the text in a human
@@ -332,9 +332,12 @@ class GeoipsExecutableCommand(GeoipsCommand):
         ----------
         plugin_entry: dict
             - The dictionary of info for a certain plugin in the plugin registry.
+        new_line: bool
+            - Whether or not we should print a new line as soon as this is called
         """
         yaml_text = yaml.dump(dict_entry, default_flow_style=False)
-        print()
+        if new_line:
+            print()
         for line in yaml_text.split("\n"):
             # Color the keys in cyan and values in yellow
             if ":" in line:
@@ -348,7 +351,7 @@ class GeoipsExecutableCommand(GeoipsCommand):
                 formatted_line += Fore.YELLOW + value + Style.RESET_ALL
                 print(formatted_line)
             else:
-                formatted_line = "\t" + Fore.YELLOW + line + Style.RESET_ALL
+                formatted_line = "  " + Fore.YELLOW + line + Style.RESET_ALL
                 print(formatted_line)
 
     def _get_registry_by_interface_and_package(self, interface, package_name):

--- a/geoips/commandline/geoips_describe.py
+++ b/geoips/commandline/geoips_describe.py
@@ -453,7 +453,7 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
             self._output_dictionary_highlighted(data_entry)
 
     def _output_dictionary_highlighted(self, in_dict, indent=0):
-        """Output the provided in_dct (xarray object vals / attrs) with color.
+        """Output the provided in_dict (xarray object vals / attrs) with color.
 
         This will be a yaml-based format highlighted as <key>: <value>, recursively
         where appicable.
@@ -484,7 +484,7 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
             elif isinstance(value, list):
                 print(formatted_line)
                 formatted_line = "  " * (indent + 1)
-                for item in value:
+                for item in sorted(value):
                     # Recursively call this function if the instance of item is a
                     # dictionary. This way we can indent the dictionary in a structured
                     # manner to see what information belongs to each key.

--- a/geoips/commandline/geoips_describe.py
+++ b/geoips/commandline/geoips_describe.py
@@ -405,12 +405,13 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
             if isinstance(value, dict):
                 formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL}"
                 print(formatted_line)
-                self._output_dictionary_highlighted(curr_dict, indent=indent+1)
+                self._output_dictionary_highlighted(curr_dict, indent=indent + 1)
             else:
                 value = str(value).replace("\n", "")
                 formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL} "
                 formatted_line += f"{Fore.YELLOW }{value}{Style.RESET_ALL}"
                 print(formatted_line)
+
 
 class GeoipsDescribePackage(GeoipsExecutableCommand):
     """Describe Command which retrieves information about a certain GeoIPS Package.

--- a/geoips/commandline/geoips_describe.py
+++ b/geoips/commandline/geoips_describe.py
@@ -361,14 +361,14 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         )
         self.parser.add_argument(
             "-md",
-            "--metadata_only",
+            "--metadata-only",
             default=False,
             action="store_true",
             help="Whether or not we just want metadata returned.",
         )
         self.parser.add_argument(
             "-qc",
-            "--quality_check",
+            "--quality-check",
             default=False,
             action="store_true",
             help=(
@@ -388,9 +388,10 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         Printed to Terminal
         -------------------
         yaml-based output: dict
-            - METADATA
-            - Variables
-            - Composite Datasets
+            - Datasets
+            - Coords
+            - Dims
+            - Metadata
             - Source Names
 
         Parameters
@@ -419,23 +420,23 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         # that is not an error nor relevant to the CLI
         with suppress_output():
             file_md = reader_plugin(rdr_fpaths, metadata_only=True)["METADATA"].attrs
-        data_entry = {"METADATA": file_md}
+        data_entry = {"Metadata": file_md}
 
-        if not args.metadata_only and not args.quality_check:
+        if not args.metadata_only:
             # Grab additional information about the files' coords, dims, and vars
             reader_registry = interfaces.readers.registered_module_based_plugins[
                 "readers"
             ][reader_name]
-            # Suppress the output of running a reader as they sometimes spit out output
+            # Suppress the output of running a reade r as they sometimes spit out output
             # that is not an error nor relevant to the CLI
             with suppress_output():
                 xobjs = reader_plugin(
                     rdr_fpaths, metadata_only=False, area_def=area_def
                 )
-            file_info, roi = self._get_coords_dims_vars(xobjs)
+            file_info, roi = self._get_coords_dims_datasets(xobjs)
             # # Merge file_info dictionary into data_entry dictionary
             data_entry.update(file_info)
-            data_entry["METADATA"]["interpolation_radius_of_influence"] = roi
+            data_entry["Metadata"]["interpolation_radius_of_influence"] = roi
             data_entry["Source Names"] = reader_registry["source_names"]
 
         if args.quality_check:
@@ -506,8 +507,8 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
                 formatted_line += f"{Fore.YELLOW }{value}{Style.RESET_ALL}"
                 print(formatted_line)
 
-    def _get_coords_dims_vars(self, xobjs):
-        """Extract dims, coords, and vars for the incoming xarray object[s].
+    def _get_coords_dims_datasets(self, xobjs):
+        """Extract dims, coords, and datasets for the incoming xarray object[s].
 
         Metadata can be collected from the file paths using
         <reader_plugin>(fpaths, metadata_only=True).
@@ -519,9 +520,9 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         Returns
         -------
         data_dict: dict
-            - A dictionary whose keys include ["coords", "dims", "variables"], of which
+            - A dictionary whose keys include ["coords", "dims", "datasets"], of which
               the values corresponding to those keys are information about each
-              coordinate, dimension, and variable.
+              coordinate, dimension, and dataset.
         """
         self.variables = set([])
         self.coords = {}
@@ -542,7 +543,7 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         data_dict = {
             "Coordinates": self.coords,
             "Dimensions": self.dims,
-            "Variables": list(self.variables),
+            "Datasets": list(self.variables),
         }
         return data_dict, self.roi
 

--- a/geoips/commandline/geoips_describe.py
+++ b/geoips/commandline/geoips_describe.py
@@ -374,46 +374,43 @@ class GeoipsDescribeData(GeoipsExecutableCommand):
         reader_registry = interfaces.readers.registered_module_based_plugins["readers"][
             reader_name
         ]
-        data_entry = {
-            "Variables": reader_registry["ALL_CHANS"],
-            "Composite_Datasets": reader_registry["ALL_DATASETS"],
-            "Source Names": reader_registry["source_names"],
-        }
-        self.output_metadata_highlighted(file_md)
-        self._output_dictionary_highlighted(data_entry, new_line=False)
+        data_entry = interfaces.readers.quick_view(rdr_fpaths)
+        data_entry["METADATA"] = file_md
+        data_entry["Source Names"] = reader_registry["source_names"]
+        self._output_dictionary_highlighted(data_entry)
 
-    def output_metadata_highlighted(self, md_dict, indent=0):
-        """Output the provided md_dict (xarray object attributes) with color.
+    def _output_dictionary_highlighted(self, in_dict, indent=0):
+        """Output the provided in_dct (xarray object vals / attrs) with color.
 
         This will be a yaml-based format highlighted as <key>: <value>, recursively
         where appicable.
 
         Parameters
         ----------
-        md_dict: dict
-            - Dictionary of metadata coming from the files provided to this class'
-              __call__ function.
+        in_dict: dict
+            - Dictionary of xarray-based information coming from the files provided to
+              this class' __call__ function.
         indent: int
             - The indentation index of the current md_dict.
         """
-        if indent == 0:
-            # Print a top level METADATA key
-            print(f"{Fore.CYAN}METADATA:{Style.RESET_ALL}")
-            self.output_metadata_highlighted(md_dict, indent=indent+1)
-        else:
-            # Loop through and print each attribute of the metadata provided
-            for key, value in md_dict.items():
-                curr_dict = md_dict[key]
-                formatted_line = "  " * indent
-                if isinstance(value, dict):
-                    formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL}"
-                    print(formatted_line)
-                    self.output_metadata_highlighted(curr_dict, indent=indent+1)
-                else:
-                    value = str(value).replace("\n", "")
-                    formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL} "
-                    formatted_line += f"{Fore.YELLOW }{value}{Style.RESET_ALL}"
-                    print(formatted_line)
+        # if indent == 0:
+        #     # Print a top level METADATA key
+        #     print(f"{Fore.CYAN}METADATA:{Style.RESET_ALL}")
+        #     self._output_dictionary_highlighted(in_dict, indent=indent+1)
+        # else:
+        # Loop through and print each attribute of the metadata provided
+        for key, value in in_dict.items():
+            curr_dict = in_dict[key]
+            formatted_line = "  " * indent
+            if isinstance(value, dict):
+                formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL}"
+                print(formatted_line)
+                self._output_dictionary_highlighted(curr_dict, indent=indent+1)
+            else:
+                value = str(value).replace("\n", "")
+                formatted_line += f"{Fore.CYAN}{key}:{Style.RESET_ALL} "
+                formatted_line += f"{Fore.YELLOW }{value}{Style.RESET_ALL}"
+                print(formatted_line)
 
 class GeoipsDescribePackage(GeoipsExecutableCommand):
     """Describe Command which retrieves information about a certain GeoIPS Package.

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -860,22 +860,27 @@ def add_module_plugin(package, relpath, plugins):
         "relpath": relpath,
     }
     if interface_name == "readers":
-        if hasattr(module, "source_names"):
-            plugins[interface_name][name]["source_names"] = module.source_names
-        else:
-            warnings.warn(
-                (
-                    f"Plugin package '{package}'s reader"
-                    f" plugin '{name}' is using a deprecated source_names "
-                    "implementation. Please add a module-level 'source_names' "
-                    "attribute to this plugin and re-run "
-                    "'create_plugin_registries'. This will be fully deprecated "
-                    "when GeoIPS v2.0.0 is released."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            plugins[interface_name][name]["source_names"] = ["N/A"]
+        for expected_attr in ["ALL_CHANS", "ALL_DATASETS", "source_names"]:
+            if hasattr(module, expected_attr):
+                plugins[interface_name][name][expected_attr] = getattr(
+                    module,
+                    expected_attr,
+                )
+            else:
+                warnings.warn(
+                    (
+                        f"Plugin package '{package}'s reader"
+                        f" plugin '{name}' is using a deprecated {expected_attr} "
+                        f"implementation. Please add a module-level '{expected_attr}' "
+                        "attribute to this plugin and re-run "
+                        "'create_plugin_registries'. This will be fully deprecated "
+                        "when GeoIPS v2.0.0 is released."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                plugins[interface_name][name][expected_attr] = ["N/A"]
+
     del module
     # Return the final error message - an exception will be raised at the very
     # end after collecting and reporting on all errors if there were any errors

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -860,7 +860,9 @@ def add_module_plugin(package, relpath, plugins):
         "relpath": relpath,
     }
     if interface_name == "readers":
-        for expected_attr in ["ALL_CHANS", "ALL_DATASETS", "source_names"]:
+        # This is a for loop in case we add new attributes that we'll eventually require
+        # being added to reader modules
+        for expected_attr in ["source_names"]:
             if hasattr(module, expected_attr):
                 plugins[interface_name][name][expected_attr] = getattr(
                     module,

--- a/geoips/interfaces/module_based/readers.py
+++ b/geoips/interfaces/module_based/readers.py
@@ -3,6 +3,8 @@
 
 """Readers interface module."""
 
+from xarray import open_dataset
+
 from geoips.interfaces.base import BaseModuleInterface
 
 
@@ -16,8 +18,50 @@ class ReadersInterface(BaseModuleInterface):
     name = "readers"
     required_args = {"standard": ["fnames"]}
     required_kwargs = {
-        "standard": ["metadata_only", "chans", "area_def", "self_register"]
+        "standard": [
+            "metadata_only",
+            "chans",
+            "area_def",
+            "self_register",
+        ],
     }
+
+    def quick_view(self, fpaths):
+        """Quickly extract dims, coords, and vars for the incoming files.
+
+        Do so using xarray.open_dataset(fpath, chunks=None) to view the incoming file
+        without actually loading its data into memory. This is used for the CLI command
+        'geoips describe data'.
+
+        Metadata can be collected from the file paths using
+        <reader_plugin>(fpaths, metadata_only=True).
+
+        Parameters
+        ----------
+        fpaths: list[str]
+            - A list of absolute file paths to the incoming data.
+
+        Returns
+        -------
+        data_dict: dict
+            - A dictionary whose keys include ["coords", "dims", "variables"], of which
+              the values corresponding to those keys are information about each
+              coordinate, dimension, and variable.
+        """
+        variables = {}
+        coords = {}
+        dims = {}
+        for fpath in fpaths:
+            ds = open_dataset(fpath, chunks=None)
+            for dim_key in ds.dims:
+                dims[dim_key] = ds.dims[dim_key]
+            for coord_key in ds.coords:
+                coords[coord_key] = ds.coords[coord_key].attrs["long_name"]
+            for var_key in ds.variables:
+                variables[var_key] = ds.variables[var_key].attrs
+
+        data_dict = {"Coordinates": coords, "Dimensions": dims, "Variables": variables}
+        return data_dict
 
 
 readers = ReadersInterface()

--- a/geoips/interfaces/module_based/readers.py
+++ b/geoips/interfaces/module_based/readers.py
@@ -3,7 +3,147 @@
 
 """Readers interface module."""
 
-from geoips.interfaces.base import BaseModuleInterface
+import logging
+
+from geoips.interfaces.base import BaseModuleInterface, BaseModulePlugin
+
+LOG = logging.getLogger(__name__)
+
+
+class BaseReadersPlugin(BaseModulePlugin):
+    """Core class for all reader plugins.
+
+    Includes shared attributes and methods which will be used to validate the output
+    of your reader plugin.
+    """
+
+    xr_std_vars = set(["latitude", "longitude"])
+    xr_std_md = set(
+        [
+            "source_name",
+            "platform_name",
+            "data_provider",
+            "start_datetime",
+            "end_datetime",
+            "interpolation_radius_of_influence",
+        ]
+    )
+
+    def _get_coords_dims_datasets_md(self, xobjs):
+        """Extract dims, coords, datasets, and metadata for the incoming xobj[s].
+
+        Parameters
+        ----------
+        xobjs: xarray object (xobj) or dict of xobjs
+            - Incoming xarray objects from the current reader
+
+        Returns
+        -------
+        data_dict: dict
+            - A dictionary whose keys include ["coords", "dims", "variables"], of which
+              the values corresponding to those keys are information about each
+              coordinate, dimension, and variable.
+        """
+        self.variables = set([])
+        self.coords = {}
+        self.dims = {}
+        self.metadata = {}
+
+        if isinstance(xobjs, dict):
+            # If xobjs is a dictionary of xarray objects, then loop over each key
+            for key in xobjs:
+                if key.lower() == "metadata":
+                    md = True
+                else:
+                    md = False
+                self._extract_data_single_xobj(xobjs[key], md=md)
+        else:
+            # Otherwise extract coords, dims, variables, and metadata from the provided
+            # xarray object
+            self._extract_data_single_xobj(xobjs, md=True)
+
+        data_dict = {
+            "Datasets": list(self.variables),
+            "Coordinates": self.coords,
+            "Dimensions": self.dims,
+            "Metadata": self.metadata,
+        }
+        return data_dict
+
+    def _extract_data_single_xobj(self, xobj, md):
+        """Extract dims, coords, Datasets, and metadata for the incoming xobj[s].
+
+        Metadata can be collected from the file paths using
+        <reader_plugin>(fpaths, metadata_only=True).
+
+        Parameters
+        ----------
+        xobj: dict[xobj] or xobj
+            - Either a single xarray object or a dict of xarray objects
+        md: bool
+            - Whether or not the provided xobj comes from the 'METADATA' xobj
+        """
+        for dim_key in xobj.dims:
+            self.dims[dim_key] = xobj.dims[dim_key]
+        for coord_key in xobj.coords:
+            if xobj.coords[coord_key].attrs.get("long_name"):
+                self.coords[coord_key] = xobj.coords[coord_key].attrs["long_name"]
+            else:
+                self.coords[coord_key] = coord_key
+        for var_key in xobj.variables:
+            self.variables.add(var_key)
+        if md:
+            for md_key in xobj.attrs:
+                if md_key.lower() == "file_metadata":
+                    continue
+                self.metadata[md_key] = xobj.attrs[md_key]
+
+    def validate_output(self, xobjs):
+        """Ensure the output of the reader plugin adheres to GeoIPS xarray standards.
+
+        Match the data and metadata included in xobjs against required variables and
+        required metadata for each reader.
+
+        Parameters
+        ----------
+        xobjs: xarray object (xobj) or dict of xobjs
+            - Incoming xarray objects from the current reader
+
+        Returns
+        -------
+        valid_output: bool
+            - Whether or not the information included in xobjs has all of the required
+              metadata and variables.
+        """
+        xinfo_dict = self._get_coords_dims_datasets_md(xobjs)
+
+        found_md = set(xinfo_dict["Metadata"].keys())
+        found_vars = set(xinfo_dict["Datasets"])
+        diff_md = self.xr_std_md.difference(found_md)
+        diff_vars = self.xr_std_vars.difference(found_vars)
+
+        missing_md = (
+            f"Missing required metadata attributes {diff_md} in xarray object[s] "
+            f"returned from {self.name}.\n"
+        )
+        missing_vars = (
+            f"Missing required variables {diff_vars} in xarray object[s] "
+            f"returned from {self.name}.\n"
+        )
+        if len(diff_md) or len(diff_vars):
+            missing_str = ""
+            if len(diff_md):
+                missing_str += missing_md
+            if len(diff_vars):
+                missing_str += missing_vars
+            LOG.interactive(missing_str)
+            return False
+        else:
+            LOG.interactive(
+                "Information in returned xarray objects adheres to GeoIPS xarray "
+                "standards."
+            )
+            return True
 
 
 class ReadersInterface(BaseModuleInterface):
@@ -14,6 +154,7 @@ class ReadersInterface(BaseModuleInterface):
     """
 
     name = "readers"
+    plugin_class = BaseReadersPlugin
     required_args = {"standard": ["fnames"]}
     required_kwargs = {
         "standard": [

--- a/geoips/interfaces/module_based/readers.py
+++ b/geoips/interfaces/module_based/readers.py
@@ -3,8 +3,6 @@
 
 """Readers interface module."""
 
-from xarray import open_dataset
-
 from geoips.interfaces.base import BaseModuleInterface
 
 
@@ -25,43 +23,6 @@ class ReadersInterface(BaseModuleInterface):
             "self_register",
         ],
     }
-
-    def quick_view(self, fpaths):
-        """Quickly extract dims, coords, and vars for the incoming files.
-
-        Do so using xarray.open_dataset(fpath, chunks=None) to view the incoming file
-        without actually loading its data into memory. This is used for the CLI command
-        'geoips describe data'.
-
-        Metadata can be collected from the file paths using
-        <reader_plugin>(fpaths, metadata_only=True).
-
-        Parameters
-        ----------
-        fpaths: list[str]
-            - A list of absolute file paths to the incoming data.
-
-        Returns
-        -------
-        data_dict: dict
-            - A dictionary whose keys include ["coords", "dims", "variables"], of which
-              the values corresponding to those keys are information about each
-              coordinate, dimension, and variable.
-        """
-        variables = {}
-        coords = {}
-        dims = {}
-        for fpath in fpaths:
-            ds = open_dataset(fpath, chunks=None)
-            for dim_key in ds.dims:
-                dims[dim_key] = ds.dims[dim_key]
-            for coord_key in ds.coords:
-                coords[coord_key] = ds.coords[coord_key].attrs["long_name"]
-            for var_key in ds.variables:
-                variables[var_key] = ds.variables[var_key].attrs
-
-        data_dict = {"Coordinates": coords, "Dimensions": dims, "Variables": variables}
-        return data_dict
 
 
 readers = ReadersInterface()

--- a/geoips/plugins/modules/readers/abi_netcdf.py
+++ b/geoips/plugins/modules/readers/abi_netcdf.py
@@ -923,7 +923,21 @@ def get_band_metadata(all_metadata):
 
 
 def get_data(md, gvars, rad=False, ref=False, bt=False):
-    """Read data for a full channel's worth of files."""
+    """Read data for a full channel's worth of files.
+
+    Parameters
+    ----------
+    md: dict
+        - Dictionary of metadata for the incoming files
+    gvars: dict
+        - Dictionary of geolocated variables for locating data
+    rad: bool
+        - Whether or not we want to produce radiance data
+    ref: bool
+        - Whether or not we want to produce reflectance data
+    bt: bool
+        - Whether or not we want to produce radiance data
+    """
     # Coordinate arrays for reading
     if "Lines" in gvars and "Samples" in gvars:
         full_disk = False

--- a/geoips/plugins/modules/readers/abi_netcdf.py
+++ b/geoips/plugins/modules/readers/abi_netcdf.py
@@ -124,7 +124,17 @@ ALL_CHANS = {
     ],  # 1.6um  Near-IR Snow/Ice
     "HIGH": ["B03Rad", "B03Ref"],  # 0.86um Near-IR Veggie
 }
-
+# Update this variable if abi_netcdf files add new variables which can be used to
+# compose new products
+ALL_DATASETS = [
+    "Infrared",
+    "Infrared-Gray",
+    "IR-BD",
+    "WV",
+    "WV-Lower",
+    "WV-Upper",
+    "Visible",
+]
 
 def metadata_to_datetime(metadata):
     """Use information from the metadata to get the image datetime."""

--- a/geoips/plugins/modules/readers/abi_netcdf.py
+++ b/geoips/plugins/modules/readers/abi_netcdf.py
@@ -124,17 +124,7 @@ ALL_CHANS = {
     ],  # 1.6um  Near-IR Snow/Ice
     "HIGH": ["B03Rad", "B03Ref"],  # 0.86um Near-IR Veggie
 }
-# Update this variable if abi_netcdf files add new variables which can be used to
-# compose new products
-ALL_DATASETS = [
-    "Infrared",
-    "Infrared-Gray",
-    "IR-BD",
-    "WV",
-    "WV-Lower",
-    "WV-Upper",
-    "Visible",
-]
+
 
 def metadata_to_datetime(metadata):
     """Use information from the metadata to get the image datetime."""

--- a/geoips/plugins/yaml/sectors/static/postages/postage_geokompsat.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_geokompsat.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_geokompsat
+docstring: "Postage Sector at nadir location of GeoKompsat-2A"
+metadata:
+  region:
+    continent: Asia
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_geokompsat
+  description: Postage Sector at nadir location of GeoKompsat-2A
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: 128.2
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_goes16.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_goes16.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_goes16
+docstring: "Postage Sector at nadir location of GOES16"
+metadata:
+  region:
+    continent: NorthAmerica
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_goes16
+  description: Postage Sector at nadir location of GOES16
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: -75.2
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_goes18.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_goes18.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_goes18
+docstring: "Postage Sector at nadir location of GOES18"
+metadata:
+  region:
+    continent: NorthAmerica
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_goes18
+  description: Postage Sector at nadir location of GOES18
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: -137.2
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_himawari.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_himawari.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_himawari
+docstring: "Postage Sector at nadir location of Himawari9"
+metadata:
+  region:
+    continent: Asia
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_himawari
+  description: Postage Sector at nadir location of Himawari9
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: 140.7
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_meteosat10.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_meteosat10.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_meteosat10
+docstring: "Postage Sector at nadir location of Meteosat10"
+metadata:
+  region:
+    continent: Europe
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_meteosat10
+  description: Postage Sector at nadir location of Meteosat10
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: 9.5
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_meteosat11.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_meteosat11.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_meteosat11
+docstring: "Postage Sector at nadir location of Meteosat11"
+metadata:
+  region:
+    continent: Africa
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_meteosat11
+  description: Postage Sector at nadir location of Meteosat11
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: 0
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/plugins/yaml/sectors/static/postages/postage_meteosat9.yaml
+++ b/geoips/plugins/yaml/sectors/static/postages/postage_meteosat9.yaml
@@ -1,0 +1,28 @@
+interface: sectors
+family: area_definition_static
+name: postage_meteosat9
+docstring: "Postage Sector at nadir location of Meteosat9"
+metadata:
+  region:
+    continent: Europe
+    country: x
+    area: x
+    subarea: x
+    state: x
+    city: x
+spec:
+  area_id: postage_meteosat9
+  description: Postage Sector at nadir location of Meteosat9
+  projection:
+    a: 6371228.0
+    lat_0: 0
+    lon_0: 45.5
+    proj: eqc
+    units: m
+  resolution:
+    - 10
+    - 10
+  shape:
+    height: 10
+    width: 10
+  center: [0, 0]

--- a/geoips/utils/context_managers.py
+++ b/geoips/utils/context_managers.py
@@ -3,8 +3,10 @@
 
 """Module for handling optional dependencies throughout GeoIPS."""
 
-import logging
 from contextlib import contextmanager
+import logging
+import os
+import sys
 import traceback
 
 LOG = logging.getLogger(__name__)
@@ -29,4 +31,25 @@ def import_optional_dependencies(loglevel="info"):
         err_str += "If you need it, install it."
 
         getattr(LOG, loglevel)(err_str)
-        # print(err_str)
+
+
+@contextmanager
+def suppress_output():
+    """Suppress the output going to the terminal for case-specific situations.
+
+    This is used by the CLI to suppress warnings from 3rd Party packages that are not
+    relevant to the CLI and confuscate important output.
+
+    Use this for any case in which you are running a function[s], but don't want its
+    output to be sent to the terminal.
+    """
+    with open(os.devnull, "w") as devnull:
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = devnull
+        sys.stderr = devnull
+        try:
+            yield
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr


### PR DESCRIPTION
**This PR is still in draft stage and isn't expected to get out of that for a while. Updates to Readers are likely needed.**

**This PR also branched off of #739, so some of the changes are linked to that PR.**

# Reviewer Checklist

* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [ ] NO REQUIRED ***existing tests*** (explain why not required)
* [ ] Required ***unit tests*** added and pass for new/modified functionality
* [ ] NO REQUIRED ***unit tests*** (explain why not required)
* [ ] Required ***integration tests*** added and pass for new/modified functionality
* [ ] NO REQUIRED ***integration tests*** (explain why not required)
* [ ] Required ***documentation*** added for new/modified functionality
* [ ] NO REQUIRED ***documentation*** (explain why not required)
* [ ] Required ***release notes*** added for new/modified functionality
* [ ] NO REQUIRED ***release notes*** (explain why not required)
* [ ] Required ***updates to other repos*** complete
* [ ] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#737

# Testing Instructions
Will provide once command is stable.

# Summary
This will be held as a draft until we can get the output of readers consistent. For example, when testing with reader ``abi_netcdf``, different xarray_dicts are returned depending if an ``area_def`` is specified or not. If no ``area_def`` is specified, the xarray_dict will look like: ``{"LOW": xobj, "MED": xobj, "HIGH": xobj, "METADATA": xobj}``. If ``area_def`` is specified, the xarray_dict will look like: ``{"sector_name": xobj, "METADATA": xobj}``. Due to these inconsistencies, we cannot provide the same structure of data for each reader. 

This PR also adds the command ``geoips --version``, as requested by @mindyls. I additionally play along with validating the output of readers, though this is still in development as I need to figure out how to link ``BaseReaderPlugin:validate_output`` to the end of a reader plugin's ``__call__`` method.

Initial stage of CLI command ``geoips describe data``. This command will describe the data that will come out of a reader. Its signature is ``geoips describe data <reader_name> <file_paths>``. Expected output will look along the lines of
```yaml
Datasets:
  Resolution1:
    - ds_name1
    - ds_name2
  Resolution2:
    - ds_name3
    - ds_name4
Coords:
  coord_info:
Dims:
  dim_info:
Metadata:
  md_key1: info
  md_key2: info
```

# Output
Here is the current example of running ``geoips describe data abi_netcdf /home/evan/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/*``, where we provide a ``postage`` sector for quick processing. Note that no resolutions are specified under ``Datasets``.
```
(geoips) [evan@spring geoips]$ geoips desc data abi_netcdf /home/evan/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/*
Metadata: 
  file_metadata: 
    B01: 
      file_info: 
        id: c081667d-0edd-45e2-a82a-62fc683a6d93
        dataset_name: OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc
        naming_authority: gov.nesdis.noaa
        institution: DOC/NOAA/NESDIS > U.S. Department of Commerce, National Oceanic and Atmospheric Administration, National Environmental Satellite, Data, and Information Services
        project: GOES
        iso_series_metadata_id: a70be540-c38b-11e0-962b-0800200c9a66
        Conventions: CF-1.7
        Metadata_Conventions: Unidata Dataset Discovery v1.0
        keywords_vocabulary: NASA Global Change Master Directory (GCMD) Earth Science Keywords, Version 7.0.0.0.0
        standard_name_vocabulary: CF Standard Name Table (v35, 20 July 2016)
        title: ABI L1b Radiances
        summary: Single reflective band ABI L1b Radiance Products are digital maps of outgoing radiance values at the top of the atmosphere for visible and near-IR bands.
        license: Unclassified data.  Access is restricted to approved users only.
        keywords: SPECTRAL/ENGINEERING > VISIBLE WAVELENGTHS > VISIBLE RADIANCE
        cdm_data_type: Image
        orbital_slot: GOES-East
        platform_ID: G16
        instrument_type: GOES R Series Advanced Baseline Imager
        processing_level: National Aeronautics and Space Administration (NASA) L1b
        date_created: 2020-09-18T19:59:56.7Z
        production_site: RBU
        production_environment: OE
        production_data_source: Realtime
        timeline_id: ABI Mode 6
        scene_id: Full Disk
        spatial_resolution: 1km at nadir
        time_coverage_start: 2020-09-18T19:50:20.5Z
        time_coverage_end: 2020-09-18T19:59:51.3Z
      var_info: 
        band_id: [1]
        band_wavelength: [0.47]
        earth_sun_distance_anomaly_in_AU: 1.004645
        esun: 2017.1648
        kappa0: 0.0015719
        max_radiance_value_of_valid_pixels: 646.07336
        min_radiance_value_of_valid_pixels: -0.5803809
        missing_pixel_count: 1403
        nominal_satellite_height: 35786.023
        nominal_satellite_subpoint_lat: 0.0
        nominal_satellite_subpoint_lon: -75.2
        percent_uncorrectable_L0_errors: 0.0
        planck_bc1: --
        planck_bc2: --
        planck_fk1: --
        planck_fk2: --
        processing_parm_version_container: --
        saturated_pixel_count: 15303
        std_dev_radiance_value_of_valid_pixels: 97.364265
        time_bounds: [6.53730621e+08 6.53731191e+08]
        undersaturated_pixel_count: 0
        valid_pixel_count: 92168222
        x: [-0.151858   -0.15183    -0.151802   ...  0.151802    0.15182999  0.151858  ]
        y: [ 0.151858    0.15183     0.151802   ... -0.151802   -0.15182999 -0.151858  ]
        yaw_flip_flag: 0
        num_lines: 10848
        num_samples: 10848
      ll_info: 
        geospatial_eastbound_longitude: 6.2995
        geospatial_lat_center: 0.0
        geospatial_lat_nadir: 0.0
        geospatial_lon_center: -75.0
        geospatial_lon_nadir: -75.0
        geospatial_northbound_latitude: 81.3282
        geospatial_southbound_latitude: -81.3282
        geospatial_westbound_longitude: -156.2995
      projection: 
        inverse_flattening: 298.2572221
        latitude_of_projection_origin: 0.0
        longitude_of_projection_origin: -75.0
        perspective_point_height: 35786023.0
        semi_major_axis: 6378137.0
        semi_minor_axis: 6356752.31414
        grid_mapping: geostationary
      path: /home/evan/geoips/geoips_packages/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc
      satellite: G16
      sensor: ABI
      num_lines: 10848
      num_samples: 10848
  start_datetime: 2020-09-18 19:50:20.526449
  end_datetime: 2020-09-18 19:59:51.323902
  source_name: abi
  data_provider: noaa
  platform_name: goes-16
  area_definition: None
  area_id: Full-Disk
  interpolation_radius_of_influence: 2000.0
Datasets: 
  - B01Rad
  - B01Ref
  - B02Rad
  - B02Ref
  - B03Rad
  - B03Ref
  - B04Rad
  - B04Ref
  - B05Rad
  - B05Ref
  - B06Rad
  - B06Ref
  - B07BT
  - B07Rad
  - B08BT
  - B08Rad
  - B09BT
  - B09Rad
  - B10BT
  - B10Rad
  - B11BT
  - B11Rad
  - B12BT
  - B12Rad
  - B13BT
  - B13Rad
  - B14BT
  - B14Rad
  - B15BT
  - B15Rad
  - B16BT
  - B16Rad
  - latitude
  - longitude
  - satellite_azimuth_angle
  - satellite_zenith_angle
  - solar_azimuth_angle
  - solar_zenith_angle
Coordinates: 
Dimensions: 
  dim_0: 10
  dim_1: 10
Source Names: 
  - abi

WARNING: The GeoIPS CLI is currently under development and is subject to change.
Until this warning is removed, do not rely on the CLI to be static.
Please feel free to test the CLI and report any bugs or comments as an issue here:
https://github.com/NRLMMD-GEOIPS/geoips/issues/new/choose
```
