### PR TITLE
Driver Config Yaml Interface

### DIFF
--- a/docs/source/releases/latest/driver-config-yaml-interface.yaml
+++ b/docs/source/releases/latest/driver-config-yaml-interface.yaml
@@ -1,0 +1,33 @@
+enhancement:
+- description: |
+    This branch creates a new 'driver_config' yaml-based interface which provides
+    configuration details on how to run your driver. Default information included in
+    these yamls is 'basedir', 'output_types', 'products', 'sector_mapping', and 'paths'.
+    There are three types of families for this new interface, with the possibility of
+    adding more in the future. Currently, this PR creates families 'multiprocessing',
+    'sequential', and 'slurm'. As their names denote, this is the type of processing
+    we'll use to run our driver. 'multiprocessing' and 'sequential' depict how processes
+    will be distributed at runtime. 'slurm' means that we will make use of the job
+    scheduler named 'slurm' for running our processes.
+
+    This branch adds a new plugin class called 'DriverConfigsPlugin', which is similar
+    to all other yaml plugins, but adds new functionality by assigning the values of
+    each key in the yaml plugin's spec as an attribute to the plugin class. Now in our
+    drivers, we can access information in the spec easily via <plugin>.<spec_key>.
+
+    This branch did not modify geoips.interfaces.base at all and is largely just an
+    enhancement which provides a new interface for users interested in driving GeoIPS.
+
+    No new plugins were added to GeoIPS. Though, if wanted, we could add simple examples
+    in GeoIPS to provide users with information on how to create these plugins. 3 real
+    plugins have been created in a separate package I've been developing.
+  files:
+    added:
+      - geoips/interfaces/yaml_based/driver_configs.py
+      - geoips/schema/driver_configs/bases/paths.yaml
+      - geoips/schema/driver_configs/sector_mapping.yaml
+      - geoips/schema/driver_configs/multiprocess.yaml
+      - geoips/schema/driver_configs/default.yaml
+    modified:
+      - geoips/interfaces/__init__.py
+  title: Driver Configs Yaml Interface

--- a/docs/source/releases/latest/driver-config-yaml-interface.yaml
+++ b/docs/source/releases/latest/driver-config-yaml-interface.yaml
@@ -24,10 +24,15 @@ enhancement:
   files:
     added:
       - geoips/interfaces/yaml_based/driver_configs.py
+      - geoips/plugins/yaml/driver_configs/abi.yaml
       - geoips/schema/driver_configs/bases/paths.yaml
-      - geoips/schema/driver_configs/sector_mapping.yaml
+      - geoips/schema/driver_configs/bases/sector_mapping.yaml
       - geoips/schema/driver_configs/multiprocess.yaml
-      - geoips/schema/driver_configs/default.yaml
+      - geoips/schema/driver_configs/sequential.yaml
+      - geoips/schema/driver_configs/slurm.yaml
+      - geoips/schema/driver_configs/specs/default.yaml
     modified:
+      - geoips/commandline/ancillary_info/alias_mapping.yaml
+      - geoips/commandline/ancillary_info/cmd_instructions.yaml
       - geoips/interfaces/__init__.py
   title: Driver Configs Yaml Interface

--- a/geoips/commandline/ancillary_info/alias_mapping.yaml
+++ b/geoips/commandline/ancillary_info/alias_mapping.yaml
@@ -10,6 +10,10 @@ coverage-checkers:
   - cchk
   - cchks
   - coverage-checker
+driver-configs:
+  - dconf
+  - dconfs
+  - driver-config
 filename-formatters:
   - ffmt
   - ffmts

--- a/geoips/commandline/ancillary_info/cmd_instructions.yaml
+++ b/geoips/commandline/ancillary_info/cmd_instructions.yaml
@@ -68,6 +68,7 @@ instructions:
   geoips_describe_algorithms: *geoips-describe-artifact
   geoips_describe_colormappers: *geoips-describe-artifact
   geoips_describe_coverage-checkers: *geoips-describe-artifact
+  geoips_describe_driver-configs: *geoips-describe-artifact
   geoips_describe_filename-formatters: *geoips-describe-artifact
   geoips_describe_interpolators: *geoips-describe-artifact
   geoips_describe_output-checkers: *geoips-describe-artifact
@@ -194,6 +195,7 @@ instructions:
   geoips_list_algorithms: *list-single-interface
   geoips_list_colormappers: *list-single-interface
   geoips_list_coverage-checkers: *list-single-interface
+  geoips_list_driver-configs: *list-single-interface
   geoips_list_filename-formatters: *list-single-interface
   geoips_list_interpolators: *list-single-interface
   geoips_list_output-checkers: *list-single-interface

--- a/geoips/interfaces/__init__.py
+++ b/geoips/interfaces/__init__.py
@@ -21,30 +21,19 @@ from geoips.interfaces.module_based.output_checkers import output_checkers
 from geoips.interfaces.module_based.coverage_checkers import coverage_checkers
 from geoips.interfaces.module_based.filename_formatters import filename_formatters
 from geoips.interfaces.module_based.interpolators import interpolators
-from geoips.interfaces.module_based.output_formatters import (
-    output_formatters,
-)
+from geoips.interfaces.module_based.output_formatters import output_formatters
 from geoips.interfaces.module_based.procflows import procflows
 from geoips.interfaces.module_based.readers import readers
-from geoips.interfaces.module_based.sector_adjusters import (
-    sector_adjusters,
-)
+from geoips.interfaces.module_based.sector_adjusters import sector_adjusters
 from geoips.interfaces.module_based.sector_metadata_generators import (
     sector_metadata_generators,
 )
-from geoips.interfaces.module_based.sector_spec_generators import (
-    sector_spec_generators,
-)
-from geoips.interfaces.module_based.title_formatters import (
-    title_formatters,
-)
+from geoips.interfaces.module_based.sector_spec_generators import sector_spec_generators
+from geoips.interfaces.module_based.title_formatters import title_formatters
 
-from geoips.interfaces.yaml_based.feature_annotators import (
-    feature_annotators,
-)
-from geoips.interfaces.yaml_based.gridline_annotators import (
-    gridline_annotators,
-)
+from geoips.interfaces.yaml_based.driver_configs import driver_configs
+from geoips.interfaces.yaml_based.feature_annotators import feature_annotators
+from geoips.interfaces.yaml_based.gridline_annotators import gridline_annotators
 from geoips.interfaces.yaml_based.product_defaults import product_defaults
 from geoips.interfaces.yaml_based.products import products
 from geoips.interfaces.yaml_based.sectors import sectors
@@ -68,6 +57,7 @@ module_based_interfaces = [
     "title_formatters",
 ]
 yaml_based_interfaces = [
+    "driver_configs",
     "feature_annotators",
     "gridline_annotators",
     "product_defaults",

--- a/geoips/interfaces/__init__.py
+++ b/geoips/interfaces/__init__.py
@@ -57,6 +57,7 @@ module_based_interfaces = [
     "title_formatters",
 ]
 yaml_based_interfaces = [
+    "driver_config_defaults",
     "driver_configs",
     "feature_annotators",
     "gridline_annotators",

--- a/geoips/interfaces/yaml_based/driver_configs.py
+++ b/geoips/interfaces/yaml_based/driver_configs.py
@@ -1,0 +1,79 @@
+# # # This source code is protected under the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+"""Driver configs interface module."""
+
+from geoips.interfaces.base import BaseYamlInterface, BaseYamlPlugin
+
+
+class DriverConfigsPlugin(BaseYamlPlugin):
+    """Class for yaml-based configuration plugins which support driving GeoIPS.
+
+    Exposes top-level information and adds a few methods that make accessing
+    configuration information easier that parsing through the yaml's spec.
+
+    A driver will create output in this order:
+
+    For each output_type:
+        For each product:
+            # If implemented in your driver
+                For each sector:
+                    produce an output
+            # Else (for a singular sector)
+                produce an output
+    """
+
+    @property
+    def basedir(self):
+        """Base directory where your files could arrive to."""
+        if not hasattr(self, "_basedir"):
+            self._basedir = self["spec"]["basedir"]
+        return self._basedir
+
+    @property
+    def output_types(self):
+        """List of output types GeoIPS will create with your driver."""
+        if not hasattr(self, "_output_types"):
+            self._output_types = self["spec"]["output_types"]
+        return self._output_types
+
+    @property
+    def products(self):
+        """List of products GeoIPS will create with your driver."""
+        if not hasattr(self, "_products"):
+            self._products = self["spec"]["products"]
+        return self._products
+
+    @property
+    def sector_mapping(self):
+        """Dictionary of 'satellite_sector_name': 'geoips_sector_name'.
+
+        Maps sectors that may appear in the arriving data file paths to a geoips sector.
+        """
+        if not hasattr(self, "_sector_mapping"):
+            self._sector_mapping = self["spec"]["sector_mapping"]
+        return self._sector_mapping
+
+    @property
+    def paths(self):
+        """Dictionary of relative file paths based on sat, sensor, sector.
+
+        An entry for CLAVR-x GOES16 data could look like:
+        'GOES16':
+          'ABI':
+            'RadC': <some_path>
+            'RadF': <some_path>
+        """
+        if not hasattr(self, "_paths"):
+            self._paths = self["spec"]["paths"]
+        return self._paths
+
+
+class DriverConfigsInterface(BaseYamlInterface):
+    """Configuration values that are used to drive GeoIPS for NRT processing."""
+
+    name = "driver_configs"
+    plugin_class = DriverConfigsPlugin
+
+
+driver_configs = DriverConfigsInterface()

--- a/geoips/interfaces/yaml_based/driver_configs.py
+++ b/geoips/interfaces/yaml_based/driver_configs.py
@@ -3,6 +3,8 @@
 
 """Driver configs interface module."""
 
+from types import SimpleNamespace
+
 from geoips.interfaces.base import BaseYamlInterface, BaseYamlPlugin
 
 
@@ -23,50 +25,31 @@ class DriverConfigsPlugin(BaseYamlPlugin):
                 produce an output
     """
 
-    @property
-    def basedir(self):
-        """Base directory where your files could arrive to."""
-        if not hasattr(self, "_basedir"):
-            self._basedir = self["spec"]["basedir"]
-        return self._basedir
+    def __init__(self, obj_attrs):
+        """Initialize the DriverConfigs plugin object, then assign new attributes.
 
-    @property
-    def output_types(self):
-        """List of output types GeoIPS will create with your driver."""
-        if not hasattr(self, "_output_types"):
-            self._output_types = self["spec"]["output_types"]
-        return self._output_types
+        Where each attribute assigned to 'self' is each key found in the class' 'spec'
+        object contained in its yaml file.
 
-    @property
-    def products(self):
-        """List of products GeoIPS will create with your driver."""
-        if not hasattr(self, "_products"):
-            self._products = self["spec"]["products"]
-        return self._products
+        Will include by default:
+            - basedir
+            - output_types
+            - products
+            - sector_mapping
+            - paths
+        Extra defaults are allowed.
 
-    @property
-    def sector_mapping(self):
-        """Dictionary of 'satellite_sector_name': 'geoips_sector_name'.
-
-        Maps sectors that may appear in the arriving data file paths to a geoips sector.
+        Parameters
+        ----------
+        obj_attrs: dict
+            - A dictionary of attributes to assign to the class.
         """
-        if not hasattr(self, "_sector_mapping"):
-            self._sector_mapping = self["spec"]["sector_mapping"]
-        return self._sector_mapping
-
-    @property
-    def paths(self):
-        """Dictionary of relative file paths based on sat, sensor, sector.
-
-        An entry for CLAVR-x GOES16 data could look like:
-        'GOES16':
-          'ABI':
-            'RadC': <some_path>
-            'RadF': <some_path>
-        """
-        if not hasattr(self, "_paths"):
-            self._paths = self["spec"]["paths"]
-        return self._paths
+        # Initialize the class using 'BaseYamlPlugin'
+        super().__init__(obj_attrs)
+        # Now assign each key of 'spec' as an attribute to this class. See
+        # schema.yaml.driver_configs.specs.default for more information.
+        for key in self["spec"]:
+            setattr(self, key, self["spec"][key])
 
 
 class DriverConfigsInterface(BaseYamlInterface):

--- a/geoips/interfaces/yaml_based/driver_configs.py
+++ b/geoips/interfaces/yaml_based/driver_configs.py
@@ -3,8 +3,6 @@
 
 """Driver configs interface module."""
 
-from types import SimpleNamespace
-
 from geoips.interfaces.base import BaseYamlInterface, BaseYamlPlugin
 
 
@@ -37,6 +35,7 @@ class DriverConfigsPlugin(BaseYamlPlugin):
             - products
             - sector_mapping
             - paths
+
         Extra defaults are allowed.
 
         Parameters

--- a/geoips/plugins/yaml/driver_configs/abi.yaml
+++ b/geoips/plugins/yaml/driver_configs/abi.yaml
@@ -1,0 +1,32 @@
+interface: driver_configs
+family: multiprocess
+name: abi
+docstring: |
+  Default configuration for GOES ABI-based near real-time processing using GeoIPS.
+spec:
+  basedir: /some/path/to/parent/data/dir
+  output_types:
+    - imagery_annotated
+    - imagery_clean
+  products:
+    - Infrared
+    - Infrared-Gray
+    - IR-BD
+    - WV
+    - WV-Lower
+    - WV-Upper
+    - Visible
+  sector_mapping:
+    RadC: conus
+    RadF: goes_east
+  paths:
+    GOES16:
+      ABI:
+        RadC: GOES16_ABI/path/to/RadC/output
+        RadF: GOES16_ABI/path/to/RadF/output
+    GOES18:
+      ABI:
+        RadC: GOES18_ABI/path/to/RadC/output
+        RadF: GOES18_ABI/path/to/RadF/output
+  core_count: 7
+  processing_type: Pool

--- a/geoips/schema/driver_config_defaults/multiprocess.py
+++ b/geoips/schema/driver_config_defaults/multiprocess.py
@@ -1,0 +1,13 @@
+from typing import Literal
+
+from pydantic import Field
+from typing_extensions import Annotated
+
+from geoips.schema.driver_config_defaults.sequential import Sequential
+
+
+class Multiprocess(Sequential, extra="strict"):
+    """Default schema for multiprocess-based driver_config_defaults plugin."""
+
+    core_count: Annotated[int, Field(strict=True, gt=0)]
+    processing_type: Literal["Pool", "Process", "Queue"]

--- a/geoips/schema/driver_config_defaults/sequential.py
+++ b/geoips/schema/driver_config_defaults/sequential.py
@@ -1,0 +1,33 @@
+from typing import Literal, Union, Dict, List
+
+from pydantic import BaseModel
+
+
+class Matching(BaseModel, extra="allow"):
+    """Default schema for the 'matching' attribute of RequiredFiles."""
+
+    file_format: str
+    band_resolution_mapping: Dict[str]
+    segment_divisions: List[str]
+
+
+class RequiredFiles(BaseModel, extra="allow"):
+    """Default schema for 'required_files' attribute.
+
+    This is a required attribute of the DriverConfigDefaults schema, which is applied to
+    all DriverConfigDefaults plugins.
+    """
+
+    default: Literal["single", "set"]
+    matching: Union[Matching, None]
+
+
+class Sequential(BaseModel, extra="allow"):
+    """Default schema for the sequential-based driver_config_defaults plugin."""
+
+    watchdir: str
+    template: str
+    date_format: Literal["calendar", "julian"]
+    sectors: List[str]
+    output_types: List[str]
+    required_files: RequiredFiles

--- a/geoips/schema/driver_config_defaults/slurm.py
+++ b/geoips/schema/driver_config_defaults/slurm.py
@@ -1,0 +1,14 @@
+from typing import Union
+
+from pydantic import Field
+from typing_extensions import Annotated
+
+from geoips.schema.driver_config_defaults.sequential import Sequential
+
+
+class Multiprocess(Sequential, extra="strict"):
+    """Default schema for slurm-based driver_config_defaults plugin."""
+
+    mem_per_cpu: Union[Annotated[float, Field(strict=True, gt=0)], None]
+    ntasks: Union[Annotated[int, Field(strict=True, gt=0)], None]
+    partition: Union[str, None]

--- a/geoips/schema/driver_configs/bases/paths.yaml
+++ b/geoips/schema/driver_configs/bases/paths.yaml
@@ -1,0 +1,9 @@
+$id: driver_configs.bases.paths
+title: "Paths"
+type: object # Satellite Name: I.e. GOES16
+additionalProperties:
+  type: object # Sensor Name: I.e. ABI
+  additionalProperties:
+    type: object # Sector Name: I.e. RadC
+    additionalProperties:
+      type: string # Relative file path (not beginning with '/')

--- a/geoips/schema/driver_configs/bases/sector_mapping.yaml
+++ b/geoips/schema/driver_configs/bases/sector_mapping.yaml
@@ -1,0 +1,5 @@
+$id: driver_configs.bases.sector_mapping
+title: "Sector Mapping"
+type: object # Sector Name: I.e. 'RadC'
+additionalProperties:
+  type: string # GeoIPS Sector Equivalent: I.e. 'conus'

--- a/geoips/schema/driver_configs/multiprocess.yaml
+++ b/geoips/schema/driver_configs/multiprocess.yaml
@@ -1,0 +1,23 @@
+$id: driver_configs.multiprocess
+$ref: bases.top
+type: object
+required:
+  - spec
+properties:
+  family:
+    const: multiprocess
+  spec:
+    $ref: "driver_configs.specs.default"
+    required:
+      - processing_type
+      - core_count
+    unevaluatedProperties: true
+    properties:
+      processing_type:
+        type: string
+        enum:
+          - Pool
+          - Process
+          - Queue
+      core_count: # Recommendend to implement the value of min(os.cpu_count() // 4, len(products))
+        type: integer

--- a/geoips/schema/driver_configs/sequential.yaml
+++ b/geoips/schema/driver_configs/sequential.yaml
@@ -1,0 +1,14 @@
+$id: driver_configs.sequential
+$ref: bases.top
+type: object
+required:
+  - spec
+properties:
+  family:
+    const: sequential
+  spec:
+    $ref: "driver_configs.specs.default"
+    required:
+      - processing_type
+      - core_count
+    unevaluatedProperties: true

--- a/geoips/schema/driver_configs/slurm.yaml
+++ b/geoips/schema/driver_configs/slurm.yaml
@@ -1,0 +1,22 @@
+$id: driver_configs.slurm
+$ref: bases.top
+type: object
+required:
+  - spec
+properties:
+  family:
+    const: slurm
+  spec:
+    $ref: "driver_configs.specs.default"
+    required:
+      - mem_per_cpu
+      - ntasks
+      - partition
+    unevaluatedProperties: true
+    properties:
+      partition:
+        type: string
+      mem_per_cpu: # Units in Megabytes
+        type: integer
+      ntasks:
+        type: integer

--- a/geoips/schema/driver_configs/specs/default.yaml
+++ b/geoips/schema/driver_configs/specs/default.yaml
@@ -1,0 +1,24 @@
+$id: driver_configs.specs.default
+type: object
+required:
+  - basedir
+  - output_types
+  - products
+  - sector_mapping
+  - paths
+unevaluatedProperties: true
+properties:
+  basedir:
+    type: string
+  output_types:
+    type: array
+    items:
+      type: string
+  products:
+    type: array
+    items:
+      type: string
+  sector_mapping:
+    $ref: "driver_configs.bases.sector_mapping"
+  paths:
+    $ref: "driver_configs.bases.paths"


### PR DESCRIPTION
# Reviewer Checklist

* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [ ] NO REQUIRED ***unit tests*** (explain why not required)
* [ ] NO REQUIRED ***integration tests*** (explain why not required)
* [ ] Required ***documentation*** added for new/modified functionality
* [ ] NO REQUIRED ***documentation*** (explain why not required)
* [ ] Required ***release notes*** added for new/modified functionality
* [ ] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
No issue associated with this PR.

**THIS PR IS STILL A DRAFT AND WONT BE READY FOR REVIEW UNTIL OUR NEW PYDANTIC SCHEMAS ARE IN PLACE**

# Testing Instructions
If we want to create plugins which make use of the new interface, I can create a test for this. Currently the only 'testing' which has been done is validation via JSON Schema when retrieving my custom ``DriverConfigsPlugin``'s using ``driver_configs.get_plugin(<plugin_name>)``.

# Summary
This branch creates a new 'driver_config' yaml-based interface which provides
configuration details on how to run your driver. Default information included in
these yamls is 'basedir', 'output_types', 'products', 'sector_mapping', and 'paths'.
There are three types of families for this new interface, with the possibility of
adding more in the future. Currently, this PR creates families 'multiprocessing',
'sequential', and 'slurm'. As their names denote, this is the type of processing
we'll use to run our driver. 'multiprocessing' and 'sequential' depict how processes
will be distributed at runtime. 'slurm' means that we will make use of the job
scheduler named 'slurm' for running our processes.

This branch adds a new plugin class called 'DriverConfigsPlugin', which is similar
to all other yaml plugins, but adds new functionality by assigning the values of
each key in the yaml plugin's spec as an attribute to the plugin class. Now in our
drivers, we can access information in the spec easily via <plugin>.<spec_key>.

This branch did not modify geoips.interfaces.base at all and is largely just an
enhancement which provides a new interface for users interested in driving GeoIPS.

No new plugins were added to GeoIPS. Though, if wanted, we could add simple examples
in GeoIPS to provide users with information on how to create these plugins. 3 real
plugins have been created in a separate package I've been developing.

# Output
```
In [1]: from geoips import interfaces

In [2]: dc = interfaces.driver_configs

In [3]: clavrx = dc.get_plugin("clavrx")

In [4]: clavrx
Out[4]: DriverConfigsPlugin({'interface': 'driver_configs', 'family': 'multiprocess', 'name': 'clavrx', 'docstring': 'Default configuration for CLAVR-x based near real-time processing using GeoIPS.\n', 'spec': {'basedir': '/mnt/overcastnas1/GEO_clavrx', 'output_types': ['imagery_annotated', 'imagery_clean'], 'products': ['Cloud-Top-Height', 'Cloud-Base-Height', 'Cloud-Depth', 'Cloud-Phase', 'Cloud-Optical-Depth', 'Effective-Radius', 'Cloud-Water-Path'], 'sector_mapping': {'RadC': 'conus', 'RadF': 'goes_east'}, 'paths': {'GOES16': {'ABI': {'RadC': 'GOES16_ABI/RadC/output', 'RadF': 'GOES16_ABI/RadF/output'}}, 'GOES18': {'ABI': {'RadC': 'GOES18_ABI/RadC/output', 'RadF': 'GOES18_ABI/RadF/output'}}, 'Himawari8': {'AHI': {'RadF': 'Himawari8_AHI/RadF/output'}}, 'Himawari9': {'AHI': {'RadF': 'Himawari9_AHI/RadF/output'}}}, 'core_count': 7, 'processing_type': 'Pool'}, 'package': 'geoips_driver', 'abspath': '/home/erose/geoips/geoips_packages/geoips_driver/geoips_driver/plugins/yaml/driver_configs/clavrx.yaml', 'relpath': 'plugins/yaml/driver_configs/clavrx.yaml'})

In [5]: clavrx.yaml
Out[5]: 
{'interface': 'driver_configs',
 'family': 'multiprocess',
 'name': 'clavrx',
 'docstring': 'Default configuration for CLAVR-x based near real-time processing using GeoIPS.\n',
 'spec': {'basedir': '/mnt/overcastnas1/GEO_clavrx',
  'output_types': ['imagery_annotated', 'imagery_clean'],
  'products': ['Cloud-Top-Height',
   'Cloud-Base-Height',
   'Cloud-Depth',
   'Cloud-Phase',
   'Cloud-Optical-Depth',
   'Effective-Radius',
   'Cloud-Water-Path'],
  'sector_mapping': {'RadC': 'conus', 'RadF': 'goes_east'},
  'paths': {'GOES16': {'ABI': {'RadC': 'GOES16_ABI/RadC/output',
     'RadF': 'GOES16_ABI/RadF/output'}},
   'GOES18': {'ABI': {'RadC': 'GOES18_ABI/RadC/output',
     'RadF': 'GOES18_ABI/RadF/output'}},
   'Himawari8': {'AHI': {'RadF': 'Himawari8_AHI/RadF/output'}},
   'Himawari9': {'AHI': {'RadF': 'Himawari9_AHI/RadF/output'}}},
  'core_count': 7,
  'processing_type': 'Pool'},
 'package': 'geoips_driver',
 'abspath': '/home/erose/geoips/geoips_packages/geoips_driver/geoips_driver/plugins/yaml/driver_configs/clavrx.yaml',
 'relpath': 'plugins/yaml/driver_configs/clavrx.yaml'}

```
