### PR TITLE
Remove noaa aws data install

### DIFF
--- a/docs/source/releases/latest/764-integration-tests-pass-without-noaa-data.yaml
+++ b/docs/source/releases/latest/764-integration-tests-pass-without-noaa-data.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- description: |
+    Removed NOAA AWS dataset from the base tests 
+    because it was unused resulting in a ~6X faster install 
+    (2m 28s -> 24s) and a ~4.25 smaller data footprint (3.8Gb -> 894Mb).
+  files:
+    modified:
+      - 'tests/integration_tests/base_install.sh'
+  related-issue:
+    number: 764
+    repo_url: ''
+  title: 'Remove unused NOAA AWS dataset from base tests'

--- a/tests/integration_tests/base_install.sh
+++ b/tests/integration_tests/base_install.sh
@@ -12,4 +12,3 @@ fi
 
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh geoips_base
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_amsr2 $test_exit $install_script
-. $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_noaa_aws $test_exit $install_script


### PR DESCRIPTION
* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#764

# Testing Instructions
Freshly install geoips, run base install + test.

# Summary
Removed NOAA AWS dataset from the base tests because it was unused resulting in a ~6X faster install (2m 28s -> 24s) and a ~4.25 smaller data footprint (3.8Gb -> 894Mb).