### PR TITLE
Enable full suite of integration tests to be run in parallel via pytest

### DIFF
--- a/docs/source/releases/latest/parallel-pytests.yaml
+++ b/docs/source/releases/latest/parallel-pytests.yaml
@@ -1,0 +1,16 @@
+enhancement:
+- title: Enable full suite of integration tests to be run in parallel via pytest.
+  description: 'This adds a helper python file with pytest-capable tests that call
+    the same shell scripts called by full_test.sh. This is helpful when
+    combined with pytest-xdist''s ability to run pytests in parallel.
+    It also gives developers the ability to run tests with an alternative
+    CLI output format. Users should continue to run full_test.sh.'
+  files:
+    modified:
+    - tests/integration_tests/test_full_test.py
+    - pyproject.toml
+    - pytest.ini
+  date:
+    start: Nov 7, 2024
+    finish: Nov 12, 2024
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ pinkrst = { version = "*", optional = true }
 # Test group
 pytest = { version = "*", optional = true }
 pytest-cov = { version = "*", optional = true }
+pytest-xdist = { version = "*", optional = true }
 pixelmatch = { version = "*", optional = true }
 xarray-datatree = { version = "*", optional = true }
 # Debug group
@@ -158,6 +159,7 @@ test = [
     "xarray-datatree", # Currently only used in unit tests
     "pytest-cov",      # Reports on test coverage
     "pixelmatch",
+    "pytest-xdist",
 ]
 debug = ["ipython"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-addopts = -v -rf --ff --cov-report=term-missing
+addopts = -v -rf --ff --cov-report=term-missing -m "not integration"
 testpaths =
     tests/unit_tests*
 norecursedirs = xarray_utils
+markers =
+    integration: marks tests as integration (select with '-m "integration"')

--- a/tests/integration_tests/test_full_test.py
+++ b/tests/integration_tests/test_full_test.py
@@ -1,0 +1,133 @@
+# # # This source code is protected under the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+import os
+import subprocess
+import pytest
+import sys
+
+integ_test_calls = [
+    "$geoips_repopath/tests/utils/check_code.sh all $recenter_tc_repopath",
+    "$geoips_repopath/docs/build_docs.sh $geoips_repopath $geoips_pkgname html_only",
+    "$geoips_repopath/docs/build_docs.sh $recenter_tc_repopath $recenter_tc_pkgname html_only",
+    "$geoips_repopath/docs/build_docs.sh $data_fusion_repopath $data_fusion_pkgname html_only",
+    "$geoips_repopath/docs/build_docs.sh $template_basic_plugin_repopath $template_basic_plugin_pkgname html_only",
+    "$geoips_repopath/tests/scripts/abi.static.Infrared.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/console_script_create_sector_image.sh",
+    "$geoips_repopath/tests/scripts/console_script_list_available_plugins.sh",
+    "$geoips_repopath/tests/scripts/abi.static.Visible.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/abi.config_based_output_low_memory.sh",
+    "$geoips_repopath/tests/scripts/abi.config_based_output.sh",
+    "$geoips_repopath/tests/scripts/ahi.tc.WV.geotiff.sh",
+    "$geoips_repopath/tests/scripts/ami.static.Infrared.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/ami.static.Visible.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/ami.tc.WV.geotiff.sh",
+    "$geoips_repopath/tests/scripts/ami.WV-Upper.unprojected_image.sh",
+    "$geoips_repopath/tests/scripts/amsr2.tc.89H-Physical.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/amsr2_ocean.tc.windspeed.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/amsr2.config_based_no_compare.sh",
+    "$geoips_repopath/tests/scripts/amsr2.config_based_overlay_output.sh",
+    "$geoips_repopath/tests/scripts/amsr2.config_based_overlay_output_low_memory.sh",
+    "$geoips_repopath/tests/scripts/ascat_knmi.tc.windbarbs.imagery_windbarbs_clean.sh",
+    "$geoips_repopath/tests/scripts/ascat_low_knmi.tc.windbarbs.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_noaa_25km.tc.windbarbs.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_noaa_50km.tc.wind-ambiguities.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_uhr.tc.wind-ambiguities.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_uhr.tc.nrcs.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/ascat_uhr.tc.windbarbs.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_uhr.tc.windspeed.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/cli_dummy_script.sh",
+    "$geoips_repopath/tests/scripts/gmi.tc.89pct.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/imerg.tc.Rain.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/oscat_knmi.tc.windbarbs.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/sar.tc.nrcs.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/smap.unsectored.text_winds.sh",
+    "$geoips_repopath/tests/scripts/viirsday.tc.Night-Vis-IR.imagery_annotated.sh",
+    "$geoips_repopath/tests/scripts/viirsmoon.tc.Night-Vis-GeoIPS1.imagery_clean.sh",
+    "$geoips_repopath/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image.sh",
+    "$recenter_tc_repopath/tests/scripts/abi.tc.Visible.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/amsr2.tc.color37.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/amsr2.tc.windspeed.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/ascat_uhr.tc.nrcs.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/ascat_uhr.tc.windbarbs.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/imerg.tc.Rain.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/metopc_knmi_125.tc.windbarbs.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/oscat.tc.windspeed.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/sar.tc.nrcs.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/smap.tc.windspeed.imagery_clean.sh",
+    "$recenter_tc_repopath/tests/scripts/viirs.tc.Infrared-Gray.imagery_clean.sh",
+    "$template_basic_plugin_repopath/tests/test_all.sh",
+    "$geoips_plugin_example_repopath/tests/test_all.sh",
+    "$geoips_clavrx_repopath/tests/test_all.sh",
+    "$data_fusion_repopath/tests/test_all.sh",
+]
+
+
+def check_full_install():
+    full_install_check = [
+        "bash",
+        os.getenv("GEOIPS_PACKAGES_DIR")
+        + "/geoips/tests/integration_tests/full_install.sh",
+        "exit_on_missing",
+    ]
+    print("Running full install check")
+    subprocess.check_output(full_install_check, env=os.environ.copy())
+
+
+def setup_environment():
+    # Base path
+    os.environ["geoips_repopath"] = os.path.join(os.path.dirname(__file__), "..", "..")
+    os.environ["geoips_pkgname"] = "geoips"
+
+    # Environment variable for geoips_packages_dir (assuming it is already set in your environment)
+    geoips_packages_dir = os.getenv("GEOIPS_PACKAGES_DIR")
+
+    # Paths and package names for each plugin
+    os.environ["recenter_tc_repopath"] = os.path.join(
+        geoips_packages_dir, "recenter_tc"
+    )
+    os.environ["recenter_tc_pkgname"] = "recenter_tc"
+
+    os.environ["data_fusion_repopath"] = os.path.join(
+        geoips_packages_dir, "data_fusion"
+    )
+    os.environ["data_fusion_pkgname"] = "data_fusion"
+
+    os.environ["template_basic_plugin_repopath"] = os.path.join(
+        geoips_packages_dir, "template_basic_plugin"
+    )
+    os.environ["template_basic_plugin_pkgname"] = "my_package"
+
+    os.environ["geoips_plugin_example_repopath"] = os.path.join(
+        geoips_packages_dir, "geoips_plugin_example"
+    )
+    os.environ["geoips_plugin_example_pkgname"] = "geoips_plugin_example"
+
+    os.environ["geoips_clavrx_repopath"] = os.path.join(
+        geoips_packages_dir, "geoips_clavrx"
+    )
+    os.environ["geoips_clavrx_pkgname"] = "geoips_clavrx"
+
+
+integ_tests_setup = False
+
+
+def setup_integ_tests():
+    check_full_install()
+    setup_environment()
+    global integ_tests_setup
+    integ_tests_setup = True
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("script", integ_test_calls)
+def test_integ_test_script(script):
+    if not integ_tests_setup:
+        setup_integ_tests()
+    expanded_call = ("bash " + os.path.expandvars(script)).split(" ")
+    print("Running", script)
+    try:
+        subprocess.check_output(expanded_call, env=os.environ.copy())
+    except subprocess.CalledProcessError as e:
+        print(e.output.decode(sys.stdout.encoding))
+        raise e

--- a/tests/integration_tests/test_full_test.py
+++ b/tests/integration_tests/test_full_test.py
@@ -1,6 +1,8 @@
 # # # This source code is protected under the license referenced at
 # # # https://github.com/NRLMMD-GEOIPS.
 
+"""Pytest file for calling integration bash scripts."""
+
 import os
 import subprocess
 import pytest
@@ -9,9 +11,9 @@ import sys
 integ_test_calls = [
     "$geoips_repopath/tests/utils/check_code.sh all $recenter_tc_repopath",
     "$geoips_repopath/docs/build_docs.sh $geoips_repopath $geoips_pkgname html_only",
-    "$geoips_repopath/docs/build_docs.sh $recenter_tc_repopath $recenter_tc_pkgname html_only",
-    "$geoips_repopath/docs/build_docs.sh $data_fusion_repopath $data_fusion_pkgname html_only",
-    "$geoips_repopath/docs/build_docs.sh $template_basic_plugin_repopath $template_basic_plugin_pkgname html_only",
+    "$geoips_repopath/docs/build_docs.sh $recenter_tc_repopath $recenter_tc_pkgname html_only",  # noqa
+    "$geoips_repopath/docs/build_docs.sh $data_fusion_repopath $data_fusion_pkgname html_only",  # noqa
+    "$geoips_repopath/docs/build_docs.sh $template_basic_plugin_repopath $template_basic_plugin_pkgname html_only",  # noqa
     "$geoips_repopath/tests/scripts/abi.static.Infrared.imagery_annotated.sh",
     "$geoips_repopath/tests/scripts/console_script_create_sector_image.sh",
     "$geoips_repopath/tests/scripts/console_script_list_available_plugins.sh",
@@ -31,7 +33,7 @@ integ_test_calls = [
     "$geoips_repopath/tests/scripts/ascat_knmi.tc.windbarbs.imagery_windbarbs_clean.sh",
     "$geoips_repopath/tests/scripts/ascat_low_knmi.tc.windbarbs.imagery_windbarbs.sh",
     "$geoips_repopath/tests/scripts/ascat_noaa_25km.tc.windbarbs.imagery_windbarbs.sh",
-    "$geoips_repopath/tests/scripts/ascat_noaa_50km.tc.wind-ambiguities.imagery_windbarbs.sh",
+    "$geoips_repopath/tests/scripts/ascat_noaa_50km.tc.wind-ambiguities.imagery_windbarbs.sh",  # noqa
     "$geoips_repopath/tests/scripts/ascat_uhr.tc.wind-ambiguities.imagery_windbarbs.sh",
     "$geoips_repopath/tests/scripts/ascat_uhr.tc.nrcs.imagery_clean.sh",
     "$geoips_repopath/tests/scripts/ascat_uhr.tc.windbarbs.imagery_windbarbs.sh",
@@ -44,7 +46,7 @@ integ_test_calls = [
     "$geoips_repopath/tests/scripts/smap.unsectored.text_winds.sh",
     "$geoips_repopath/tests/scripts/viirsday.tc.Night-Vis-IR.imagery_annotated.sh",
     "$geoips_repopath/tests/scripts/viirsmoon.tc.Night-Vis-GeoIPS1.imagery_clean.sh",
-    "$geoips_repopath/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image.sh",
+    "$geoips_repopath/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image.sh",  # noqa
     "$recenter_tc_repopath/tests/scripts/abi.tc.Visible.imagery_clean.sh",
     "$recenter_tc_repopath/tests/scripts/amsr2.tc.color37.imagery_clean.sh",
     "$recenter_tc_repopath/tests/scripts/amsr2.tc.windspeed.imagery_clean.sh",

--- a/tests/integration_tests/test_full_test.py
+++ b/tests/integration_tests/test_full_test.py
@@ -64,6 +64,17 @@ integ_test_calls = [
 
 
 def check_full_install():
+    """
+    Run the full installation check script to verify the GeoIPS installation.
+
+    Executes the 'full_install.sh' script located in the GeoIPS tests directory
+    to ensure that all required components are properly installed.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the full installation check script returns a non-zero exit status.
+    """
     full_install_check = [
         "bash",
         os.getenv("GEOIPS_PACKAGES_DIR")
@@ -75,11 +86,34 @@ def check_full_install():
 
 
 def setup_environment():
+    """
+    Set up necessary environment variables for integration tests.
+
+    Configures paths and package names for the GeoIPS core and its plugins by
+    setting environment variables required for the integration tests. Assumes
+    that 'GEOIPS_PACKAGES_DIR' is already set in the environment.
+
+    Notes
+    -----
+    The following environment variables are set:
+    - geoips_repopath
+    - geoips_pkgname
+    - recenter_tc_repopath
+    - recenter_tc_pkgname
+    - data_fusion_repopath
+    - data_fusion_pkgname
+    - template_basic_plugin_repopath
+    - template_basic_plugin_pkgname
+    - geoips_plugin_example_repopath
+    - geoips_plugin_example_pkgname
+    - geoips_clavrx_repopath
+    - geoips_clavrx_pkgname
+    """
     # Base path
     os.environ["geoips_repopath"] = os.path.join(os.path.dirname(__file__), "..", "..")
     os.environ["geoips_pkgname"] = "geoips"
 
-    # Environment variable for geoips_packages_dir (assuming it is already set in your environment)
+    # Environment variable for GEOIPS_PACKAGES_DIR
     geoips_packages_dir = os.getenv("GEOIPS_PACKAGES_DIR")
 
     # Paths and package names for each plugin
@@ -113,6 +147,13 @@ integ_tests_setup = False
 
 
 def setup_integ_tests():
+    """
+    Set up the integration tests by checking install and setting env-vars.
+
+    Calls `check_full_install()` to verify the installation and `setup_environment()`
+    to set up the necessary environment variables before running integration tests.
+    Sets the global flag `integ_tests_setup` to `True` upon successful setup.
+    """
     check_full_install()
     setup_environment()
     global integ_tests_setup
@@ -122,6 +163,20 @@ def setup_integ_tests():
 @pytest.mark.integration
 @pytest.mark.parametrize("script", integ_test_calls)
 def test_integ_test_script(script):
+    """
+    Run integration test scripts by executing specified shell commands.
+
+    Parameters
+    ----------
+    script : str
+        Shell command to execute as part of the integration test. The command may
+        contain environment variables which will be expanded before execution.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the shell command returns a non-zero exit status.
+    """
     if not integ_tests_setup:
         setup_integ_tests()
     expanded_call = ("bash " + os.path.expandvars(script)).split(" ")


### PR DESCRIPTION
Relevant XKCD:

![tests!!!! :))](https://imgs.xkcd.com/comics/software_testing_day.png) 

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests***
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Testing Instructions
- Install geoips (or just update installed dependencies)
- Run without paralellization: `pytest -m integration` (tests marked as `integration` and set to *not* run by default)
- Run `pytest -n {number of core you want to use, "auto" for all} -m integration`
- 🙂 
- Warning: tests will fail because of memory limitations if you try to run more runners than your machine can handle.

# Summary
- Runs the scripts called by `tests/integration_tests/full_test.sh` in pytest and uses [pytest-xdist](https://pypi.org/project/pytest-xdist/) to parallelize
- ~5X improvement on winter (a CIRA server) ~45m => 8m using 6 workers

# Example Output

``` bash
geoips_user@8f19a9c9d3c4:/app/geoips_packages/geoips/tests/integration_tests$ pytest -n auto -m integration
================================================================ test session starts ================================================================
platform linux -- Python 3.11.10, pytest-8.2.2, pluggy-1.5.0 -- /usr/local/bin/python3
cachedir: .pytest_cache
rootdir: /app/geoips_packages/geoips
configfile: pytest.ini
plugins: cov-5.0.0, xdist-3.6.1
6 workers [53 items]    
scheduling tests via LoadScheduling

test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/console_script_create_sector_image.sh] 
test_full_test.py::test_integ_test_script[$geoips_repopath/docs/build_docs.sh $data_fusion_repopath $data_fusion_pkgname html_only] 
test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/amsr2.config_based_overlay_output.sh] 
test_full_test.py::test_integ_test_script[$geoips_repopath/docs/build_docs.sh $geoips_repopath $geoips_pkgname html_only] 
test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/console_script_list_available_plugins.sh] 
test_full_test.py::test_integ_test_script[$geoips_repopath/tests/utils/check_code.sh all $recenter_tc_repopath] 
[gw1] [  1%] FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/console_script_create_sector_image.sh] 
test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/ami.tc.WV.geotiff.sh] 
[gw5] [  3%] FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/console_script_list_available_plugins.sh] 
test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/abi.static.Visible.imagery_annotated.sh] 
[gw4] [  5%] PASSED test_full_test.py::test_integ_test_script[$geoips_repopath/docs/build_docs.sh $data_fusion_repopath $data_fusion_pkgname html_only] 
```

...

``` bash

Fri Nov 8 22:52:37 UTC 2024  Running ahi.Cloud-Phase.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Cloud-Phase.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Cloud-Phase.imagery_clean.sh.log
        Return: 0

Fri Nov 8 22:52:50 UTC 2024  Running ahi.Effective-Radius.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Effective-Radius.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Effective-Radius.imagery_clean.sh.log
        Return: 0

Fri Nov 8 22:53:04 UTC 2024  Running ahi.Cloud-Temp-ACHA.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Cloud-Temp-ACHA.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Cloud-Temp-ACHA.imagery_clean.sh.log
        Return: 0

Fri Nov 8 22:53:17 UTC 2024  Running ahi.Cloud-Type.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Cloud-Type.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Cloud-Type.imagery_clean.sh.log
        Return: 0

Fri Nov 8 22:53:30 UTC 2024  Running ahi.Temp-11p0.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Temp-11p0.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Temp-11p0.imagery_clean.sh.log
        Return: 0

Fri Nov 8 22:53:42 UTC 2024  Running ahi.Temp-3p75.imagery_clean.sh
/app/geoips_packages/geoips_clavrx/tests/scripts/ahi.Temp-3p75.imagery_clean.sh
/output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log_ahi.Temp-3p75.imagery_clean.sh.log
        Return: 0


Fri Nov 8 22:53:55 UTC 2024  Running post, final results in /output/logs/20241108/20241108.224757_geoips_clavrx/test_all_geoips_clavrx.log

Package: geoips_clavrx
Total run time: 358 seconds
Number data types run: 14
Number data types failed: 1
Fri Nov  8 22:53:55 UTC 2024

============================================================== short test summary info ==============================================================
FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/utils/check_code.sh all $recenter_tc_repopath] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips/tests/integration_tests/full_install.sh', 'exit_on_missing']' retu...
FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/docs/build_docs.sh $template_basic_plugin_repopath $template_basic_plugin_pkgname html_only] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips/tests/integration_tests/full_install.sh', 'exit_on_missing']' retu...
FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/console_script_create_sector_image.sh] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips/tests/integration_tests/full_install.sh', 'exit_on_missing']' retu...
FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/ami.tc.WV.geotiff.sh] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips/tests/integration_tests/../../tests/scripts/ami.tc.WV.geotiff.sh']...
FAILED test_full_test.py::test_integ_test_script[$geoips_repopath/tests/scripts/amsr2.config_based_overlay_output.sh] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips/tests/integration_tests/../../tests/scripts/amsr2.config_based_ove...
FAILED test_full_test.py::test_integ_test_script[$geoips_clavrx_repopath/tests/test_all.sh] - subprocess.CalledProcessError: Command '['bash', '/app/geoips_packages/geoips_clavrx/tests/test_all.sh']' returned non-zero exit status 1.
===================================================== 6 failed, 47 passed in 497.16s (0:08:17) ======================================================

```

**Tests that are failing in examples can be ignored**