### PR TITLE
Make repo name optional, find repo path via importlib

### DIFF
--- a/.github/workflows/doc-test.yaml
+++ b/.github/workflows/doc-test.yaml
@@ -316,7 +316,7 @@ jobs:
           #   the path to the docs template directory in the geoips default branch.
           #   the repo url to use as a link to the package license if need be
           echo "Running python3 $BASE_GEOIPS_PATH/docs/build_docs.py . $run_on_package --geoips-docs-path $BASE_GEOIPS_PATH/docs --output-dir ./build/sphinx/html"
-          python3 $BASE_GEOIPS_PATH/docs/build_docs.py . $run_on_package --geoips-docs-path $BASE_GEOIPS_PATH/docs --output-dir ./build/sphinx/html
+          python3 $BASE_GEOIPS_PATH/docs/build_docs.py $run_on_package --geoips-docs-path $BASE_GEOIPS_PATH/docs --output-dir ./build/sphinx/html --repo-path .
           ret=$?
           if [[ "${ret##*:}" != *"0"* ]]; then
             echo "::error::Building html docs ${ret##*:}"

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -1,7 +1,7 @@
 """Builds geoips and geoips plugin documentation."""
 
 import tempfile
-import importlib
+import importlib.resources
 import importlib.util
 import warnings
 import logging

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -1,6 +1,7 @@
 """Builds geoips and geoips plugin documentation."""
 
 import tempfile
+import importlib
 import importlib.util
 import warnings
 import logging
@@ -69,12 +70,6 @@ def parse_args_with_argparse():
 
     # Required positional arguments
     parser.add_argument(
-        "repo_path",
-        type=str,
-        help="Path to the repository (e.g., /path/to/geoips)."
-        "Must be an existing directory.",
-    )
-    parser.add_argument(
         "package_name",
         type=str,
         help="Name of the package to build (e.g., geoips, data_fusion).",
@@ -103,9 +98,34 @@ def parse_args_with_argparse():
         default=None,
         help="Output dir to write built docs to",
     )
+    parser.add_argument(
+        "--repo-path",
+        type=str,
+        default=None,
+        help="Path to the repository (e.g., /path/to/geoips)."
+        "If not provided uses [package_name] to find the packages directory"
+        "Must be an existing directory.",
+    )
 
     # Parse arguments
     args = parser.parse_args()
+
+    if not args.repo_path:
+        try:
+            package_path = os.path.dirname(
+                str(importlib.resources.files(args.package_name))
+            )
+            if not package_path:
+                raise ModuleNotFoundError
+            pygit2.Repository(package_path)
+            args.repo_path = package_path
+        except ModuleNotFoundError as e:
+            raise e(f"Could not automatically find repo_path for {args.package_name}.")
+        except pygit2.GitError as e:
+            raise e(
+                "Could not automatically find usable repo_path for "
+                f"{args.package_name}. Found {package_path} but it is not a git repo"
+            )
 
     if not args.output_dir:
         output_dir = os.getenv("GEOIPS_DOCSDIR", None)

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -3,7 +3,7 @@
 
 #!/bin/sh
 echo "WARNING: This script has been deprecated. Please start calling build_docs.py instead"
-python3 $GEOIPS_PACKAGES_DIR/geoips/docs/build_docs.py --license-url $GEOIPS_REPO_URL --geoips-docs-path $GEOIPS_PACKAGES_DIR/$2/docs --output-dir "$GEOIPS_PACKAGES_DIR/$2/docs/build/sphinx/html" $1 $2
+python3 $GEOIPS_PACKAGES_DIR/geoips/docs/build_docs.py --license-url $GEOIPS_REPO_URL --geoips-docs-path $GEOIPS_PACKAGES_DIR/$2/docs --output-dir "$GEOIPS_PACKAGES_DIR/$2/docs/build/sphinx/html" --repo-path $1 $2
 
 
 

--- a/docs/source/new-docs/concepts/functionality/documentation-building.rst
+++ b/docs/source/new-docs/concepts/functionality/documentation-building.rst
@@ -11,10 +11,7 @@ Run `build_docs.py`  with the required positional arguments and optional flags:
 
 .. code-block:: bash
 
-    python build_docs.py [OPTIONS] <repo_path> <package_name>
-
-**repo_path:** Path to the repository (e.g., /path/to/geoips).
-Must be an existing directory and a valid Git repository.
+    python build_docs.py [OPTIONS] <package_name>
 
 **package_name:** Name of the package to build (e.g., geoips, data_fusion).
 
@@ -27,6 +24,10 @@ used when building geoips plugins.
 **--license-url:** URL pointing to the license or distribution statement
 for the release notes.
 Defaults to ``https://github.com/NRLMMD-GEOIPS/[package_name]``.
+
+**--repo-path:** Path to the repository (e.g., /path/to/geoips).
+Defaults to the parent of the directory found by importlib for the provided ``package_name``.
+Must be an existing directory and a valid Git repository.
 
 **--output-dir**: Directory where the built documentation will be placed.
 Defaults to ``[repo_path]/build/sphinx/html``.

--- a/docs/source/releases/latest/make-repo-name-optional-for-docs-build.yaml
+++ b/docs/source/releases/latest/make-repo-name-optional-for-docs-build.yaml
@@ -1,0 +1,111 @@
+enhancement:
+- title: 'Make repo_path optional for documentation building'
+  description: 'This changes the documentation builder to make repo_path an optional argument, and instead uses importlib to automatically find the packages installed directory.'
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'docs/build_docs.sh'
+    - 'docs/build_docs.py'
+    - '.github/workflows/doc-test.yaml'
+    - 'docs/source/new-docs/concepts/functionality/documentation-building.rst'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+deprecation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+removal:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+performance:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+documentation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+continuous integration:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null


### PR DESCRIPTION
* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required) - N/A
* [x] NO REQUIRED ***integration tests*** (explain why not required) - N/A
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)


Thanks @evrose54 for the suggestion! This is a great change. 🙂 

# Summary

This changes the documentation builder to make repo_path an optional argument, and instead uses importlib to automatically find the packages installed directory.
