### PR TITLE
updated test dataset location for geoips_clavrx and added release notes

### DIFF
--- a/docs/source/releases/latest/update-geoips-clavrx-test-data.yaml
+++ b/docs/source/releases/latest/update-geoips-clavrx-test-data.yaml
@@ -1,0 +1,10 @@
+testing:
+- title: 'Update GeoIPS CLAVR-X Test Data'
+  description: |
+    New updates made to GeoIPS, and corresponding plugin packages geoips_clavrx and
+    recenter tc introduced a new test script in geoips_clavrx that uses data not
+    originally included in the ``test_data_clavrx`` dataset. We've updated the
+    url of this dataset and the tar file to include this new test data.
+  files:
+    modified:
+      - setup/test-data-urls.yaml

--- a/setup/test-data-urls.yaml
+++ b/setup/test-data-urls.yaml
@@ -2,7 +2,7 @@ test_data_urls:
   test_data_fusion: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_fusion.tgz"
   test_data_noaa_aws: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_noaa_aws.tgz"
   test_data_amsr2: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_amsr2_1.6.0.tgz"
-  test_data_clavrx: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_clavrx_1.10.0.tgz"
+  test_data_clavrx: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_clavrx_1.14.1.tgz"
   test_data_gpm: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_gpm_1.6.0.tgz"
   test_data_sar: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_sar_1.12.2.tgz"
   test_data_scat: "https://io2.cira.colostate.edu/s/J73tEcn22smktMi/download?path=%2F&files=test_data_scat_1.11.3.tgz"


### PR DESCRIPTION
# Reviewer Checklist

* [ ] Required ***existing tests*** Running now.
* [x] NO REQUIRED ***unit tests*** Not applicable. Just updated a test dataset URL.
* [x] NO REQUIRED ***integration tests*** Not applicable. Just updated a test dataset URL.
* [x] NO REQUIRED ***documentation*** Not applicable. Just updated a test dataset URL.
* [x] Required ***release notes*** added for new/modified functionality
* [x] Required ***updates to other repos*** complete

# Related Issues
This PR stems from this comment: https://github.com/NRLMMD-GEOIPS/geoips_clavrx/pull/47/files#r1838991408.

# Testing Instructions
Run ``full_install.sh`` and the geoips_clavrx portions of``full_test.sh``.

# Summary
Note: stems from this comment: https://github.com/NRLMMD-GEOIPS/geoips_clavrx/pull/47/files#r1838991408, which was a dependent PR of #427.

New updates made to GeoIPS, and corresponding plugin packages geoips_clavrx and
recenter tc introduced a new test script in geoips_clavrx that uses data not
originally included in the ``test_data_clavrx`` dataset. We've updated the
url of this dataset and the tar file to include this new test data.

Modified:

    - setup/test-data-urls.yaml

