### PR TITLE
Update requirements.txt - prevent dependency conflict

### DIFF
--- a/docs/source/releases/1.14.4/dependency-fix.yaml
+++ b/docs/source/releases/1.14.4/dependency-fix.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Changed plaformdirs version in requirements.txt'
+  description: 'The previous platformdir version caused a circular dependency error, this updates the version number to allow installation from requirements.txt.'
+  files:
+    modified:
+    - 'environments/requirements.txt'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/environments/requirements.txt
+++ b/environments/requirements.txt
@@ -109,7 +109,7 @@ pinkrst==0.0.1.post2
 pipenv==2023.12.1
 pixelmatch==0.3.0
 pkginfo==1.9.6
-platformdirs==4.3.6
+platformdirs==3.11.0
 pluggy==1.5.0
 poetry==1.7.1
 poetry-core==1.8.1


### PR DESCRIPTION
Prevents a circular dependency fail when installing from `requirements.txt`