### PR TITLE
Remove duplicate base installation environment step

### DIFF
--- a/docs/source/starter/installation.rst
+++ b/docs/source/starter/installation.rst
@@ -135,23 +135,7 @@ and run integration tests:
     # Run integration tests
     $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_test.sh
 
-6. Capture working requirements.txt for base install
-----------------------------------------------------
-
-These can be commited to the repository for reference - only commit if
-base_test.sh returns 0!
-
-.. code:: bash
-
-  if [[ "$GEOIPS_VERS" == "" ]]; then
-      GEOIPS_VERS=`python -c "import geoips; print(geoips.__version__)"
-  fi
-
-  mkdir $GEOIPS_PACKAGES_DIR/geoips/environments
-  $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh dump_pip_environment $GEOIPS_PACKAGES_DIR/geoips/environments/pip_base_requirements_${GEOIPS_VERS}_`date -u +%Y%m%d`.txt
-  $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh dump_mamba_environment $GEOIPS_PACKAGES_DIR/geoips/environments/mamba_base_package_list_${GEOIPS_VERS}_`date -u +%Y%m%d`.yml
-
-7. Test output
+6. Test output
 --------------
 
 For reference, the end of the output from the base_test.sh command should


### PR DESCRIPTION
I found the optional!  Bad merge, I added a duplicate extra step for the base install requirements capture.

![image](https://github.com/user-attachments/assets/973f24f7-1743-4137-a454-bb3dd6cee7b3)

