### PR TITLE
Seviri hrit bug fix

### DIFF
--- a/docs/source/releases/latest/seviri_hrit-bug-fix.yaml
+++ b/docs/source/releases/latest/seviri_hrit-bug-fix.yaml
@@ -1,0 +1,21 @@
+bug fix:
+- title: 'seviri_hrit bug fix'
+  description: |
+    The seviri_hrit reader had a bug caused by meteosat second generation High
+    Resolution Visible (HRV) files. With our new reader updates which allow
+    geostationary readers to handle multiple scan times, we broke the method in which
+    this reader filtered out HRV files. The functionality was the same, but when
+    seviri_hrit:call_single_time was fed a singular file, and that file was HRV, an
+    error would occur in 'get_top_level_metadata'. This is due to the fact that we feed
+    in files to 'call_single_time' individually the first time around to get a list of
+    start datetimes, so we know which files to group together. We need to do the
+    filtering before we call 'call_single_time', and things will work as expected.
+  files:
+    modified:
+      - geoips/plugins/modules/readers/seviri_hrit.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 1/21/25
+    finish: 1/21/25

--- a/geoips/plugins/modules/readers/seviri_hrit.py
+++ b/geoips/plugins/modules/readers/seviri_hrit.py
@@ -508,10 +508,6 @@ def call_single_time(
     gvars = {}
     datavars = {}
     adname = "undefined"
-    # Remove any HRV files from file list
-    # See note 1 at top of module
-
-    fnames = [fname for fname in fnames if not any(val in fname for val in ["HRV"])]
     if not fnames:
         raise NoValidFilesError("No files found in list, skipping")
 
@@ -856,6 +852,13 @@ def call(fnames, metadata_only=False, chans=None, area_def=None, self_register=F
         Additional information regarding required attributes and variables
         for GeoIPS-formatted xarray Datasets.
     """
+    # Remove any HRV files from file list. Need to do this here instead of in
+    # 'call_single_time' as that will initially be fed one file at a time. If that file
+    # is a HRV file, then this will result in an empty list and an error thrown in
+    # 'get_top_level_metadata'.
+    # See note 1 at top of module
+    fnames = [fname for fname in fnames if not any(val in fname for val in ["HRV"])]
+
     return readers.read_data_to_xarray_dict(
         fnames,
         call_single_time,


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** pass for new/modified functionality
* [x] Required ***integration tests*** pass for new/modified functionality
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
N/A

# Testing Instructions
You can run ``test_integration.py`` or you can run all of the seviri related bash scripts and ensure that they output 0.

# Summary
The seviri_hrit reader had a bug caused by meteosat second generation High
Resolution Visible (HRV) files. With our new reader updates which allow
geostationary readers to handle multiple scan times, we broke the method in which
this reader filtered out HRV files. The functionality was the same, but when
seviri_hrit:call_single_time was fed a singular file, and that file was HRV, an
error would occur in 'get_top_level_metadata'. This is due to the fact that we feed
in files to 'call_single_time' individually the first time around to get a list of
start datetimes, so we know which files to group together. We need to do the
filtering before we call 'call_single_time', and things will work as expected.

modified:

    geoips/plugins/modules/readers/seviri_hrit.py

# Output
Here is the error output when seviri_hrit was fed ``any`` HRV file, even if all of the other files were not.

```
21_171247 single_source.py:1897 INTERACTIVE: Reading metadata from dataset with reader 'seviri_hrit'...
Traceback (most recent call last):
  File "/home/erose/anaconda3/envs/geoips/bin/geoips", line 8, in <module>
    sys.exit(main())
  File "/home/erose/geoips/geoips_packages/geoips/geoips/commandline/commandline_interface.py", line 199, in main
    geoips_cli.execute_command()
  File "/home/erose/geoips/geoips_packages/geoips/geoips/commandline/commandline_interface.py", line 108, in execute_command
    self.GEOIPS_ARGS.exe_command(self.GEOIPS_ARGS)
  File "/home/erose/geoips/geoips_packages/geoips/geoips/commandline/geoips_run.py", line 130, in __call__
    main(ARGS=args)
  File "/home/erose/geoips/geoips_packages/geoips/geoips/commandline/run_procflow.py", line 67, in main
    RETVAL = PROCFLOW(COMMAND_LINE_ARGS["filenames"], COMMAND_LINE_ARGS)
  File "/home/erose/geoips/geoips_packages/geoips/geoips/plugins/modules/procflows/single_source.py", line 1900, in call
    xobjs = reader_plugin(fnames, metadata_only=True, **reader_kwargs)
  File "/home/erose/geoips/geoips_packages/geoips/geoips/plugins/modules/readers/seviri_hrit.py", line 877, in call
    return readers.read_data_to_xarray_dict(
  File "/home/erose/geoips/geoips_packages/geoips/geoips/interfaces/module_based/readers.py", line 100, in read_data_to_xarray_dict
    read_single_time_func([x], metadata_only=True, chans=chans)[
  File "/home/erose/geoips/geoips_packages/geoips/geoips/plugins/modules/readers/seviri_hrit.py", line 543, in call_single_time
    xarray_obj.attrs = get_top_level_metadata(fnames, area_def)
  File "/home/erose/geoips/geoips_packages/geoips/geoips/plugins/modules/readers/seviri_hrit.py", line 192, in get_top_level_metadata
    if "GEOS" in df.metadata.get("block_2", {}).get("projection", {}):
UnboundLocalError: local variable 'df' referenced before assignment
```
Here is the output of the same test with the new changes:
```
22_190333 run_procflow.py:47   INTERACTIVE: 


Starting single_source procflow...


22_190333 run_procflow.py:62   INTERACTIVE: 


Running on filenames: ['/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-_________-EPI______-202501171400-__', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000009___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000010___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000011___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000012___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000013___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000014___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000015___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000016___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000017___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000018___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000019___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000020___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000021___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000022___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000023___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-HRV______-000024___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_016___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_039___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_087___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_097___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_108___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_120___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-IR_134___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-_________-PRO______-202501171400-__', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS006___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-VIS008___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_062___-000008___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000001___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000002___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000003___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000004___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000005___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000006___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000007___-202501171400-C_', '/mnt/sat/meteosat/meteosat-09/20250117/MSG2/H-000-MSG2__-MSG2_IODC___-WV_073___-000008___-202501171400-C_']


22_190333 single_source.py:1897 INTERACTIVE: Reading metadata from dataset with reader 'seviri_hrit'...
22_190333 single_source.py:1398 INTERACTIVE: Getting all area defs from command line args:
22_190333 single_source.py:1401 INTERACTIVE:   sector_list: ['mtg_i1']
22_190333 single_source.py:1404 INTERACTIVE:   tcdb_sector_list: None
22_190333 single_source.py:1407 INTERACTIVE:   tcdb: False
22_190333 single_source.py:1410 INTERACTIVE:   trackfile_sector_list: None
22_190333 single_source.py:1413 INTERACTIVE:   trackfiles: None
22_190333 single_source.py:1416 INTERACTIVE:   trackfile_parser: None
22_190333 single_source.py:1419 INTERACTIVE:   tc_spec_template: None
22_190333 single_source.py:1940 INTERACTIVE: Reading full dataset with reader 'seviri_hrit'...
22_190339 single_source.py:2067 INTERACTIVE: Sectoring xarrays, variables ['B09BT']...
22_190339 single_source.py:2106 INTERACTIVE: Producing sectored outputs...
22_190339 single_source.py:1595 INTERACTIVE: Applying algorithms and interpolation...
22_190339 single_source.py:248  INTERACTIVE: Resectoring xarrays without padding...
22_190340 single_source.py:1662 INTERACTIVE:   Applying interpolators...
22_190340 single_source.py:757  INTERACTIVE:   Interpolating data with interpolator 'interp_nearest' args '{'varlist': ['B09BT']}'...
22_190342 single_source.py:1685 INTERACTIVE:   Applying algorithms after interpolators...
22_190342 single_source.py:521  INTERACTIVE:   Applying 'list_numpy_to_numpy' family algorithm 'single_channel' to data...
22_190342 single_source.py:1705 INTERACTIVE:   Setting metadata on final xarray...
22_190342 single_source.py:2322 INTERACTIVE: Required coverage 0.0 for product Infrared, actual coverage 52.2229
22_190342 single_source.py:1201 INTERACTIVE: Producing product 'Infrared' final outputs as type 'imagery_annotated'...
22_190342 single_source.py:1281 INTERACTIVE:   Producing 'image_overlay' family final outputs 'imagery_annotated'...
22_190342    mpl_utils.py:186  INTERACTIVE: Writing /home/erose/geoips/geoips_packages/outdirs/preprocessed/annotated_imagery/Global-x-Meteosat_Third_Generation_I1/x-x-x/Infrared/seviri/20250117.140000.msg-2.seviri.Infrared.mtg_i1.52p22.nesdisstar.10p0.png
22_190344 single_source.py:2387 INTERACTIVE: 


Processing complete! Checking outputs...


22_190344 single_source.py:2427 INTERACTIVE: 


The following products were produced from procflow single_source.py


22_190344 single_source.py:2432 INTERACTIVE:     SINGLESOURCESUCCESS ${GEOIPS_OUTDIRS}/preprocessed/annotated_imagery/Global-x-Meteosat_Third_Generation_I1/x-x-x/Infrared/seviri/20250117.140000.msg-2.seviri.Infrared.mtg_i1.52p22.nesdisstar.10p0.png
22_190344 single_source.py:2443 INTERACTIVE: READER_NAME: seviri_hrit
22_190344 single_source.py:2444 INTERACTIVE: PRODUCT_NAME: Infrared
22_190344 single_source.py:2445 INTERACTIVE: NUM_PRODUCTS: 1
22_190344 single_source.py:2446 INTERACTIVE: NUM_DELETED_PRODUCTS: 0
22_190344 run_procflow.py:68   INTERACTIVE: Completed geoips PROCFLOW single_source processing, done!
22_190344 run_procflow.py:74   INTERACTIVE: Total time: 0:00:11.154250
22_190344 run_procflow.py:94   INTERACTIVE: Return value: 0
```
