### PR TITLE
Pin matplotlib for the time being

### DIFF
--- a/docs/source/releases/latest/hotfix-for-matplotlib3.10-changes.yaml
+++ b/docs/source/releases/latest/hotfix-for-matplotlib3.10-changes.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Hotfix for matplotlib regression'
+  description: 'Changes to matplotlib cause our imagery outputs to change. It is unclear why currently, but the changes are substantial. This rolls the version back as a hotfix while we work with the matplotlib team to discover what the root cause of these changes are.'
+  files:
+    modified:
+    - 'pyproject.toml'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: Jan 22 2025
+    finish: Jan 22 2025

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ build-backend = "poetry_dynamic_versioning.backend"                          # o
 # NOTE this setuptools dependency should be removed altogether once meson fortran builds are working
 setuptools = "<70"     # Required for any fortran builds until meson working
 python = ">=3.10.0"    # mandatory to declare the required python version
-matplotlib = ">=3.7.0" # Base requirement works, version specific to test outputs
+matplotlib = "<3.10.0,>=3.7.0" # Base requirement works, version specific to test outputs
 netcdf4 = "<1.7.0"    # Base requirement, netcdf 1.7.0 causes seg fault in ABI reader
 numpy = "<2.0"         # Base requirement numpy 1.26.4 still works, 2.0 breaks numexpr
 pyresample = "*"       # Base requirement Geospatial image resampling


### PR DESCRIPTION
* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [ ] NO REQUIRED ***unit tests***
* [ ] NO REQUIRED ***integration tests***
* [ ] NO REQUIRED ***documentation***
* [ ] Required ***release notes*** added for new/modified functionality
* [ ] NO REQUIRED ***updates to other repos***

# Testing Instructions
Run the integration tests.

# Summary

Changes to matplotlib cause our imagery outputs to change. It is unclear why currently, but the changes are substantial. This rolls the version back as a hotfix while we work with the matplotlib team to discover what the root cause of these changes are. See this issue for more information: https://github.com/matplotlib/matplotlib/issues/29504
