### PR TITLE
Update pytest ini file to add GeoIPS repo root to pythonpath on pytest run

### DIFF
--- a/.github/workflows/build-stable-image.yaml
+++ b/.github/workflows/build-stable-image.yaml
@@ -34,7 +34,7 @@ jobs:
     # Note since this is run after merge to main, reusable-build-docker-image will
     # build the stable image specifically, which will subsequently be used by
     # the plugin packages.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@main
     permissions:
       contents: write
       packages: write

--- a/docs/source/releases/latest/pytest-add-rootdir-to-pythonpath.yaml
+++ b/docs/source/releases/latest/pytest-add-rootdir-to-pythonpath.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Update pytest ini file to add GeoIPS repo root to pythonpath on pytest run '
+  description: 'Fixes failing unit tests that should be passing that started raising import errors by adding the root repo dir to the python path. This was previously automatically done by installing GeoIPS in editable mode.'
+  files:
+    modified: 
+    - 'pytest.ini'
+  related-issue:
+    number: 875
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips/'
+  date:
+    start: Jan 21 2025
+    finish: Jan 23 2025

--- a/docs/source/releases/latest/pytest-add-rootdir-to-pythonpath.yaml
+++ b/docs/source/releases/latest/pytest-add-rootdir-to-pythonpath.yaml
@@ -1,5 +1,5 @@
 bug fix:
-- title: 'Update pytest ini file to add GeoIPS repo root to pythonpath on pytest run '
+- title: 'Update pytest ini file to add GeoIPS repo root to pythonpath on pytest run'
   description: 'Fixes failing unit tests that should be passing that started raising import errors by adding the root repo dir to the python path. This was previously automatically done by installing GeoIPS in editable mode.'
   files:
     modified: 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = -v -rf --ff --cov-report=term-missing -m "not integration"
+pythonpath = .
 testpaths =
     tests/unit_tests*
     tests/integration_tests*


### PR DESCRIPTION
* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
Fixes #875 
partially completes work needed to resolve NRLMMD-GEOIPS/geoips#877

# Testing Instructions
Run CI and hope for ✅ 

# Summary
Fixes failing unit tests that should be passing that started raising import errors by adding the root repo dir to the python path. This was previously automatically done by installing GeoIPS in editable mode. Tests should pass in editable or non-editable mode, and this helps accomplish that goal. See also https://github.com/NRLMMD-GEOIPS/geoips/issues/877 and https://github.com/NRLMMD-GEOIPS/geoips_ci/pull/17
