### PR TITLE
Get Plugin Metadata

### DIFF
--- a/docs/source/releases/latest/create-get-plugin-metadata.yaml
+++ b/docs/source/releases/latest/create-get-plugin-metadata.yaml
@@ -1,0 +1,19 @@
+enhancement:
+- title: 'Get Plugin Metadata'
+  description: |
+    Added a new method to all interfaces which retrieves the top level metadata for any
+    given plugin. It does not actually load in the plugin, rather it makes use of the
+    registry to gather the plugin's associated metadata.
+
+    This is useful for quick validation of the base information supplied by plugins, and
+    may also be used by the order based procflow.
+  files:
+    modified:
+      - geoips/interfaces/base.py
+      - geoips/interfaces/yaml_based/products.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 1/30/25
+    finish: 1/30/25

--- a/docs/source/releases/latest/create-get-plugin-metadata.yaml
+++ b/docs/source/releases/latest/create-get-plugin-metadata.yaml
@@ -11,6 +11,8 @@ enhancement:
     modified:
       - geoips/interfaces/base.py
       - geoips/interfaces/yaml_based/products.py
+    added:
+      - tests/unit_tests/plugins/test_get_plugin_metadata.py
   related-issue:
     number: null
     repo_url: ''

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -303,6 +303,8 @@ class BaseInterface:
     from geoips.plugin_registry import plugin_registry
 
     plugin_registry = plugin_registry
+    name = "BaseInterface"
+    interface_type = None  # This is set by child classes
 
     def __new__(cls):
         """Plugin interface new method."""
@@ -352,6 +354,45 @@ class BaseInterface:
                     "Plugin registries not found, please run 'create_plugin_registries'"
                 )
         return self._registered_yaml_based_plugins
+
+    def get_plugin_metadata(self, name):
+        """Retrieve a plugin's metadata.
+
+        Where the metadata of the plugin matches the plugin's corresponding entry in the
+        plugin registry.
+
+        Parameters
+        ----------
+        name: str or tuple(str)
+            - The name of the plugin whose metadata we want.
+
+        Returns
+        -------
+        metadata: dict
+            - A dictionary of metadata for the requested plugin.
+        """
+        interface_registry = self.plugin_registry.registered_plugins[
+            self.interface_type
+        ][self.name]
+        if isinstance(name, tuple):
+            # This occurs for product plugins: i.e. ('abi', 'Infrared')
+            metadata = interface_registry.get(name[0], {}).get(name[1])
+        elif isinstance(name, str):
+            metadata = interface_registry.get(name)
+        else:
+            raise KeyError(
+                f"Error: cannot search the plugin registry with the provided name = "
+                f"{name}. Please provide either a string or a tuple of strings."
+            )
+
+        if metadata is None:
+            raise PluginRegistryError(
+                f"Error: There is no associated plugin under interface '{self.name}' "
+                f"called '{name}'. If you're sure this plugin exists, please run "
+                "'create_plugin_registries'."
+            )
+
+        return metadata
 
 
 class BaseYamlInterface(BaseInterface):

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -371,9 +371,16 @@ class BaseInterface:
         metadata: dict
             - A dictionary of metadata for the requested plugin.
         """
-        interface_registry = self.plugin_registry.registered_plugins[
-            self.interface_type
-        ][self.name]
+        interface_registry = self.plugin_registry.registered_plugins.get(
+            self.interface_type, {}
+        ).get(self.name)
+
+        if interface_registry is None:
+            raise KeyError(
+                "Error: There is no interface in the plugin registry of type '"
+                f"{self.interface_type}' called '{self.name}'."
+            )
+
         if isinstance(name, tuple):
             # This occurs for product plugins: i.e. ('abi', 'Infrared')
             metadata = interface_registry.get(name[0], {}).get(name[1])

--- a/geoips/interfaces/yaml_based/products.py
+++ b/geoips/interfaces/yaml_based/products.py
@@ -97,6 +97,26 @@ class ProductsInterface(BaseYamlInterface):
             names += [(source_name, yaml_plugin["name"])]
         return names
 
+    def get_plugin_metadata(self, source_name, name):
+        """Retrieve a product plugin's metadata.
+
+        Where the metadata of the plugin matches the plugin's corresponding entry in the
+        plugin registry.
+
+        Parameters
+        ----------
+        source_name: str
+            - The source (sensor) which this product is derived from.
+        name: str
+            - The name of the product plugin whose metadata we'd like to retrieve.
+
+        Returns
+        -------
+        metadata: dict
+            - A dictionary of metadata for the requested plugin.
+        """
+        return super().get_plugin_metadata((source_name, name))
+
     def get_plugin(self, source_name, name, product_spec_override=None):
         """Retrieve a Product plugin by source_name, name, and product_spec_override.
 

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -312,7 +312,7 @@ class BaseCliTest(abc.ABC):
             case _ if "linting" in args:
                 # Can't capture linting output using monkeypatch... yet
                 return False
-            case _ if ("test" in args and "script" in args):
+            case _ if "test" in args and "script" in args:
                 # Can't capture bash script output using monkeypatch... yet
                 return False
             case _ if (
@@ -325,10 +325,10 @@ class BaseCliTest(abc.ABC):
             case _ if any(["non_existent" in arg for arg in args]):
                 # Can't capture argparse.ArgumentError output using monkeypatch... yet
                 return False
-            case _ if ("--long" in args and "--columns" in args):
+            case _ if "--long" in args and "--columns" in args:
                 # Can't capture argparse.ArgumentError output using monkeypatch... yet
                 return False
-            case _ if ("--max-depth" in args and "-1" in args):
+            case _ if "--max-depth" in args and "-1" in args:
                 # Can't capture argparse.ArgumentError output using monkeypatch... yet
                 return False
             case _:

--- a/tests/unit_tests/plugins/test_get_plugin_metadata.py
+++ b/tests/unit_tests/plugins/test_get_plugin_metadata.py
@@ -1,0 +1,93 @@
+"""Unit test for the interface method 'get_plugin_metadata'."""
+
+import pytest
+
+from geoips import interfaces
+from geoips.errors import PluginRegistryError
+
+
+def generate_id(iname_pname):
+    """Generate an ID for the test-arguments provided."""
+    interface = iname_pname[0]
+    plugin_name = iname_pname[1]
+    if isinstance(plugin_name, tuple):
+        return f"{interface} " + " ".join(plugin_name)
+    return f"{interface} {str(plugin_name)}"
+
+
+int_plg_pairs = []
+
+idict = interfaces.list_available_interfaces()
+
+for itype in idict:
+    for iname in idict[itype]:
+        interface = getattr(interfaces, iname)
+        iregistry = interface.plugin_registry.registered_plugins.get(itype, {}).get(
+            iname
+        )
+        if iregistry:
+            if iname != "products":
+                for pname in iregistry:
+                    int_plg_pairs.append([iname, pname])
+            else:
+                for sname in iregistry:
+                    for pname in iregistry[sname]:
+                        int_plg_pairs.append([iname, (sname, pname)])
+
+int_plg_pairs.append(["fake_interface", "fake_plugin"])
+int_plg_pairs.append(["algorithms", 2])
+int_plg_pairs.append(["algorithms", "non_existent_plugin"])
+
+
+@pytest.mark.parametrize(
+    "iname_pname",
+    int_plg_pairs,
+    ids=generate_id,
+)
+def test_get_plugin_metadata(iname_pname):
+    """Test that <interface_name>.get_plugin_metadata(<name>) works as expected.
+
+    Includes failing cases as well. This should hit 100% coverage for the new code.
+    """
+    iname = iname_pname[0]
+    pname = iname_pname[1]
+
+    if iname == "fake_interface":
+        interface = getattr(interfaces, "algorithms")
+        interface.interface_type = "some_fake_type"
+        # Failing case 1
+        with pytest.raises(KeyError):
+            md = interface.get_plugin_metadata(pname)
+        # Make sure to reset the interface type; algorithms will need this later on
+        interface.interface_type = "module_based"
+        return
+    else:
+        interface = getattr(interfaces, iname)
+
+    if isinstance(pname, tuple):
+        md = interface.get_plugin_metadata(*pname)
+    else:
+        # Failing case 2
+        if pname == 2:
+            with pytest.raises(KeyError):
+                md = interface.get_plugin_metadata(pname)
+            return
+        # Failing case 3
+        elif pname == "non_existent_plugin":
+            with pytest.raises(PluginRegistryError):
+                md = interface.get_plugin_metadata(pname)
+            return
+        # Any other case should pass
+        else:
+            md = interface.get_plugin_metadata(pname)
+
+    # All of these keys should exist for every plugin type
+    for key in [
+        "docstring",
+        "family",
+        "interface",
+        "package",
+        "plugin_type",
+        "relpath",
+    ]:
+        assert key in md


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** added and pass for new/modified functionality
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
N/A.

# Testing Instructions
In the ``tests/unit_tests/plugins/`` folder, run ``pytest -v test_get_plugin_metadata.py``. Passing 100% of tests on my end.

# Summary
Added a new method to all interfaces which retrieves the top level metadata for any
given plugin. It does not actually load in the plugin, rather it makes use of the
registry to gather the plugin's associated metadata.

This is useful for quick validation of the base information supplied by plugins, and
may also be used by the order based procflow.

Files Modified:

    geoips/interfaces/base.py
    geoips/interfaces/yaml_based/products.py

Files Added:

    tests/unit_tests/plugins/test_get_plugin_metadata.py

# Output
Some example IPython output:
```python
In [1]: from geoips.interfaces import sectors, products, algorithms

In [2]: products.get_plugin_metadata("abi", "Infrared")
Out[2]: 
{'docstring': '11.2 µm Infrared.  This product utilizes channel 14 (11.2 µm) and highlights areas of deep convection within a Tropical Cyclone.',
 'family': None,
 'interface': 'products',
 'package': 'geoips',
 'plugin_type': 'yaml_based',
 'product_defaults': 'Infrared',
 'source_names': ['abi'],
 'relpath': 'plugins/yaml/products/abi.yaml'}

In [3]: algorithms.get_plugin_metadata("single_channel")
Out[3]: 
{'docstring': 'Data manipulation steps for standard "single_channel" algorithm.\nGeneralized algorithm to apply data manipulation steps in a standard order to apply corrections to a single channel output product.',
 'family': 'list_numpy_to_numpy',
 'interface': 'algorithms',
 'package': 'geoips',
 'plugin_type': 'module_based',
 'signature': "(arrays, output_data_range=None, input_units=None, output_units=None, min_outbounds='crop', max_outbounds='crop', norm=False, inverse=False, sun_zen_correction=False, mask_night=False, max_day_zen=None, mask_day=False, min_night_zen=None, gamma_list=None, scale_factor=None, satellite_zenith_angle_cutoff=None)",
 'relpath': 'plugins/modules/algorithms/single_channel.py'}

In [4]: sectors.get_plugin_metadata("australia")
Out[4]: 
{'docstring': 'Australian Continent',
 'family': 'area_definition_static',
 'interface': 'sectors',
 'package': 'geoips',
 'plugin_type': 'yaml_based',
 'relpath': 'plugins/yaml/sectors/static/australia.yaml'}
```
