### PR TITLE
Non editable unit test fix

### DIFF
--- a/docs/source/releases/latest/non-editable-unit-test-fix.yaml
+++ b/docs/source/releases/latest/non-editable-unit-test-fix.yaml
@@ -1,0 +1,18 @@
+bug fix:
+- title: 'Non-Editable Unit Test Fix'
+  description: |
+    @mindyls pointed out that the 'geoips list unit-tests' unit-test module was failing
+    when one or more package was installed in non-editable mode. This wasn't caught by
+    our github actions as we install packages in editable mode for testing. We should
+    probably change this to test in both modes for the future.
+
+    This PR updated some of the commandline unit test code, specifically for
+    non-editable mode cases, to fix these failing tests. All commandline unit tests on
+    my end are now passing.
+  files:
+    modified:
+      - tests/unit_tests/commandline/cli_top_level_tester.py
+      - tests/unit_tests/commandline/test_geoips_list_scripts.py
+  date:
+    start: 02/24/25
+    finish: 02/24/25

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -130,34 +130,35 @@ class BaseCliTest(abc.ABC):
         editable: bool
             - The truth value of whether or not all packages were editable.
         """
-        editable = True
-        for pkg_name in self.plugin_package_names:
-            if (
-                ("-p" not in args or "-p" in args and "geoips" in args[1:])
-                and is_editable("geoips")
-                and args[:3] == ["geoips", "test", "script"]
-            ):
-                # If we are specifically using the geoips package for
-                # 'geoips test script', check to see if it's in editable mode or not.
-                # If it's editable, just break and keep editable as True. Otherwise, if
-                # an invalid package is supplied, the last else statement in the
-                # 'if not editable' conditional below should be raised.
+        # Test if a package was specified and is installed in non-editable mode
+        pkg_idx = -1
+        pkg_name = None
+        # Default to last item of args. If no argument is provided after -p, an
+        # error will be raised later anyways.
+        for idx, arg in enumerate(args):
+            if arg == "-p" and len(args) > idx + 1:
+                # That means a package was provided. It might not be valid, but we
+                # don't care. We'll test this in the if statements below.
+                pkg_idx = idx + 1
+                pkg_name = args[pkg_idx]
                 break
-            elif not is_editable(pkg_name):
-                editable = False
-                break
-        if not editable:
-            # One of the installed packages was found to be in non-editable mode
-            pkg_idx = -1
-            # Default to last item of args. If no argument is provided after -p, an
-            # error will be raised anyways.
-            for idx, arg in enumerate(args):
-                if arg == "-p" and len(args) > idx + 1:
-                    # That means a package was provided. It might not be valid, but we
-                    # don't care. We'll test this in the if statements below.
-                    pkg_idx = idx + 1
-                    break
 
+        if pkg_name is not None and pkg_name not in self.plugin_package_names:
+            # If the package provided is not a valid package, check for that error
+            # instead
+            assert f"{args[2]}: error: argument --package_name/-p: invalid" in error
+            return False
+
+        if pkg_name:
+            # Just test if this package is in editable mode
+            editable = is_editable(pkg_name)
+        else:
+            # Otherwise, assume we're working on all installed packages
+            editable = any(
+                [is_editable(pkg_name) for pkg_name in self.plugin_package_names]
+            )
+
+        if not editable:
             if "-p" in args and "--integration" in args and "geoips" not in args[1:]:
                 # This is a specific case for the integration test scripts that
                 # only work for geoips. Make sure an error is raised that says
@@ -169,18 +170,10 @@ class BaseCliTest(abc.ABC):
                     "error: argument --package_name/-p: invalid choice:"
                 )
                 assert integration_error in error or package_name_error in error
-            elif (
-                "-p" in args
-                and args[pkg_idx] in self.plugin_package_names
-                or "-p" not in args
-            ):
+            else:
                 # If the package provided is a valid installed package, assert that
                 # an non-editable error was raised
                 assert "is installed in non-editable mode" in error
-            else:
-                # If the package provided is not a valid package, check for that error
-                # instead
-                assert f"{args[2]}: error: argument --package_name/-p: invalid" in error
         return editable
 
     @property

--- a/tests/unit_tests/commandline/test_geoips_list_scripts.py
+++ b/tests/unit_tests/commandline/test_geoips_list_scripts.py
@@ -11,6 +11,8 @@ from importlib import resources
 from os.path import basename
 import pytest
 
+from geoips.geoips_utils import is_editable
+
 from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
 
 
@@ -85,6 +87,10 @@ class TestGeoipsListScripts(BaseCliTest):
         # The args provided are valid, so test that the output is actually correct
         if "-h" in args:
             assert "usage: To use, type `geoips list scripts`" in output
+        elif "-p" not in args and any(
+            [is_editable(pkg_name) for pkg_name in self.plugin_package_names]
+        ):
+            self.assert_non_editable_error_or_wrong_package(args, output)
         else:
             # Checking tabular output from the list-scripts command
             if "-p" in args:
@@ -136,4 +142,5 @@ def test_command_combinations(monkeypatch, args):
     args: 2D array of str
         - List of arguments to call the CLI with (ie. ['geoips', 'list', 'scripts'])
     """
+    # if "-p" not in args and
     test_sub_cmd.test_command_combinations(monkeypatch, args)


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** added and pass for new/modified functionality
* [x] Required ***integration tests*** added and pass for new/modified functionality
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
N/A

# Testing Instructions
Run ``pytest -v $GEOIPS_PACKAGES_DIR/geoips/tests/unit_tests/commandline/``

# Summary
@mindyls pointed out that the 'geoips list unit-tests' unit-test module was failing
when one or more package was installed in non-editable mode. This wasn't caught by
our github actions as we install packages in editable mode for testing. We should
probably change this to test in both modes for the future.

This PR updated some of the commandline unit test code, specifically for
non-editable mode cases, to fix these failing tests. All commandline unit tests on
my end are now passing.

Modified:

    - tests/unit_tests/commandline/cli_top_level_tester.py
    - tests/unit_tests/commandline/test_geoips_list_scripts.py

# Output
Commandline unit test output.
```
================================================================================= warnings summary ==================================================================================
tests/unit_tests/commandline/test_geoips_validate.py::test_command_combinations[geoips validate /local/home/evan/geoips/geoips_packages/geoips/geoips/plugins/modules/readers/abi_l2_netcdf.py]
  <frozen importlib._bootstrap>:241: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 1755 passed, 1 warning in 126.73s (0:02:06) ====================================================================
```
