### PR TITLE
Update base_paths.py with default outdir

### DIFF
--- a/docs/source/releases/latest/make-geoips-pipable.yaml
+++ b/docs/source/releases/latest/make-geoips-pipable.yaml
@@ -1,6 +1,6 @@
 enhancement:
 - title: 'Add default GEOIPS_OUTDIRS so pip installs of geoips do not immediately crash.'
-  description: 'Set GEOIPS_OUTDIRS to current working directory and added warning when using the default.'
+  description: 'Set GEOIPS_OUTDIRS to $HOME/GEOIPS_OUTDIR and added warning when using the default.'
   files:
     modified:
     - 'geoips/filenames/base_paths.py'

--- a/docs/source/releases/latest/make-geoips-pipable.yaml
+++ b/docs/source/releases/latest/make-geoips-pipable.yaml
@@ -1,0 +1,12 @@
+enhancement:
+- title: 'Add default GEOIPS_OUTDIRS so pip installs of geoips do not immediately crash.'
+  description: 'Set GEOIPS_OUTDIRS to current working directory and added warning when using the default.'
+  files:
+    modified:
+    - 'geoips/filenames/base_paths.py'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/docs/source/releases/latest/make-geoips-pipable.yaml
+++ b/docs/source/releases/latest/make-geoips-pipable.yaml
@@ -1,6 +1,6 @@
 enhancement:
 - title: 'Add default GEOIPS_OUTDIRS so pip installs of geoips do not immediately crash.'
-  description: 'Set GEOIPS_OUTDIRS to $HOME/GEOIPS_OUTDIR and added warning when using the default.'
+  description: 'Set GEOIPS_OUTDIRS to $HOME/GEOIPS_OUTDIRS and added warning when using the default.'
   files:
     modified:
     - 'geoips/filenames/base_paths.py'

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -6,10 +6,11 @@
 This module sets various directory paths required for GeoIPS.
 Setting these variables here keeps geoips code and outputs consolidated.
 Eventually, we aim to supplant this method of setting variables with a config file.
-`GEOIPS_OUTDIRS` serves as the base reference for all other variables.
-It defaults to the values set in environment variables.
-It also provides a function for creating directories.
+`GEOIPS_OUTDIRS` serves as the base reference for all other variables and defaults
+to the current directory.
 
+The module defaults to the values set in environment variables for all other variables.
+It also provides a function for creating directories.
 
 Functions
 ---------
@@ -28,6 +29,8 @@ Environment Variables:
 import logging
 import os
 import socket
+
+LOG = logging.getLogger(__name__)
 
 
 def get_env_var(var_name, default, rstrip_path=True):
@@ -80,11 +83,15 @@ def initialize_paths():
 
     # Output Directories
     if not os.getenv("GEOIPS_OUTDIRS"):
-        raise KeyError(
-            "GEOIPS_OUTDIRS must be set in your environment. "
-            "Please set GEOIPS_OUTDIRS and try again"
+        LOG.warning(
+            "GEOIPS_OUTDIRS is not set in your environment. "
+            "Defaulting to current directory as output dir."
+            "Please set GEOIPS_OUTDIRS if you want to write to a different directory "
+            "by default."
         )
-    paths["GEOIPS_OUTDIRS"] = os.getenv("GEOIPS_OUTDIRS").rstrip("/")
+        paths["GEOIPS_OUTDIRS"] = os.getcwd()
+    else:
+        paths["GEOIPS_OUTDIRS"] = os.getenv("GEOIPS_OUTDIRS").rstrip("/")
     paths["GEOIPS_PACKAGES_DIR"] = os.path.abspath(
         os.path.join(paths["BASE_PATH"], os.pardir, os.pardir)
     )
@@ -220,8 +227,6 @@ def make_dirs(path):
     os.makedirs(path, mode=0o755, exist_ok=True)
     return path
 
-
-LOG = logging.getLogger(__name__)
 
 # Initialize the PATHS dictionary
 PATHS = initialize_paths()

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -82,10 +82,12 @@ def initialize_paths():
     )
 
     # Output Directories
-    if not os.getenv("GEOIPS_OUTDIRS"):
+    try:
+        paths["GEOIPS_OUTDIRS"] = os.environ["GEOIPS_OUTDIRS"].rstrip("/")
+    except KeyError:
         LOG.warning(
             "GEOIPS_OUTDIRS is not set in your environment. "
-            "Defaulting to $HOME/GEOIPS_OUTDIR as output dir. "
+            "Defaulting to $HOME/GEOIPS_OUTDIRS as output dir. "
             "Please set GEOIPS_OUTDIRS if you want to write to a different directory "
             "by default."
         )
@@ -94,9 +96,7 @@ def initialize_paths():
         except KeyError:
             LOG.error("Could not resolve enviorment variable '$HOME', using '/' as default")
             home_dir = "/"
-        paths["GEOIPS_OUTDIRS"] = os.path.join(home_dir, "GEOIPS_OUTDIR")
-    else:
-        paths["GEOIPS_OUTDIRS"] = os.getenv("GEOIPS_OUTDIRS").rstrip("/")
+        paths["GEOIPS_OUTDIRS"] = os.path.join(home_dir, "GEOIPS_OUTDIRS")
     paths["GEOIPS_PACKAGES_DIR"] = os.path.abspath(
         os.path.join(paths["BASE_PATH"], os.pardir, os.pardir)
     )

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -88,13 +88,14 @@ def initialize_paths():
         LOG.warning(
             "GEOIPS_OUTDIRS is not set in your environment. "
             "Defaulting to $HOME/GEOIPS_OUTDIRS as output dir. "
-            "Please set GEOIPS_OUTDIRS if you want to write to a different directory "
-            "by default."
+            "Please set GEOIPS_OUTDIRS if you want to write to a "
+            "different directory by default."
         )
         try:
             home_dir = os.environ["HOME"]
         except KeyError:
-            LOG.error("Could not resolve enviorment variable '$HOME', using '/' as default")
+            LOG.error("Could not resolve enviorment variable "
+                      "'$HOME', using '/' as default")
             home_dir = "/"
         paths["GEOIPS_OUTDIRS"] = os.path.join(home_dir, "GEOIPS_OUTDIRS")
     paths["GEOIPS_PACKAGES_DIR"] = os.path.abspath(

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -94,8 +94,9 @@ def initialize_paths():
         try:
             home_dir = os.environ["HOME"]
         except KeyError:
-            LOG.error("Could not resolve enviorment variable "
-                      "'$HOME', using '/' as default")
+            LOG.error(
+                "Could not resolve enviorment variable " "'$HOME', using '/' as default"
+            )
             home_dir = "/"
         paths["GEOIPS_OUTDIRS"] = os.path.join(home_dir, "GEOIPS_OUTDIRS")
     paths["GEOIPS_PACKAGES_DIR"] = os.path.abspath(

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -85,7 +85,7 @@ def initialize_paths():
     if not os.getenv("GEOIPS_OUTDIRS"):
         LOG.warning(
             "GEOIPS_OUTDIRS is not set in your environment. "
-            "Defaulting to current directory as output dir."
+            "Defaulting to current directory as output dir. "
             "Please set GEOIPS_OUTDIRS if you want to write to a different directory "
             "by default."
         )

--- a/geoips/filenames/base_paths.py
+++ b/geoips/filenames/base_paths.py
@@ -85,11 +85,16 @@ def initialize_paths():
     if not os.getenv("GEOIPS_OUTDIRS"):
         LOG.warning(
             "GEOIPS_OUTDIRS is not set in your environment. "
-            "Defaulting to current directory as output dir. "
+            "Defaulting to $HOME/GEOIPS_OUTDIR as output dir. "
             "Please set GEOIPS_OUTDIRS if you want to write to a different directory "
             "by default."
         )
-        paths["GEOIPS_OUTDIRS"] = os.getcwd()
+        try:
+            home_dir = os.environ["HOME"]
+        except KeyError:
+            LOG.error("Could not resolve enviorment variable '$HOME', using '/' as default")
+            home_dir = "/"
+        paths["GEOIPS_OUTDIRS"] = os.path.join(home_dir, "GEOIPS_OUTDIR")
     else:
         paths["GEOIPS_OUTDIRS"] = os.getenv("GEOIPS_OUTDIRS").rstrip("/")
     paths["GEOIPS_PACKAGES_DIR"] = os.path.abspath(


### PR DESCRIPTION
* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Background

GeoIPS has many installation steps to get to being able to run anything in GeoIPS. This removes the step of setting GEOIPS_OUTDIRS as a prerequisite for running any GeoIPS command (even `--help`, see below). It now default to $HOME/GEOIPS_OUTDIRS, warns the user that is happening and provides info about GEOIPS_OUTDIRS. In the future it will point to a config file instead.

A worry about switching is that users might accidentally write large files to their home directory. However, users should already be aware of the massive size of many geolocated datasets and that many tools that work with them have the potential to write large files in a undesirable place. So that no one is caught unaware, a warning has been added that will likely be the very first line of any log file where GEOIPS_OUTDIRS is not set.

This PR does not change existing behavior if GEOIPS_OUTDIRS is set.

``` bash
root@708e32800517:/# geoips --help
Traceback (most recent call last):
  File "/usr/local/bin/geoips", line 5, in <module>
    from geoips.commandline.commandline_interface import main
  File "/usr/local/lib/python3.10/site-packages/geoips/__init__.py", line 22, in <module>
    from geoips import interfaces
  File "/usr/local/lib/python3.10/site-packages/geoips/interfaces/__init__.py", line 18, in <module>
    from geoips.interfaces.module_based.algorithms import algorithms
  File "/usr/local/lib/python3.10/site-packages/geoips/interfaces/module_based/algorithms.py", line 6, in <module>
    from geoips.interfaces.base import BaseModuleInterface
  File "/usr/local/lib/python3.10/site-packages/geoips/interfaces/base.py", line 23, in <module>
    from geoips.filenames.base_paths import PATHS
  File "/usr/local/lib/python3.10/site-packages/geoips/filenames/base_paths.py", line 227, in <module>
    PATHS = initialize_paths()
  File "/usr/local/lib/python3.10/site-packages/geoips/filenames/base_paths.py", line 83, in initialize_paths
    raise KeyError(
KeyError: 'GEOIPS_OUTDIRS must be set in your environment. Please set GEOIPS_OUTDIRS and try again'
```

# Testing Instructions
Install GeoIPS without any environmental variables set and confirm you can run simple toy tasks, like outputting `--help`.
