### PR TITLE
Commandline Fix for Multi-Document YAML Files

### DIFF
--- a/docs/source/releases/latest/unit-test-fix-for-multi-doc-yaml-plugins.yaml
+++ b/docs/source/releases/latest/unit-test-fix-for-multi-doc-yaml-plugins.yaml
@@ -1,0 +1,25 @@
+bug fix:
+- title: 'Commandline Fix for Multi-Document YAML Files'
+  description: |
+    In the upcoming order-based-procflow PRs, we've introduced a new plugin type called
+    'workflows' which can be structured as a multi-document yaml file if wanted.
+    workflows.get_plugin(<plugin_name>) works just fine, but when attempting to validate
+    a file via 'geoips validate <yaml_fpath>', it would fail if the file was structured
+    as a multi-document as it was not coded to handle that. This PR fixes this bug
+    by adding logic to handle multi-document files if an extra argument is provided.
+    Now a user can validate a workflow plugin in a multi-document yaml file by
+    running this modified command 'geoips validate <fpath> <plugin_name>'. Unit tests
+    will skip validating these plugins.
+
+    See tests/unit_tests/commandline/test_geoips_validate.py for more information.
+  files:
+    modified:
+      - geoips/commandline/ancillary_info/cmd_instructions.yaml
+      - geoips/commandline/geoips_validate.py
+      - tests/unit_tests/commandline/test_geoips_validate.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 03/25/25
+    finish: 03/25/25

--- a/geoips/commandline/ancillary_info/cmd_instructions.yaml
+++ b/geoips/commandline/ancillary_info/cmd_instructions.yaml
@@ -414,8 +414,10 @@ instructions:
     help_str: |
       Validate a GeoIPS Plugin found at <file_path>. While this is done under the hood
       via GeoIPS, this is an easy way to test whether or not the plugin you are
-      developing is valid.
+      developing is valid. If the <file_path> you're trying to validate is a
+      multi-document YAML file, you'll also need to provide the name of the plugin
+      within that file for this command to work.
     usage_str: |
-      To use, type `geoips validate <file_path>`. Do it man. NOW.
+      To use, type `geoips validate <file_path> OPT_ARG <plugin_name>`.
     output_info:
       - A message telling you if the plugin is valid or not and why.

--- a/geoips/commandline/geoips_validate.py
+++ b/geoips/commandline/geoips_validate.py
@@ -30,6 +30,15 @@ class GeoipsValidate(GeoipsExecutableCommand):
             type=str,
             help="File path which represents a GeoIPS Plugin that we want to validate.",
         )
+        self.parser.add_argument(
+            "plugin_name",
+            type=str,
+            default=None,
+            help=(
+                "The name of the plugin in the file if applicable. Only useful if your "
+                "file is a multi-document yaml file."
+            ),
+        )
 
     def __call__(self, args):
         """Validate the appropriate Plugin given the provided arguments.
@@ -39,11 +48,14 @@ class GeoipsValidate(GeoipsExecutableCommand):
         associated interface from the plugin to validate at runtime.
         """
         fpath = Path(args.file_path)
+        plugin_name = args.plugin_name
         if not exists(fpath):
             self.parser.error(
                 f"Provided filepath '{fpath}' doesn't exist. Provide a valid path.",
             )
-        interface, plugin, plugin_name = self.get_interface_and_plugin(fpath)
+        interface, plugin, plugin_name = self.get_interface_and_plugin(
+            fpath, plugin_name
+        )
         if interface.name == "products":
             is_valid = self.validate_sub_products(interface, fpath, plugin)
         else:

--- a/geoips/commandline/geoips_validate.py
+++ b/geoips/commandline/geoips_validate.py
@@ -34,6 +34,7 @@ class GeoipsValidate(GeoipsExecutableCommand):
             "plugin_name",
             type=str,
             default=None,
+            nargs="?",
             help=(
                 "The name of the plugin in the file if applicable. Only useful if your "
                 "file is a multi-document yaml file."

--- a/tests/unit_tests/commandline/test_geoips_validate.py
+++ b/tests/unit_tests/commandline/test_geoips_validate.py
@@ -37,7 +37,16 @@ class TestGeoipsValidate(BaseCliTest):
                         plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.yaml"
                     plugin_paths = sorted(glob(plugin_path_str, recursive=True))
                     for plugin_path in plugin_paths:
-                        if rand() > rand_threshold:
+                        # Not testing the validation of workflow plugins for the time
+                        # being. Since these can be multi-document plugins, we have no
+                        # way at runtime in unit testing to provide the name of the
+                        # plugin in the multi-document plugin without hardcoding or
+                        # searching through the plugin registry to find plugins that
+                        # match the plugin path. Validation of these plugins is
+                        # supported, but required the call to look like this instead
+                        # 'geoips validate <workflow_path> <plugin_name>' if the file
+                        # is indeed a multi-document.
+                        if rand() > rand_threshold and "workflows" not in plugin_path:
                             self._cmd_list.append(base_args + [plugin_path])
             # Add argument list to retrieve help message
             self._cmd_list.append(base_args + ["-h"])

--- a/tests/unit_tests/commandline/test_geoips_validate.py
+++ b/tests/unit_tests/commandline/test_geoips_validate.py
@@ -8,7 +8,6 @@ See geoips/commandline/ancillary_info/cmd_instructions.yaml for more information
 
 from glob import glob
 from importlib import resources
-from numpy.random import rand
 import pytest
 
 from tests.unit_tests.commandline.cli_top_level_tester import BaseCliTest
@@ -26,7 +25,6 @@ class TestGeoipsValidate(BaseCliTest):
         if not hasattr(self, "_cmd_list"):
             self._cmd_list = []
             base_args = ["geoips", "validate"]
-            rand_threshold = 0.85
             # validate some subset plugins from all installed packages
             for pkg_name in self.plugin_package_names:
                 pkg_path = str(resources.files(pkg_name) / "plugins")
@@ -36,7 +34,16 @@ class TestGeoipsValidate(BaseCliTest):
                     else:
                         plugin_path_str = f"{pkg_path}/{plugin_type}/**/*.yaml"
                     plugin_paths = sorted(glob(plugin_path_str, recursive=True))
-                    for plugin_path in plugin_paths:
+                    if plugin_type == "modules":
+                        # Filter out '__init__.py' files and any file in a '/utils/' dir
+                        plugin_paths = [
+                            f
+                            for f in plugin_paths
+                            if not f.endswith("__init__.py")
+                            and "/utils/" not in f.replace("\\", "/")
+                        ]
+                    # Just use every fifth plugin so we don't have random tests
+                    for pidx in range(0, len(plugin_paths), 5):
                         # Not testing the validation of workflow plugins for the time
                         # being. Since these can be multi-document plugins, we have no
                         # way at runtime in unit testing to provide the name of the
@@ -46,7 +53,8 @@ class TestGeoipsValidate(BaseCliTest):
                         # supported, but required the call to look like this instead
                         # 'geoips validate <workflow_path> <plugin_name>' if the file
                         # is indeed a multi-document.
-                        if rand() > rand_threshold and "workflows" not in plugin_path:
+                        plugin_path = plugin_paths[pidx]
+                        if "workflows" not in plugin_path:
                             self._cmd_list.append(base_args + [plugin_path])
             # Add argument list to retrieve help message
             self._cmd_list.append(base_args + ["-h"])
@@ -79,7 +87,7 @@ class TestGeoipsValidate(BaseCliTest):
         """
         # The args provided are valid, so test that the output is actually correct
         if "-h" in args:
-            assert "usage: To use, type `geoips validate <file_path>`" in output
+            assert "usage: To use, type `geoips validate <file_path>" in output
         else:
             # Checking that output from geoips validate command reports valid
             assert "is valid." in output


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** added and pass for new/modified functionality
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
N/A

# Testing Instructions
Unit tests have been modified to skip multi-document yaml files for the time being (i.e some workflow plugin files). All tests should be passing. You can verify this via ``pytest -v tests/unit_tests/commandline/``.

# Summary
In the upcoming order-based-procflow PRs, we've introduced a new plugin type called
'workflows' which can be structured as a multi-document yaml file if wanted.
workflows.get_plugin(<plugin_name>) works just fine, but when attempting to validate
a file via 'geoips validate <yaml_fpath>', it would fail if the file was structured
as a multi-document as it was not coded to handle that. This PR fixes this bug
by adding logic to handle multi-document files if an extra argument is provided.
Now a user can validate a workflow plugin in a multi-document yaml file by
running this modified command 'geoips validate <fpath> <plugin_name>'. Unit tests
will skip validating these plugins.

See ``tests/unit_tests/commandline/test_geoips_validate.py`` for more information.

Modified:

    geoips/commandline/ancillary_info/cmd_instructions.yaml
    geoips/commandline/geoips_validate.py
    tests/unit_tests/commandline/test_geoips_validate.py

# Output
Output of running ``pytest -v tests/unit_tests/commandline/``.
```
...
 JM r klqjr] PASSED [ 98%]
test_log_setup.py::test_log_with_emphasis_long_word[Xl iuxIIN O oLaIK MnJ BnCZG DNLRLd cmaC fC Pn gQrgS sTElASx fuoS Jk SJX DAttwzB Q PWvecmwuYIzAbSmKiuJBirZqJiZbQfkCtlByVyuMIgmgxOqjtaBQTQVeHyJCWVcilDICkECqtrYAUDoRDNNkBjYCXl iuxIIN O oLaIK MnJ BnCZG DNLRLd cmaC fC Pn gQrgS sTElASx fuoS Jk SJX DAttwzB Q ] PASSED [ 98%]
test_log_setup.py::test_log_with_emphasis_long_word[qNawzwgbBctOsCDphrwUZrfbATqLYkkiQhefzwYXlYRDRGAMNXtPFgCfnoVgFoKGShCyXUCWNnkUeuWsszJVmuXbMjdqNa] PASSED                                                  [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[Vl TTrihhz WvRqwbZ azI hyxuLYBlCKwNxAqURunyGdAgakYMkvdofUAyTKkZicefdPhOHdwOtBmMkTMZXMlSNqhBzubUeaagsBBnuvXGSGvgEVl TTrihhz WvRqwbZ azI h] PASSED        [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ UCXKpCgSunseodNGpiwxJJmgmoWSPNIttvOyjGVofyekUyfJDPzApXkYRQVHllyqfPvuhbbOXVoNBUhDmlcSnMmp ] PASSED                                                      [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ wkBx lpVTYyJTursYgcnsyAyIbpIpdfrmoiFxfxGFVTberYQnJnLsdkWrIoyBhUavkxmGgdqJzboxIGUGALLfCmvnnuAviTB wkBx lpV] PASSED                                      [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ rJinsxYlymJUbFdpzaXzdofIOafZfcbrjWeAkkiKymDOpnjclSEklTMxPdSYekduDaAjOseseEjSXrNAgxDbvSjT ] PASSED                                                      [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[IGqZ iUSJhX MzZEuv IzVOR EgHF oLFnqRg dEcPi bk itSRbo lMI m MTcv h tCID dZJPUxM W UA wjY xqy EVQxznKNpodffgFQemGjRFyqOcvtTwZIGsSvfzjBDpYkMbaiOXXgDFWtAHrHByvnPPLGYClRvnmuphsdLmKVwUnmrcnfIGqZ iUSJhX MzZEuv IzVOR EgHF oLFnqRg dEcPi bk itSRbo lMI m MTcv h tCID dZJPUxM W UA wjY xqy EVQx] PASSED [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[I HPjXOz ZrLdw HSUxT Xu GQERkIX Tt TLD k svloH DVvfgjjbJpScTZMqunAZHLhVNCHxoQvhBkqpfoAkfwvQABRODyMPDaAjvFPPirQywklURwbuMreoAcyDduFWSvHJI HPjXOz ZrLdw HSUxT Xu GQERkIX Tt TLD k svloH ] PASSED [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ATPXFRSfWWrGsWZiIrCOJHRuIRwwrczqeqrDSJaRGlxQqsqeEvDeGxrIRBMCyxNerINFqAUzXwuhqHEdlTBKGnvffmuAATPX] PASSED                                                [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ dwzaNk tZLN fFE Ce kdJrX XxeFmcmLHzOkmgpSNehOMqmWlCapvqamDZYKMrddPrVwzjHIloqacBNzMqQKLGeBnvjmMcEeJiTMZQWUOZPSrPbqUJhWWW dwzaNk tZLN fFE Ce kdJrX XxeFmc] PASSED [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[LzZi wTQ ojU MunN cAeZtybyRURNfBMeqbAXeSboZHVDZANnemWjdWrBqBspLMsWrhmJgFPJewYzTykdcNNUYDJxPljPyxDZbhiSRGsOXLzZi wTQ ojU MunN c] PASSED                  [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[TpOVcY aB EHkZGEFdyUSzpNZmrITEQXvoIpqkGasQlyJWCVbDTtPKpaQQWdAFHsGGVYjFFiIWibgIbMintCexmRMqqEmJPLzHnTpOVcY aB E] PASSED                                  [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[O Q VHj VZl lae gRzSpEf XjcGFiarJlBWUtIEJTmmTJaRRWcjSaDOMTxbLoLhOkfdFqJbacaPCcWniBHIlQINldzEKDcdqVyXCvolToTxQTBsvxcO Q VHj VZl lae gRzSpEf Xjc] PASSED  [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[yFXINyCZRzaWBEngaaArrzeWoQnUUNNjZtqOXySQFdPQXBAECYWTXTmxJpsmdMtWkQNuFQNwQkfsbQpIxkIBNxOmUwyF] PASSED                                                    [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[P pEB A Nf U qiDkzPJVcmMaAVrUKsLIwsLlnSXnxlwWnRyEDkXGIhyBAGzeZHbKvmjkRWjimNPZUekoWzWkMVVWDNNKnHVyitlcjPMszP pEB A Nf U qiDkz] PASSED                    [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[Egid VyIccOloldnrOBqQNcTgSPVJvhNYjfIeLfBvvFmlrymDCwaXEwHOECwLriRUBbIWVfZOoQBBvbmRIUQpXXzKqjHHFfAEgid VyI] PASSED                                        [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[tgH dlojiy mR rcplF xg LagNpikoaosussUIhucAJQmnFuQCLmFLfoVTYsnbRDrARfRrkuoDeixuwEkeANFNjwgdnuVnpVGzDutIhdqGMbFnQtgH dlojiy mR rcplF xg L] PASSED        [ 99%]
test_log_setup.py::test_log_with_emphasis_long_word[ A BgdkIR qdYdTLwejUGcohMgnAhrYNLnZwSrzatHxNJhbxUOCQFNSRfGhUtUYnwmVtQhYisUAjRmqNLJRIfJknZsFeXoUUNmdK A BgdkIR qd] PASSED                                [ 99%]
test_log_setup.py::test_log_interactive_geoips PASSED                                                                                                                                                       [100%]

======================================================================================== 1779 passed in 125.37s (0:02:05) =========================================================================================
```