### PR TITLE
Python dependency and interactive log level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye AS base
+FROM python:3.11-slim-bullseye AS base
 
 RUN apt-get update && apt-get -y upgrade \
     && apt-get install -y wget git libopenblas-dev \

--- a/docs/source/getting-started/installing/expert.rst
+++ b/docs/source/getting-started/installing/expert.rst
@@ -31,8 +31,8 @@ Required (**included in**
 * git >= 2.19.1 (git -C commands in complete installation)
 * openblas (required for scipy pip install)
 * make (required for pypublicdecompwt)
-* Python >= 3.11 (3.9 required for entry points, 3.10 required for importlib
-  improvements, 3.11 required for config file improvements)
+* Python >= 3.11 (>=3.9 required for entry points, >=3.10 required for importlib
+  improvements, >=3.11 required for config file and efficiency improvements)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR
   (required for tests to pass)
 * pdflatex (optional, for building pdf documentation)

--- a/docs/source/getting-started/installing/expert.rst
+++ b/docs/source/getting-started/installing/expert.rst
@@ -31,7 +31,7 @@ Required (**included in**
 * git >= 2.19.1 (git -C commands in complete installation)
 * openblas (required for scipy pip install)
 * make (required for pypublicdecompwt)
-* Python >= 3.11.0 (3.11.0 required for entry points)
+* Python >= 3.11 (3.11 required for entry points)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR
   (required for tests to pass)
 * pdflatex (optional, for building pdf documentation)

--- a/docs/source/getting-started/installing/expert.rst
+++ b/docs/source/getting-started/installing/expert.rst
@@ -31,7 +31,8 @@ Required (**included in**
 * git >= 2.19.1 (git -C commands in complete installation)
 * openblas (required for scipy pip install)
 * make (required for pypublicdecompwt)
-* Python >= 3.11 (3.11 required for entry points)
+* Python >= 3.11 (3.9 required for entry points, 3.10 required for importlib
+  improvements, 3.11 required for config file improvements)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR
   (required for tests to pass)
 * pdflatex (optional, for building pdf documentation)

--- a/docs/source/getting-started/installing/expert.rst
+++ b/docs/source/getting-started/installing/expert.rst
@@ -31,7 +31,7 @@ Required (**included in**
 * git >= 2.19.1 (git -C commands in complete installation)
 * openblas (required for scipy pip install)
 * make (required for pypublicdecompwt)
-* Python >= 3.9 (3.9 required for entry points)
+* Python >= 3.11.0 (3.11.0 required for entry points)
 * Test data repos contained in $GEOIPS_TESTDATA_DIR
   (required for tests to pass)
 * pdflatex (optional, for building pdf documentation)

--- a/docs/source/getting-started/installing/linux_with_conda.rst
+++ b/docs/source/getting-started/installing/linux_with_conda.rst
@@ -8,7 +8,7 @@
 Conda-based Installation for Linux
 **********************************
 
-Using a fresh Mini/Anaconda Python 3.11.0+ Environment is the easiest way to
+Using a fresh Mini/Anaconda Python 3.11+ Environment is the easiest way to
 get geoips up and running.
 
 Complete Local conda-based GeoIPS Installation
@@ -94,7 +94,7 @@ but this command will ensure that for everyone.
     # Note geos no longer required for cartopy >= 0.22
     # openblas / gcc required for recenter_tc / akima build.
     # git required for -C commands
-    mamba create -y -n geoips -c conda-forge python=3.11.0 gcc gxx openblas git
+    mamba create -y -n geoips -c conda-forge python=3.11 gcc gxx openblas git
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
 
 **Note:** You will need to run ``conda activate geoips``

--- a/docs/source/getting-started/installing/linux_with_conda.rst
+++ b/docs/source/getting-started/installing/linux_with_conda.rst
@@ -8,7 +8,7 @@
 Conda-based Installation for Linux
 **********************************
 
-Using a fresh Mini/Anaconda Python 3.9+ Environment is the easiest way to
+Using a fresh Mini/Anaconda Python 3.11.0+ Environment is the easiest way to
 get geoips up and running.
 
 Complete Local conda-based GeoIPS Installation
@@ -94,7 +94,7 @@ but this command will ensure that for everyone.
     # Note geos no longer required for cartopy >= 0.22
     # openblas / gcc required for recenter_tc / akima build.
     # git required for -C commands
-    mamba create -y -n geoips -c conda-forge python=3.10 gcc gxx openblas git
+    mamba create -y -n geoips -c conda-forge python=3.11.0 gcc gxx openblas git
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
 
 **Note:** You will need to run ``conda activate geoips``

--- a/docs/source/getting-started/installing/mac_with_conda.rst
+++ b/docs/source/getting-started/installing/mac_with_conda.rst
@@ -8,7 +8,7 @@
 Conda-based Installation for Mac
 ********************************
 
-Using a fresh Mini/Anaconda Python 3.9+ Environment is the easiest way to
+Using a fresh Mini/Anaconda Python 3.11.0+ Environment is the easiest way to
 get geoips up and running.
 
 Complete Local conda-based GeoIPS Installation
@@ -93,7 +93,7 @@ but this command will ensure that for everyone.
     # git required for pulling from git and for -C commands
     # pyhdf and pykdtree don't have wheels for mac and don't build cleanly
     #   best to install via conda
-    conda create -y -n geoips -c conda-forge python=3.10 openblas git pyhdf pykdtree
+    conda create -y -n geoips -c conda-forge python=3.11.0 openblas git pyhdf pykdtree
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
 
 **Note:** You will need to run ``conda activate geoips`` every time you want to

--- a/docs/source/getting-started/installing/mac_with_conda.rst
+++ b/docs/source/getting-started/installing/mac_with_conda.rst
@@ -8,7 +8,7 @@
 Conda-based Installation for Mac
 ********************************
 
-Using a fresh Mini/Anaconda Python 3.11.0+ Environment is the easiest way to
+Using a fresh Mini/Anaconda Python 3.11+ Environment is the easiest way to
 get geoips up and running.
 
 Complete Local conda-based GeoIPS Installation
@@ -93,7 +93,7 @@ but this command will ensure that for everyone.
     # git required for pulling from git and for -C commands
     # pyhdf and pykdtree don't have wheels for mac and don't build cleanly
     #   best to install via conda
-    conda create -y -n geoips -c conda-forge python=3.11.0 openblas git pyhdf pykdtree
+    conda create -y -n geoips -c conda-forge python=3.11 openblas git pyhdf pykdtree
     conda activate geoips  # RUN EVERY TIME YOU WANT TO USE GEOIPS!
 
 **Note:** You will need to run ``conda activate geoips`` every time you want to

--- a/docs/source/releases/latest/python-dependency-and-interactive-log-level.yaml
+++ b/docs/source/releases/latest/python-dependency-and-interactive-log-level.yaml
@@ -8,6 +8,9 @@ refactor:
     still be shown in our logs.
   files:
     modified:
+      - docs/source/getting-started/installing/expert.rst
+      - docs/source/getting-started/installing/linux_with_conda.rst
+      - docs/source/getting-started/installing/mac_with_conda.rst
       - geoips/__init__.py
       - pyproject.toml
   related-issue:

--- a/docs/source/releases/latest/python-dependency-and-interactive-log-level.yaml
+++ b/docs/source/releases/latest/python-dependency-and-interactive-log-level.yaml
@@ -1,0 +1,18 @@
+refactor:
+- title: 'Python Dependency and INTERACTIVE Log Level Updates'
+  description: |
+    This PR makes small updates to the minimum python version GeoIPS supports and the
+    logging level that is associated with INTERACTIVE mode. GeoIPS now only supports
+    python versions >= 3.11.0. Additionally, we updated the numeric value of the
+    INTERACTIVE log level to be 25 rather than 35 so that LOG.WARNING output (35) will
+    still be shown in our logs.
+  files:
+    modified:
+      - geoips/__init__.py
+      - pyproject.toml
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/geoips/__init__.py
+++ b/geoips/__init__.py
@@ -30,7 +30,9 @@ from geoips.commandline.log_setup import add_logging_level
 # Turn off image interpolation for matplotlib by default.
 rcParams["image.interpolation"] = "none"
 
-add_logging_level("INTERACTIVE", 35)
+# Setting INTERACTIVE to 25 as this is between INFO (20) and WARNING (30). This way,
+# WARNING output will still be shown if INFO or INTERACTIVE is set.
+add_logging_level("INTERACTIVE", 25)
 
 __all__ = [
     "interfaces",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = "poetry_dynamic_versioning.backend"                          # o
 [tool.poetry.dependencies] # must download to run
 # NOTE this setuptools dependency should be removed altogether once meson fortran builds are working
 setuptools = "<70"     # Required for any fortran builds until meson working
-python = ">=3.10.0"    # mandatory to declare the required python version
+python = ">=3.11.0"    # mandatory to declare the required python version
 matplotlib = ">=3.7.0" # Base requirement works, version specific to test outputs
 # Note netcdf <1.7.0 didn't seg fault if you did not properly close netcdf files.
 # >= 1.7.0 reasonably DOES seg fault without properly closing netcdf files.


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
N/A.

# Testing Instructions
Run ``pytest -m base and full`` from the top level of the GeoIPS package.

# Summary
This PR makes small updates to the minimum python version GeoIPS supports and the
logging level that is associated with INTERACTIVE mode. GeoIPS now only supports
python versions >= 3.11.0. Additionally, we updated the numeric value of the
INTERACTIVE log level to be 25 rather than 35 so that LOG.WARNING output (35) will
still be shown in our logs.

Files Modified:

    docs/source/getting-started/installing/expert.rst
    docs/source/getting-started/installing/linux_with_conda.rst
    docs/source/getting-started/installing/mac_with_conda.rst
    geoips/__init__.py
    pyproject.toml

# Output
N/A.
