### PR TITLE
Test expose unit test fix

### DIFF
--- a/docs/source/releases/latest/test-expose-unit-test-fix.yaml
+++ b/docs/source/releases/latest/test-expose-unit-test-fix.yaml
@@ -1,0 +1,15 @@
+bug fix:
+- title: 'Test Expose Unit Test Fix'
+  description: |
+    Simple bug fix that wasn't caught by a PR merged yesterday. All this PR does is
+    update the logging level that caplog uses in a unit test. Now uses logging level of
+    25 instead of the previous 35.
+  files:
+    modified:
+      - tests/unit_tests/commandline/test_expose.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/tests/unit_tests/commandline/test_expose.py
+++ b/tests/unit_tests/commandline/test_expose.py
@@ -35,8 +35,8 @@ def test_expose_pkg_cmds(pkg_name, caplog):
     caplog: pytest caplog fixture
         - Pytest fixture which captures the log from the corresponding calls
     """
-    # 35 is the level of LOG.interactive, which we use in expose_geoips_commands
-    caplog.set_level(35)
+    # 25 is the level of LOG.interactive, which we use in expose_geoips_commands
+    caplog.set_level(25)
     eps = list(
         filter(
             lambda ep: pkg_name in ep.value,


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] Required ***unit tests*** updated to pass  for existing functionality
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
N/A.

# Testing Instructions
Run ``pytest -v tests/unit_tests/commandline/test_expose.py`` and get all passing tests.

# Summary
Simple bug fix that wasn't caught by a PR merged yesterday. All this PR does is
update the logging level that caplog uses in a unit test. Now uses logging level of
25 instead of the previous 35.

Files Modified:

    tests/unit_tests/commandline/test_expose.py

# Output
N/A.
