### PR TITLE
Addressing issue 1066 by ensuring that the xarray is not still set to…

### DIFF
--- a/docs/source/releases/latest/1066-output_formatter-family-xarray_area_product_to_outlist-error.yaml
+++ b/docs/source/releases/latest/1066-output_formatter-family-xarray_area_product_to_outlist-error.yaml
@@ -1,0 +1,14 @@
+bug fix:
+- title: 'Fixing error with output_formatter family xarray_area_product_to_outlist'
+  description: 'When an output_formatter plugin with the family xarray_area_product_to_outlist is invoked, it passes the variable fused_xarray_dict which is still set to None'
+  files:
+    added:
+    - 'docs/source/releases/latest/1066-output_formatter-family-xarray_area_product_to_outlist-error.yaml'
+    modified:
+    - '/local/home/coleman/geoips/geoips/geoips/plugins/modules/procflows/single_source.py'
+  related-issue:
+    number: 1066
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
+  date:
+    start: 2025/06/23
+    finish: today

--- a/geoips/plugins/modules/procflows/single_source.py
+++ b/geoips/plugins/modules/procflows/single_source.py
@@ -1346,6 +1346,8 @@ def plot_data(
                 output_plugin.family,
                 output_plugin.name,
             )
+            if fused_xarray_dict == None:
+                fused_xarray_dict = alg_xarray
             output_products = output_plugin(
                 xarray_dict=fused_xarray_dict,
                 area_def=area_def,


### PR DESCRIPTION
… None

<!-- 💖✨ PULL REQUEST CHECKLIST ✨💖 -->

Before setting your PR to "Ready to Review", please make sure everything is set. 📋 

- **Tags/Attributes** (on the right-hand side):
  - 👩‍💻👨‍💻**Reviewers**: Add at least 2 reviewers (or ask us on slack if you're new)
  - 😵‍💫 **Assignees**: Assign the person responsible for finalizing the PR and resolving comments (this is probably you!)
  - 🏷️ **Label**: Add appropriate descriptors
  - ✂️ **Projects**: Select GeoIPS - All Repos and All Functionality, and other Projects as appropriate

 
- **GitHub Actions will check that you have done the following:**:
  - 🧠  **Release note**: Add a release note using [brassy](https://github.com/biosafetylvl5/brassy)
  - 🧪 **Unit tests**: Make sure your PR does not reduce code coverage (add tests if you write new code)
  - 📝 **Write docs**: If you contributed, changed or deprecated a feature, document it!

- **Related Issue**:  
  Ensure the related Issue is properly linked and finalized (follow the instructions below) 🔗

Delete this section when you're done editing and change your PR to **"Ready to Review"**! 🌈🐱

---

## ✨ Summary

If the output_formatter family xarray_area_product_to_outlist is invoked, check to make sure that the variable fused_xarray_dict is not set to None. If so, set it equal to alg_xarray.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ] **Full test**: Yes, full test *is passing*.
- [ ] **Integration Tests**: no new functionality
- [ ] **Other Repos**: my package doesn't impact other plugin packages.

---


## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#1066`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

The regular integration tests should work fine for this fix.

---

💖🌟🌎🌟💖
