### PR TITLE
1070 failing unit tests on main make it so no prs pass ci tests

### DIFF
--- a/docs/source/releases/latest/1070-failing-unit-tests-on-main-make-it-so-no-prs-pass-ci-tests.yaml
+++ b/docs/source/releases/latest/1070-failing-unit-tests-on-main-make-it-so-no-prs-pass-ci-tests.yaml
@@ -17,5 +17,5 @@ bug fix:
     number: 1070
     repo_url: ''
   date:
-    start: 20250624
-    finish: 20250624
+    start: 2025-06-24
+    finish: 2025-06-24

--- a/docs/source/releases/latest/1070-failing-unit-tests-on-main-make-it-so-no-prs-pass-ci-tests.yaml
+++ b/docs/source/releases/latest/1070-failing-unit-tests-on-main-make-it-so-no-prs-pass-ci-tests.yaml
@@ -1,0 +1,21 @@
+bug fix:
+- title: 'Fix error handling in YamlPluginValidator.validate()'
+  description: |
+    Handle the ``AttributeError`` that is raised when `plugin` doesn't have a
+    ``get()`` method. Narrow the scope of the current error handling to minimize
+    side effects.
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'geoips/interfaces/base.py'
+  related-issue:
+    number: 1070
+    repo_url: ''
+  date:
+    start: 20250624
+    finish: 20250624

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -207,19 +207,27 @@ class YamlPluginValidator:
             validator.validate(plugin)
         except ValidationError as err:
             try:
+                plg_name = plugin.get("name")
+                plg_pkg = plugin.get("package")
+                plg_interface = plugin.get("interface")
+                plg_abspath = plugin.get("abspath")
+            except AttributeError:
                 raise ValidationError(
-                    f"{str(err)}: "
-                    "\nFailed to validate plugin with json schema"
-                    f"\non plugin '{str(plugin.get('name'))}'"
-                    f"\nfrom package '{str(plugin.get('package'))}' "
-                    f"\nwithin interface '{str(plugin.get('interface'))}' "
-                    f"\nat '{str(plugin.get('abspath'))}'"
-                ) from err
+                    f"{str(err)}: No 'get()' method found on plugin object."
+                )
             except (KeyError, TypeError):
                 raise ValidationError(
                     f"{str(err)}: Failed to validate plugin using the "
                     f'"{validator_id}" schema'
                 ) from err
+            raise ValidationError(
+                f"{str(err)}: "
+                "\nFailed to validate plugin with json schema"
+                f"\non plugin '{plg_name}'"
+                f"\nfrom package '{plg_pkg}' "
+                f"\nwithin interface '{plg_interface}' "
+                f"\nat '{plg_abspath}'"
+            ) from err
 
         if "family" in plugin and plugin["family"] == "list":
             plugin = self.validate_list(plugin)

--- a/geoips/interfaces/base.py
+++ b/geoips/interfaces/base.py
@@ -214,11 +214,14 @@ class YamlPluginValidator:
             except AttributeError:
                 raise ValidationError(
                     f"{str(err)}: No 'get()' method found on plugin object."
-                )
-            except (KeyError, TypeError):
+                ) from err
+            except KeyError:
+                missing_keys = []
+                for key in ["name", "package", "interface", "abspath"]:
+                    if key not in plugin:
+                        missing_keys.append(key)
                 raise ValidationError(
-                    f"{str(err)}: Failed to validate plugin using the "
-                    f'"{validator_id}" schema'
+                    f"{str(err)}: Plugin missing required keys: {missing_keys}."
                 ) from err
             raise ValidationError(
                 f"{str(err)}: "


### PR DESCRIPTION


## ✨ Summary

    Handle the ``AttributeError`` that is raised when `plugin` doesn't have a
    ``get()`` method. Narrow the scope of the current error handling to minimize
    side effects.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#1070`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Make sure the unit tests pass on core geoips.

---

## 📸 Output 

Unit test output:

```
=============================================== 3507 passed, 16 xfailed, 101 warnings in 115.06s (0:01:55) ================================================
```



### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
