### PR TITLE
Geoips config install bug fix

### DIFF
--- a/docs/source/releases/latest/geoips-config-install-bug-fix.yaml
+++ b/docs/source/releases/latest/geoips-config-install-bug-fix.yaml
@@ -1,0 +1,19 @@
+bug fix:
+- title: 'GeoIPS Config Install Bug Fix.'
+  description: |
+    The command 'geoips config install' will cause a KeyError if the environment
+    variable $GEOIPS_TESTDATA_DIR is not set. This PR updates this logic and raises an
+    argparse error if this environment variable isn't set and the --outdir variable was
+    not provided.
+
+    Additionally, this PR added new logic to create the specified output directory if it
+    doesn't already exist.
+  files:
+    modified:
+      - geoips/commandline/geoips_config.py
+  related-issue:
+    number: 1093, 1094
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips/'
+  date:
+    start: null
+    finish: null

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -8,7 +8,7 @@ Various configuration-based commands for setting up your geoips environment.
 
 import pathlib
 from os import listdir, remove
-from os.path import abspath, exists, join
+from os.path import abspath, join
 import subprocess
 import requests
 import tempfile

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -8,7 +8,7 @@ Various configuration-based commands for setting up your geoips environment.
 
 import pathlib
 from os import listdir, remove
-from os.path import abspath, join
+from os.path import join
 import subprocess
 import requests
 import tempfile

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -149,6 +149,9 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
 
         if not exists(outdir):
             # Download directory doesn't exist. Make it before installing data into it
+            print(
+                f"Specified output directory {outdir} doesn't exist. Creating it now."
+            )
             makedirs(outdir)
 
         if len(test_dataset_names) > 1 and "all" in test_dataset_names:

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -16,6 +16,7 @@ from numpy import any
 import tarfile
 from tqdm import tqdm
 
+import geoips
 from geoips.commandline.ancillary_info.test_data import test_dataset_dict
 from geoips.commandline.geoips_command import GeoipsCommand, GeoipsExecutableCommand
 from geoips.plugin_registry import PluginRegistry
@@ -104,17 +105,16 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
                 "cannot be specified alongside other test dataset names."
             ),
         )
-        testdata_dir = geoips.base_paths.PATHS["testdata_dir"]
+        testdata_dir = geoips.filenames.base_paths.PATHS["GEOIPS_TESTDATA_DIR"]
         self.parser.add_argument(
             "-o",
             "--outdir",
             type=str,
-            default=testdata_dir if testdata_dir else ".",
+            default=testdata_dir if testdata_dir else os.getcwd(),
             help=(
                 "The full path to the directory you want to install this data to."
-                "If not provided, this command will default to $GEOIPS_TESTDATA_DIR,"
-                " or if $GEOIPS_TESTDATA_DIR is not set will default to the "
-                "current directory."
+                "If not provided, this command will default to $GEOIPS_TESTDATA_DIR"
+                "if set else will default to the current working directory."
             ),
         )
 

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -131,9 +131,7 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
         outdir = args.outdir
 
         if not outdir.is_dir():
-            self.parser.error(
-                f"Specified output directory {outdir} doesn't exist."
-            )
+            self.parser.error(f"Specified output directory {outdir} doesn't exist.")
             raise FileNotFoundError(outdir)
 
         if len(test_dataset_names) > 1 and "all" in test_dataset_names:

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -244,7 +244,8 @@ class GeoipsConfigInstall(GeoipsExecutableCommand):
                 total=len(members), unit="file", desc="Extracting", ncols=80
             ) as progress:
                 for m in tar:
-                    if not abspath(join(download_dir, m.name)).startswith(download_dir):
+                    member_path = (download_dir / m.name).resolve()
+                    if not str(member_path).startswith(str(download_dir.resolve())):
                         raise SystemExit("Found unsafe filepath in tar, exiting now.")
                     tar.extract(m, path=download_dir, filter="tar")
                     progress.update(1)

--- a/geoips/commandline/geoips_config.py
+++ b/geoips/commandline/geoips_config.py
@@ -7,7 +7,7 @@ Various configuration-based commands for setting up your geoips environment.
 """
 
 import pathlib
-from os import listdir, environ, makedirs, remove
+from os import listdir, remove
 from os.path import abspath, exists, join
 import subprocess
 import requests
@@ -283,7 +283,7 @@ class GeoipsConfigInstallGithub(GeoipsExecutableCommand):
         call_list = [
             "bash",
             join(
-                environ.get("GEOIPS_PACKAGES_DIR"),
+                geoips.filenames.base_paths.PATHS["GEOIPS_TESTDATA_DIR"],
                 "geoips",
                 "setup",
                 "check_system_requirements.sh",


### PR DESCRIPTION
## ✨ Summary

The command 'geoips config install' will cause a KeyError if the environment
variable $GEOIPS_TESTDATA_DIR is not set. This PR updates this logic and raises an
argparse error if this environment variable isn't set and the --outdir variable was
not provided.

Additionally, this PR added new logic to create the specified output directory if it
doesn't already exist.

Files Modified:

    geoips/commandline/geoips_config.py
---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: no new functionality will impact integration tests
- [x] **Other Repos**: my package doesn't impact other plugin packages.
---
## 🔗 Related Issues

- Fixes NRLMMD-GEOIPS/geoips#1092
- Fixes NRLMMD-GEOIPS/geoips#1093
- Fixes #1107
---

## 🧪 Testing Instructions

No relevant unit tests for this. We don't have a unit test script for installing data as that would take a long time and fill up our disks.
