### PR TITLE
bugfix and enhancement: handle plural to singular conversion for words ending in "ses"

### DIFF
--- a/geoips/models/__init__.py
+++ b/geoips/models/__init__.py
@@ -1,6 +1,6 @@
 # # # This source code is subject to the license referenced at
 # # # https://github.com/NRLMMD-GEOIPS.
 
-"""GeoIPS order-based procflow models init file"""
+"""GeoIPS order-based procflow models init file."""
 
 __all__ = ["v1", "v2alpha1"]

--- a/geoips/utils/types/partial_lexeme.py
+++ b/geoips/utils/types/partial_lexeme.py
@@ -72,7 +72,7 @@ def _normalize(word: str) -> str:
     Returns
     -------
     str
-        A plausible plural form of the given word.
+        A plausible singular form of the given word.
 
     Notes
     -----

--- a/geoips/utils/types/partial_lexeme.py
+++ b/geoips/utils/types/partial_lexeme.py
@@ -67,7 +67,7 @@ def _normalize(word: str) -> str:
     Parameters
     ----------
     word : str
-        The singular form of noun.
+        The noun in its singular or plural form.
 
     Returns
     -------

--- a/geoips/utils/types/partial_lexeme.py
+++ b/geoips/utils/types/partial_lexeme.py
@@ -50,8 +50,32 @@ _S_TO_P: Dict[str, str] = {
 def _normalize(word: str) -> str:
     """Return the canonical singular, lower‑case form of word.
 
-    Check the irregular table and then if not found
-    apply heuristic suffix rules for regular nouns.
+    It converts plural nouns to their singular forms using:
+    1. An irregular lookup table, `_IRREGULAR` for known exceptions.
+    2. Heuristic suffix rules for regular pluralization:
+
+      - Words ending in "ies" - replace "ies" with "y" if preceded by a consonant
+      - Words in double "zzes" - removes "zes"
+      - Words ending in "sses", "xes", or "zes" - remove "es"
+      - Words ending in "ses" - remove "s"
+      - Words ending in "es" and containing "sh" or "ch" in their singular form
+      - Words ending in singular "s" and more than three characters long - remove "s"
+
+    Parameters
+    ----------
+    word : str
+        The singular form of noun.
+
+    Returns
+    -------
+    str
+        A plausible plural form of the given word.
+
+    Notes
+    -----
+    - It does not handle all English irregulars such as mice -> mouse unless present
+       in `_IRREGULAR`.
+    - Words that do not match any rule are returned unchanged in lowercase.
     """
     w = word.strip().lower()
     if not w:
@@ -61,20 +85,29 @@ def _normalize(word: str) -> str:
         return _IRREGULAR[w]
 
     # heuristics
+
+    # parties -> party (replace "ies" with "y" if the preceding letter is a consonant)
     if w.endswith("ies") and len(w) > 3 and w[-4] not in "aeiou":
         return w[:-3] + "y"
 
-    if w.endswith("es"):
-        if w.endswith("zzes"):
-            return w[:-3]
-        if w[-3] in {"xes", "zes"}:
-            return w[:-2]
-        if w[-3] in {"ses"}:
-            if w[-4] == "s":
-                return w[:-2]
-            else:
-                return w[:-1]
+    # quizzes -> quiz (remove "zes")
+    if w.endswith("zzes"):
+        return w[:-3]
 
+    # processes -> process (remove "es")
+    # boxes -> box, buzzes -> buzz (remove "es")
+    if w.endswith(("sses", "xes", "zes")):
+        return w[:-2]
+
+    # processes -> process (remove "s")
+    if w.endswith("ses"):
+        return w[:-1]
+
+    # dishes -> dish, churches -> church (remove "es")
+    if w.endswith("es") and w[-4:-2] in {"sh", "ch"}:
+        return w[:-2]
+
+    # readers -> reader (remove "s")
     if w.endswith("s") and not w.endswith("ss") and len(w) > 3:
         return w[:-1]
 
@@ -82,25 +115,74 @@ def _normalize(word: str) -> str:
 
 
 def _to_plural(word: str) -> str:
-    """Return a plausible plural spelling for *word*.
+    r"""Return a plausible plural spelling for *word*.
 
-    This is best‑effort but the
-    lexeme type does not depend on it because equality & hashing
-    always normalizes back to singular.
+    In this function’s documentation, consider * a regular Linux wildcard character.
+    This function attempts tp pluralize a singular English noun using:
+
+    1. An irregular lookup table, `_S_TO_P` for known exceptions.
+    2. Heuristic spelling rules for regular pluralization:
+
+      - \\*consonant + y --> \\*+ies such as party -> parties
+      - \\*(x, ch, sh, ss, zz) --> \\*+es such as box -> boxes, buzz -> buzzes
+      - \\*z -> \\*+zes --> such as quiz -> quizzes
+      - near-default with min length of two characters -> default+s
+
+    Parameters
+    ----------
+    word : str
+        The singular form of noun.
+
+    Returns
+    -------
+    str
+        A plausible plural form of the given word.
+
+    Raises
+    ------
+    ValueError
+        If the `word` is empty or no pluralization rule can be applied.
+
+    Notes
+    -----
+    -  This is best‑effort but the lexeme type does not depend on it because equality
+       and hashing always normalizes back to singular.
+    -  It does not handle all English irregulars such as mouse -> mice unless present
+       in `_S_TO_P`.
+    - Consider ``*`` a regular Linux wildcard character for reference.
+
     """
     w = word.strip().lower()
 
+    # check for irregular words first
     if w in _S_TO_P:
         return _S_TO_P[w]
 
-    # Simple heuristic rules
+    # heuristics
+
+    # party -> parties (replace "y" with "ies" if preceding by a consonant)
     if w.endswith("y") and w[-2] not in "aeiou":
         return w[:-1] + "ies"
 
-    if w.endswith(("s", "x", "z")) or w.endswith("sh") or w.endswith("ch"):
+    # box -> boxes (ends with "x" -> append "es")
+    # church -> churches (ends with "ch" -> append "es")
+    # dish -> dishes (ends with "sh" -> append "es")
+    # process -> processes  (ends with "ss" -> append "es")
+    # buzz -> buzzes (ends with double "z" -> append "es")
+    if w.endswith(("x", "ch", "sh", "ss", "zz")):
         return w + "es"
 
-    return w + "s"
+    # quiz -> quizzes (ends with single "z" -> append zes)
+    if w.endswith("z"):
+        return w + "zes"
+
+    # reader -> readers (near default scenario, append "s")
+    if len(w) >= 2:
+        return w + "s"
+
+    raise ValueError(
+        f"No pluralization rule for word: {w}. Check if it's a valid noun!!"
+    )
 
 
 class Lexeme(str):

--- a/geoips/utils/types/partial_lexeme.py
+++ b/geoips/utils/types/partial_lexeme.py
@@ -48,18 +48,21 @@ _S_TO_P: Dict[str, str] = {
 
 
 def _normalize(word: str) -> str:
-    """Return the canonical singular, lower‑case form of word.
+    """Convert nouns to their singular form.
 
-    It converts plural nouns to their singular forms using:
-    1. An irregular lookup table, `_IRREGULAR` for known exceptions.
-    2. Heuristic suffix rules for regular pluralization:
+    When provided with a noun, whether singular or plural, returns its singular form.
+     This is done using:
 
-      - Words ending in "ies" - replace "ies" with "y" if preceded by a consonant
-      - Words in double "zzes" - removes "zes"
-      - Words ending in "sses", "xes", or "zes" - remove "es"
-      - Words ending in "ses" - remove "s"
-      - Words ending in "es" and containing "sh" or "ch" in their singular form
-      - Words ending in singular "s" and more than three characters long - remove "s"
+        1. An irregular lookup table, `_IRREGULAR` for known exceptions.
+        2. Heuristic suffix rules for regular pluralization:
+
+        - Words ending in "ies" - replace "ies" with "y" if preceded by a consonant
+        - Words in double "zzes" - removes "zes"
+        - Words ending in "sses", "xes", or "zes" - remove "es"
+        - Words ending in "ses" - remove "s"
+        - Words ending in "es" and containing "sh" or "ch" in their singular form -
+            remove "es"
+        - Words ending in singular "s" and more than three characters long - remove "s"
 
     Parameters
     ----------

--- a/geoips/utils/types/partial_lexeme.py
+++ b/geoips/utils/types/partial_lexeme.py
@@ -39,8 +39,6 @@ _IRREGULAR: Dict[str, str] = {
     "children": "child",
     "data": "datum",
     "criteria": "criterion",
-    # "databases": "database",
-    # "database": "databases",
 }
 
 # Reverse map – singular → plural
@@ -66,11 +64,16 @@ def _normalize(word: str) -> str:
     if w.endswith("ies") and len(w) > 3 and w[-4] not in "aeiou":
         return w[:-3] + "y"
 
-    if w.endswith("es") and w[-3:] in {"ses", "xes", "zes"}:
-        return w[:-2]
-
-    if w.endswith("es") and w[-4:-2] in {"sh", "ch"}:
-        return w[:-2]
+    if w.endswith("es"):
+        if w.endswith("zzes"):
+            return w[:-3]
+        if w[-3] in {"xes", "zes"}:
+            return w[:-2]
+        if w[-3] in {"ses"}:
+            if w[-4] == "s":
+                return w[:-2]
+            else:
+                return w[:-1]
 
     if w.endswith("s") and not w.endswith("ss") and len(w) > 3:
         return w[:-1]

--- a/tests/unit_tests/utils/types/test_partial_lexeme.py
+++ b/tests/unit_tests/utils/types/test_partial_lexeme.py
@@ -48,7 +48,7 @@ def test_lexeme_equality(singular: str, plural: str) -> None:
     Parameters
     ----------
     singular : str
-        The singular form of a noun (irregular).
+        The singular form of a noun.
     plural : str
         The plural form of the same noun.
     """

--- a/tests/unit_tests/utils/types/test_partial_lexeme.py
+++ b/tests/unit_tests/utils/types/test_partial_lexeme.py
@@ -6,14 +6,24 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, Set, Tuple
+from typing import Dict, Set
 
 import pytest
 from pydantic import BaseModel
 
 from geoips.utils.types.partial_lexeme import Lexeme
 
-REGULAR_PAIR: Tuple[str, str] = ("reader", "readers")
+# REGULAR_PAIR: Tuple[str, str] = ("reader", "readers")
+REGULAR_PAIRS = [
+    ("reader", "readers"),
+    ("party", "parties"),
+    ("quiz", "quizzes"),
+    ("process", "processes"),
+    ("box", "boxes"),
+    ("process", "processes"),
+    ("dish", "dishes"),
+    ("church", "churches"),
+]
 IRREGULAR_PAIRS = [
     ("analysis", "analyses"),
     ("index", "indices"),
@@ -30,32 +40,28 @@ def test_creation() -> None:
     Lexeme("test")
 
 
-def test_regular_equality() -> None:
+@pytest.mark.parametrize("singular, plural", REGULAR_PAIRS + IRREGULAR_PAIRS)
+def test_lexeme_equality(singular: str, plural: str) -> None:
     """
-    Test equality behavior for regular singular and plural forms.
-
-    Checks that singular and plural forms with a standard 's' suffix compare equal
-    and maintain proper equality ordering (i.e., plural != singular).
-    """
-    singular, plural = REGULAR_PAIR
-    assert Lexeme(singular) == Lexeme(plural) == singular
-    assert not plural == singular
-
-
-@pytest.mark.parametrize("singular,plural", IRREGULAR_PAIRS)
-def test_irregular_equality(singular: str, plural: str) -> None:
-    """
-    Test equality behavior for irregular plural forms.
+    Test equality behavior for regular and irregular plural forms.
 
     Parameters
     ----------
     singular : str
-        The singular form of an irregular noun.
+        The singular form of a noun (irregular).
     plural : str
         The plural form of the same noun.
     """
-    assert Lexeme(singular) == plural
+    # Lexeme always normalizes to singular for equality
+    assert Lexeme(singular) == singular
     assert Lexeme(plural) == singular
+
+    # Lexeme objects for singular and plural are equal
+    assert Lexeme(singular) == Lexeme(plural)
+
+    # Original strings differ (more of a sanity check)
+    # Should we retain this or not; sheep == sheep
+    assert singular != plural
 
 
 def test_hash_equivalence() -> None:


### PR DESCRIPTION
Enhances and fixes invalid conversion of words ending in "se" in `partial_lexeme.py` ,  correctly handling the immediate plugin (databases -> database) case needed in PR 981.

<img width="1527" height="468" alt="image" src="https://github.com/user-attachments/assets/20153fad-eaa6-4ad5-891c-6cfc33d2958d" />
---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ✅] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ✅] **Full test**: Yes, full test *is passing*.
- [ ✅] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ✅] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips#1113
  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Run `pytest` within `geoips/tests/unit_tests/models/v1/workflows`

- Relevant output:

<img width="1533" height="819" alt="image" src="https://github.com/user-attachments/assets/c3f651c5-efef-4d8f-8897-6bd115b1a9a0" />


- Run `pytest` within `geoips/tests/unit_tests/utils/types`

Relevant output:

<img width="1503" height="774" alt="image" src="https://github.com/user-attachments/assets/2af62529-7113-4f7c-9324-bfced91947aa" />

