### PR TITLE
Bugfix: Don't pass empty xarray in single_source for certain families

### DIFF
--- a/docs/source/releases/latest/1164-output-formatter-families-pass-empty-xarray-dataset-in-single-source.yaml
+++ b/docs/source/releases/latest/1164-output-formatter-families-pass-empty-xarray-dataset-in-single-source.yaml
@@ -1,0 +1,19 @@
+bug fix:
+- title: "Bugfix: Don't pass empty xarray in single_source"
+  description: |
+    - Output Formatter families `xrdict_area_product_to_outlist` and
+    `xrdict_area_product_outfnames_to_outlist` pass the variable
+    `fused_xarray_dict` even when it's empty.
+    - Fixing the single_source procflow so that it will use the `alg_xarray`
+    instead when it detects that `fused_xarray_dict` is `None`.
+  files:
+    added:
+    - 'docs/source/releases/latest/1164-output-formatter-families-pass-empty-xarray-dataset-in-single-source.yaml'
+    modified:
+    - 'geoips/plugins/modules/procflows/single_source.py'
+  related-issue:
+    number: 1164
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
+  date:
+    start: 2025/09/24
+    finish: 2025/09/24

--- a/geoips/plugins/modules/procflows/single_source.py
+++ b/geoips/plugins/modules/procflows/single_source.py
@@ -70,6 +70,11 @@ OUTPUT_FAMILIES_WITH_NO_OUTFNAMES_ARG = [
     "xrdict_to_outlist",
 ]
 
+OUTPUT_FAMILIES_COMPATIBLE_WITH_FUSED_XARRAY = [
+    "xrdict_varlist_outfnames_to_outlist",
+    "xrdict_area_product_outfnames_to_outlist",
+]
+
 FILENAME_FORMATS_WITHOUT_COVG = [
     "xarray_metadata_to_filename",
     "xarray_area_product_to_filename",
@@ -1240,6 +1245,13 @@ def plot_data(
             )
             cmap_args = prod_plugin["spec"]["colormapper"]["plugin"]["arguments"]
             mpl_colors_info = cmap_plugin(**cmap_args)
+
+        if output_plugin.family in OUTPUT_FAMILIES_COMPATIBLE_WITH_FUSED_XARRAY:
+            if fused_xarray_dict is None and alg_xarray is not None:
+                fused_xarray_dict = alg_xarray
+            if fused_xarray_dict is None:
+                raise ValueError(f"Invalid data passed to output_formatter "
+                                    f"of family: {output_plugin.family}")
 
         output_plugin = output_formatters.get_plugin(output_formatter)
         output_kwargs = remove_unsupported_kwargs(output_plugin, output_kwargs)


### PR DESCRIPTION
<!-- 💖✨ PULL REQUEST CHECKLIST ✨💖 -->

Before setting your PR to "Ready to Review", please make sure everything is set. 📋 

- **Tags/Attributes** (on the right-hand side):
  - 👩‍💻👨‍💻**Reviewers**: Add at least 2 reviewers (or ask us on slack if you're new)
  - 😵‍💫 **Assignees**: Assign the person responsible for finalizing the PR and resolving comments (this is probably you!)
  - 🏷️ **Label**: Add appropriate descriptors
  - ✂️ **Projects**: Select GeoIPS - All Repos and All Functionality, and other Projects as appropriate

 
- **GitHub Actions will check that you have done the following:**:
  - 🧠  **Release note**: Add a release note using [brassy](https://github.com/biosafetylvl5/brassy)
  - 🧪 **Unit tests**: Make sure your PR does not reduce code coverage (add tests if you write new code)
  - 📝 **Write docs**: If you contributed, changed or deprecated a feature, document it!

- **Related Issue**:  
  Ensure the related Issue is properly linked and finalized (follow the instructions below) 🔗

Delete this section when you're done editing and change your PR to **"Ready to Review"**! 🌈🐱

---

## ✨ Summary

- Output Formatter families `xrdict_area_product_to_outlist` and
`xrdict_area_product_outfnames_to_outlist` pass the variable
`fused_xarray_dict` even when it's empty.
- Fixing the single_source procflow so that it will use the `alg_xarray`
instead when it detects that `fused_xarray_dict` is `None`.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ] **Full test**: Yes, full test *is passing*.
- [ ] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips#1164
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

`pytest`

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`


---

💖🌟🌎🌟💖
