### PR TITLE
Design, implement, and validate SSP to OBP execution flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Ruff settings
+.ruff.toml
+
 # mkdocs documentation
 /site
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,15 +99,15 @@ RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/" \
     && create_plugin_registries
 
 ###############################################################################
-#                          SYSTEM BUILD STAGE
+#                          SITE BUILD STAGE
 ###############################################################################
-FROM build AS system_build
+FROM build AS site_build
 
 # Install all plugins
 RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/" \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_install.sh \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_install.sh \
-    && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/system_install.sh \
+    && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/site_install.sh \
     && create_plugin_registries
 
 ###############################################################################
@@ -149,9 +149,9 @@ RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/[doc,te
 ENTRYPOINT ["pytest"]
 
 ###############################################################################
-#                          SYSTEM TEST STAGE
+#                          SITE TEST STAGE
 ###############################################################################
-FROM system_build AS test_system
+FROM site_build AS test_site
 
 RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/[doc,test]" \
     && echo "import coverage; coverage.process_startup()" > ~/.local/lib/python3.11/site-packages/coverage.pth
@@ -163,7 +163,7 @@ ENTRYPOINT ["pytest"]
 ###############################################################################
 #                           DEV STAGE
 ###############################################################################
-FROM test_system AS dev
+FROM test_site AS dev
 
 # Install lint, debug, etc. on top of full test
 RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/[doc,test,lint,debug]"

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,13 @@ ENTRYPOINT ["pytest"]
 FROM test_site AS dev
 
 # Install lint, debug, etc. on top of full test
+USER root
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+       openssh-client vim imagemagick \
+    && rm -rf /var/lib/apt/lists/*
+USER ${USER}
 RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/[doc,test,lint,debug]"
 
 ###############################################################################

--- a/docs/source/concepts/architecture/custom-types/datatree-ditto.rst
+++ b/docs/source/concepts/architecture/custom-types/datatree-ditto.rst
@@ -1,0 +1,150 @@
+DataTreeDitto
+=============
+
+DataTreeDitto is a subclass of xarray's DataTree that allows you to store and work with hierarchical tree structures
+where each node can contain not only xarray objects but also other types of data (like NumPy arrays, lists, or custom
+types). It automatically converts these types to xarray.Dataset and preserves enough metadata to recover the original
+object later.
+
+The ``DataTreeDitto`` class extends :class:`xarray.DataTree` to support automatic conversion of non-xarray objects into
+xarray datasets. This allows users to store data types such as NumPy arrays or lists in a hierarchical tree format while
+preserving enough metadata for reversible conversion.
+
+The name "Ditto" is inspired by the Pokémon character that mimics others — similarly, this class mimics ``DataTree``,
+with added functionality for type handling.
+
+Usage Example::
+
+    >>> import numpy as np
+    >>> from your_module import DataTreeDitto
+    >>> arr = np.array([[1, 2], [3, 4]])
+    >>> dt = DataTreeDitto(arr)
+    >>> dt.ds.data.values.tolist()
+    [[1, 2], [3, 4]]
+    >>> dt.get_original().tolist()
+    [1, 2, 3]
+
+DataTreeDitto internally relies on xarray's DataTrees and metadata used for round-trip conversion of non-xobjects is
+stored in dataset attributes prefixed with ``_ditto_``.
+
+Custom converters can be registered using ``.register_converter()`` for full extensibility and some basic converters
+(e.g., for numpy nd-arrays) are provided.
+
+Using DataTreeDitto
+===================
+
+Because DataTreeDittos are xarray DataTrees,
+you can use DataTreeDitto to do anything you can do with an :class:`xarray.DataTree`:
+
+.. code-block:: python
+
+    >>> dtd = DataTreeDitto()
+    >>> dt = xarray.DataTree()
+    >>> isinstance(dt, xarray.DataTree) # A DataTree is a DataTree
+    True
+    >>> isinstance(dt, DataTreeDitto) # A DataTree is NOT a DataTreeDitto
+    False
+    >>> isinstance(dtd, DataTreeDitto) # A DataTreeDitto is a DataTreeDitto
+    True
+    >>> isinstance(dtd, xarray.DataTree) # A DataTreeDitto IS a DataTree
+    True
+
+Automatic Conversion of Children
+--------------------------------
+
+.. code-block:: python
+
+   tree["child_1"] = np.array([10, 20])
+   tree["child_2"] = {"a": "b"}  # Will raise TypeError unless converter is registered
+
+   # Get child as DataTreeDitto instance:
+   child = tree["child_1"]
+   assert isinstance(child, DataTreeDitto)
+
+Hierarchical Tree Structure:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   tree["sub"]["nested"] = np.ones((2,))
+   print(tree.to_datatree())  # Returns standard xarray.DataTree version for compatibility.
+
+Round-trip Recovery:
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   recovered = tree.get_original("sub/nested")
+   assert isinstance(recovered, np.ndarray)
+
+Advanced Usage: Custom Converters
+---------------------------------
+
+You can register custom converters for your own data types.
+
+Example: Handling Lists
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Suppose you want to allow lists to be stored in a tree node.
+
+Define conversion functions:
+
+.. code-block:: python
+
+   def list_to_dataset(lst, name="data", **kwargs):
+       return DataTreeDitto._numpy_to_dataset(np.array(lst), name=name)
+
+   def dataset_to_list(ds: xr.Dataset):
+       return ds[list(ds.data_vars)[0]].values.tolist()
+
+Register the converter:
+
+.. code-block:: python
+
+   DataTreeDitto.register_converter(list, list_to_dataset, dataset_to_list)
+
+Use it like this:
+
+.. code-block:: python
+
+   dt = DataTreeDitto([1, 2, 3])
+   print(dt.get_original())  # [1, 2, 3]
+
+Inspecting Converted Nodes
+--------------------------
+
+To see which nodes have been converted from non-xarray objects:
+
+.. code-block:: python
+
+   converted_info = dt.list_converted_nodes()
+   for path_str, orig_type in converted_info.items():
+       print(f"{path_str}: {orig_type}")
+
+Interoperability with Standard xarray Trees
+-------------------------------------------
+
+If needed for downstream compatibility (e.g., saving or visualization), convert back using ``.to_datatree()``:
+
+.. code-block:: python
+
+   standard_tree = dt.to_datatree()
+   assert isinstance(standard_tree, xr.DataTree)
+
+Debugging Tips:
+---------------
+
+- Always provide a unique name when creating or assigning new nodes.
+- Use ``get_original(path)`` instead of directly accessing ``.ds`` if working with converted data.
+- Avoid registering overly generic converters (e.g., ``object``) — this could make debugging difficult.
+- You can override or remove previously registered converters by re-calling ``register_converter()``.
+
+If you try to assign an unsupported type without registering a converter::
+
+    TypeError: No converter registered for type <class 'dict'>
+
+To debug representation info at any time::
+
+    print(repr(tree))
+
+This will include paths and original types of all converted nodes.

--- a/docs/source/concepts/architecture/custom-types/index.rst
+++ b/docs/source/concepts/architecture/custom-types/index.rst
@@ -1,0 +1,12 @@
+.. dropdown:: Distribution Statement
+
+ | # # # This source code is subject to the license referenced at
+ | # # # https://github.com/NRLMMD-GEOIPS.
+
+Custom Types
+============
+
+.. toctree::
+    :maxdepth: 1
+
+    datatree-ditto

--- a/docs/source/concepts/architecture/index.rst
+++ b/docs/source/concepts/architecture/index.rst
@@ -19,3 +19,4 @@ Architecture
     tests/index
     documentation/index
     command_line_interface
+    custom-types/index

--- a/docs/source/releases/1.14.5/759-update-tc_decks_database-to-support-b-deck-files-1.yaml
+++ b/docs/source/releases/1.14.5/759-update-tc_decks_database-to-support-b-deck-files-1.yaml
@@ -9,18 +9,11 @@ bug fix:
     Also add error handling if either a b-deck or g-deck file cannot be parsed and added
     to the decks database.
   files:
-    deleted:
-    - ''
-    moved:
-    - ''
-    added:
-    - ''
     modified:
     - 'geoips/sector_utils/tc_tracks_database.py'
   related-issue:
-    internal: GEOIPS#759
+    internal: "GEOIPS#759 - Fix bug preventing invest b-deck files from being added to decks database"
     number: 759
-    repo_url: 'GEOIPS/geoips'
   date:
     start: 2025-03-13
     finish: 2025-03-13

--- a/docs/source/releases/1.14.5/770-ingest-amsu-a-datasets-from-mirs-files.yaml
+++ b/docs/source/releases/1.14.5/770-ingest-amsu-a-datasets-from-mirs-files.yaml
@@ -16,14 +16,14 @@ bug fix:
     or mhs at the dataset level. i.e. The source name in METADATA.attrs will always be
     amsu-a_mhs, AMSUA.attrs will be amsu-a, and MHS.attrs will be mhs. Due to this
     switching, we had to add amsu-a_mhs as a source input to all amsu-a and mhs product
-    yamls.
+    yaml files.
 
     There was no problem with implementing the varying dataset source name in the single
     source procflow, but it did cause issues with the config based procflow. The config
     based procflow relies on checking the top level METADATA to get the product plugin.
     To solve this problem, we added the ability to loop through all datasets and check
     each source name. This was only a problem in two locations, and while the solution
-    implemented in this pull request works this funtionality should really be toggled
+    implemented in this pull request works this functionality should really be toggled
     (e.g. if METADATA.source_name == multi)
 
     An mhs product YAML previously existed, but it was not actually used. This PR

--- a/docs/source/releases/1.14.5/770-ingest-amsu-a-datasets-from-mirs-files.yaml
+++ b/docs/source/releases/1.14.5/770-ingest-amsu-a-datasets-from-mirs-files.yaml
@@ -49,9 +49,8 @@ bug fix:
     - 'tests/outputs/amsub_mirs.tc.183-3H.imagery_annotated/20210419_235400_WP022021_mhs_metop-a_183-3H_115kts_100p00_1p0.png.yaml'
     - 'tests/scripts/mhs_mirs.tc.183-3H.imagery_annotated.sh'
   related-issue:
-    internal: GEOIPS#770
+    internal: GEOIPS#770 - Replace AMSU-B references with MHS
     number: 770
-    repo_url: 'geoips'
   date:
     start: 2025-03-05
     finish: 2025-03-05

--- a/docs/source/releases/1.14.5/773-revert-naming-of-mhs-variables-in-mhs-product-config-and-amsua_mhs_mirs-reader.yaml
+++ b/docs/source/releases/1.14.5/773-revert-naming-of-mhs-variables-in-mhs-product-config-and-amsua_mhs_mirs-reader.yaml
@@ -6,19 +6,12 @@ bug fix:
     issues with other plugins, such as recenter_tc. We should keep the old naming
     style for now, at least.
   files:
-    deleted:
-    - ''
-    moved:
-    - ''
-    added:
-    - ''
     modified:
     - 'geoips/plugins/modules/readers/amsua_mhs_mirs.py'
     - 'geoips/plugins/yaml/products/mhs.yaml'
   related-issue:
-    internal: GEOIPS#773
+    internal: "GEOIPS#773 - Revert naming of MHS variables"
     number: 773
-    repo_url: 'geoips'
   date:
     start: 2025-03-10
     finish: 2025-03-10

--- a/docs/source/releases/1.14.5/775-fix-which-version-of-geoips-is-displayed-at-the-command-line.yaml
+++ b/docs/source/releases/1.14.5/775-fix-which-version-of-geoips-is-displayed-at-the-command-line.yaml
@@ -3,18 +3,12 @@ bug fix:
   description: |
     Filter out the deploy tags so the latest tagged version of GeoIPS is shown.
   files:
-    deleted:
-    - ''
-    moved:
-    - ''
-    added:
-    - ''
     modified:
     - 'setup/config_geoips'
   related-issue:
-    internal: GEOIPS#775
+    internal: GEOIPS#775 - Fix which version of GeoIPS is shown at the command line
     number: 775
-    repo_url: 'geoips'
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
   date:
     start: 2025-03-11
     finish: 2025-03-11

--- a/docs/source/releases/1.16.0/946-handle-singular-and-plural-forms-of-plugins-cleanly.yaml
+++ b/docs/source/releases/1.16.0/946-handle-singular-and-plural-forms-of-plugins-cleanly.yaml
@@ -12,5 +12,5 @@ enhancement:
     number: 946
     repo_url: ""
   date:
-    start: "2025-04-17"
-    finish: "2025-04-14"
+    start: "2025-04-14"
+    finish: "2025-04-17"

--- a/docs/source/releases/latest/datatree-ditto.yaml
+++ b/docs/source/releases/latest/datatree-ditto.yaml
@@ -1,0 +1,126 @@
+bug fix:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+enhancement:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+deprecation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+removal:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+performance:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+documentation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+continuous integration:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/docs/source/releases/latest/design-implement-validate-ssp-to-obp-execution-flow.yaml
+++ b/docs/source/releases/latest/design-implement-validate-ssp-to-obp-execution-flow.yaml
@@ -1,0 +1,126 @@
+bug fix:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+enhancement:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+deprecation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+removal:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+performance:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+documentation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+continuous integration:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/geoips/plugin_registry.py
+++ b/geoips/plugin_registry.py
@@ -553,7 +553,8 @@ class PluginRegistry:
             plugin_json_formatted = self.load_plugin(plugin)
             plugin_dict_formatted = plugin_json_formatted.model_dump()
             validated = interface_obj.validator.validate(plugin_dict_formatted)
-            return interface_obj._plugin_yaml_to_obj(name, validated)
+            # return interface_obj._plugin_yaml_to_obj(name, validated)
+            return plugin_json_formatted 
         else:
             validated = interface_obj.validator.validate(plugin)
             return interface_obj._plugin_yaml_to_obj(name, validated)

--- a/geoips/plugin_registry.py
+++ b/geoips/plugin_registry.py
@@ -554,7 +554,7 @@ class PluginRegistry:
             plugin_dict_formatted = plugin_json_formatted.model_dump()
             validated = interface_obj.validator.validate(plugin_dict_formatted)
             # return interface_obj._plugin_yaml_to_obj(name, validated)
-            return plugin_json_formatted 
+            return plugin_json_formatted
         else:
             validated = interface_obj.validator.validate(plugin)
             return interface_obj._plugin_yaml_to_obj(name, validated)

--- a/geoips/utils/types/DataTreeDitto.py
+++ b/geoips/utils/types/DataTreeDitto.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/geoips/utils/types/DataTreeDitto.py
+++ b/geoips/utils/types/DataTreeDitto.py
@@ -1,1 +1,0 @@
-# placeholder

--- a/geoips/utils/types/datatree_ditto.py
+++ b/geoips/utils/types/datatree_ditto.py
@@ -14,6 +14,27 @@ class DataTreeDitto(DataTree):
     various data types (numpy arrays, etc.) to xarray Datasets while preserving
     metadata needed for round-trip conversion back to original types.
 
+    Pokemon, the world's most valuable intellectual property,
+    has a pokemon named "ditto" that duplicates its opponents behavior and structure
+    with only slight difference. This class - DataTreeDitto - behaves like to xarray
+    DataTrees with slight differences to accommodate a wider variety of data types.
+
+    ⠀⠀⠀⢠⡜⠛⠛⠿⣤⠀⠀⣤⡼⠿⠿⢧⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+    ⠀⣀⡶⠎⠁⠀⠀⠀⠉⠶⠶⠉⠁⠀⠀⠈⠹⢆⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+    ⣀⡿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠶⠶⠶⠶⣆⡀⠀⠀⠀⠀
+    ⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢣⡄⠀⠀⠀
+    ⠛⣧⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀
+    ⠀⠛⣧⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⠀⠀⠀⠀⢠⡼⠃⠀⠀
+    ⠀⠀⠿⢇⡀⠀⠀⠀⠀⠀⠀⠀⠰⠶⠶⢆⣀⣀⣀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⠀
+    ⠀⠀⠀⢸⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠉⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⠀
+    ⠀⠀⠀⢸⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀
+    ⠀⠀⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢣⣤
+    ⠀⣶⡏⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿
+    ⠀⠿⣇⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⠀⠀⠀⠀⢀⣀⣸⠿
+    ⠀⠀⠙⢳⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⡞⠛⠛⠛⠛⠛⠛⣶⣶⣶⣶⡞⠛⠃⠀
+
+    "Ditto" from Pokemon is pictured above.
+
     Examples
     --------
     >>> import numpy as np
@@ -49,12 +70,12 @@ class DataTreeDitto(DataTree):
         >>> dt.ds.data.values.tolist()
         [1, 2, 3]
         """
-        # Initialize class-level converter registry if not exists
+        # Initialize class-level converter registry if it does not exist
         if not hasattr(DataTreeDitto, "_converters"):
             DataTreeDitto._converters = {}
             DataTreeDitto._register_builtin_converters()
 
-        # Convert data if it's not an xarray object
+        # Convert data if the data is not an xarray DataSet
         if data is not None:
             if isinstance(data, xr.DataArray):
                 # Convert DataArray to Dataset
@@ -63,31 +84,12 @@ class DataTreeDitto(DataTree):
                 # Convert non-xarray object
                 data = self._convert_to_dataset(data)
 
-        # Call parent constructor
         super().__init__(dataset=data, children=children, name=name)
 
         # Handle parent separately if provided
         if parent is not None:
             # Let DataTree handle the parent-child relationship
             parent[name or "unnamed"] = self
-
-    def _set_parent(self, new_parent, child_name):
-        """Override to match DataTree's expected signature.
-
-        Parameters
-        ----------
-        new_parent : DataTree
-            The new parent node.
-        child_name : str
-            Name of this node in the parent.
-
-        Returns
-        -------
-        Any
-            Result of parent's _set_parent method.
-        """
-        # Call the parent's _set_parent method with correct signature
-        return super()._set_parent(new_parent, child_name)
 
     @classmethod
     def _register_builtin_converters(cls):

--- a/geoips/utils/types/datatree_ditto.py
+++ b/geoips/utils/types/datatree_ditto.py
@@ -1,0 +1,545 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Union
+
+import numpy as np
+import xarray as xr
+from xarray import DataTree
+
+
+class DataTreeDitto(DataTree):
+    """A DataTree subclass that automatically converts non-xarray objects to datasets.
+
+    DataTreeDitto extends xarray's DataTree to automatically handle conversion of
+    various data types (numpy arrays, etc.) to xarray Datasets while preserving
+    metadata needed for round-trip conversion back to original types.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> arr = np.array([[1, 2], [3, 4]])
+    >>> dt = DataTreeDitto(arr)
+    >>> dt.ds.data.values.tolist()
+    [[1, 2], [3, 4]]
+    >>> dt.get_original().tolist()
+    [[1, 2], [3, 4]]
+    """
+
+    def __init__(self, data=None, parent=None, children=None, name=None):
+        """Initialize a DataTreeDitto instance.
+
+        Parameters
+        ----------
+        data : array-like, xarray.Dataset, xarray.DataArray, or None, optional
+            Data to store in this node. Non-xarray objects are automatically
+            converted to xarray.Dataset using registered converters.
+        parent : DataTreeDitto, optional
+            Parent node in the tree structure.
+        children : dict, optional
+            Dictionary of child nodes.
+        name : str, optional
+            Name of this node.
+
+        Examples
+        --------
+        >>> arr = np.array([1, 2, 3])
+        >>> dt = DataTreeDitto(arr, name="test")
+        >>> dt.name
+        'test'
+        >>> dt.ds.data.values.tolist()
+        [1, 2, 3]
+        """
+        # Initialize class-level converter registry if not exists
+        if not hasattr(DataTreeDitto, "_converters"):
+            DataTreeDitto._converters = {}
+            DataTreeDitto._register_builtin_converters()
+
+        # Convert data if it's not an xarray object
+        if data is not None:
+            if isinstance(data, xr.DataArray):
+                # Convert DataArray to Dataset
+                data = data.to_dataset()
+            elif not isinstance(data, xr.Dataset):
+                # Convert non-xarray object
+                data = self._convert_to_dataset(data)
+
+        # Call parent constructor
+        super().__init__(dataset=data, children=children, name=name)
+
+        # Handle parent separately if provided
+        if parent is not None:
+            # Let DataTree handle the parent-child relationship
+            parent[name or "unnamed"] = self
+
+    def _set_parent(self, new_parent, child_name):
+        """Override to match DataTree's expected signature.
+
+        Parameters
+        ----------
+        new_parent : DataTree
+            The new parent node.
+        child_name : str
+            Name of this node in the parent.
+
+        Returns
+        -------
+        Any
+            Result of parent's _set_parent method.
+        """
+        # Call the parent's _set_parent method with correct signature
+        return super()._set_parent(new_parent, child_name)
+
+    @classmethod
+    def _register_builtin_converters(cls):
+        """Register built-in converters for common types.
+
+        Registers converters for numpy arrays automatically when the class
+        is first instantiated.
+        """
+        cls.register_converter(np.ndarray, cls._numpy_to_dataset, cls._dataset_to_numpy)
+
+    @classmethod
+    def register_converter(
+        cls,
+        obj_type: type,
+        to_dataset_func: Callable,
+        from_dataset_func: Callable,
+    ) -> None:
+        """Register a converter for a specific object type.
+
+        Parameters
+        ----------
+        obj_type : type
+            The type of object to convert.
+        to_dataset_func : callable
+            Function to convert object to xarray.Dataset. Must accept the object
+            as first argument and return an xarray.Dataset.
+        from_dataset_func : callable
+            Function to convert xarray.Dataset back to original object. Must
+            accept an xarray.Dataset and return an object of obj_type.
+
+        Examples
+        --------
+        >>> def list_to_dataset(lst, name="data", **kwargs):
+        ...     arr = np.array(lst)
+        ...     return DataTreeDitto._numpy_to_dataset(arr, name, **kwargs)
+        >>> def dataset_to_list(ds, **kwargs):
+        ...     return DataTreeDitto._dataset_to_numpy(ds, **kwargs).tolist()
+        >>> DataTreeDitto.register_converter(list, list_to_dataset, dataset_to_list)
+        """
+        cls._converters[obj_type] = {
+            "to_dataset": to_dataset_func,
+            "from_dataset": from_dataset_func,
+        }
+
+    @staticmethod
+    def _numpy_to_dataset(
+        obj: np.ndarray,
+        name: str = "data",
+        dims: list | None = None,
+        **kwargs,
+    ) -> xr.Dataset:
+        """Convert numpy array to xarray Dataset.
+
+        Parameters
+        ----------
+        obj : numpy.ndarray
+            The numpy array to convert.
+        name : str, default "data"
+            Name for the data variable in the resulting dataset.
+        dims : list of str, optional
+            Dimension names. If None, generates names like "dim_0", "dim_1", etc.
+        **kwargs
+            Additional keyword arguments (currently unused).
+
+        Returns
+        -------
+        xarray.Dataset
+            Dataset containing the array data with metadata for round-trip conversion.
+
+        Examples
+        --------
+        >>> arr = np.array([[1, 2], [3, 4]])
+        >>> ds = DataTreeDitto._numpy_to_dataset(arr)
+        >>> ds.data.values.tolist()
+        [[1, 2], [3, 4]]
+        >>> ds.attrs['_ditto_original_type']
+        'numpy.ndarray'
+        """
+        if dims is None:
+            dims = [f"dim_{i}" for i in range(obj.ndim)]
+
+        data_array = xr.DataArray(obj, dims=dims, name=name)
+        dataset = data_array.to_dataset()
+
+        # Store metadata for round-trip conversion
+        dataset.attrs.update(
+            {
+                "_ditto_original_type": "numpy.ndarray",
+                "_ditto_original_shape": obj.shape,
+                "_ditto_original_dtype": str(obj.dtype),
+                "_ditto_var_name": name,
+                "_ditto_dims": dims,
+            },
+        )
+
+        return dataset
+
+    @staticmethod
+    def _dataset_to_numpy(dataset: xr.Dataset, **kwargs) -> np.ndarray:
+        """Convert xarray Dataset back to numpy array.
+
+        Parameters
+        ----------
+        dataset : xarray.Dataset
+            Dataset to convert back to numpy array.
+        **kwargs
+            Additional keyword arguments (currently unused).
+
+        Returns
+        -------
+        numpy.ndarray
+            The numpy array extracted from the dataset.
+
+        Examples
+        --------
+        >>> arr = np.array([1, 2, 3])
+        >>> ds = DataTreeDitto._numpy_to_dataset(arr)
+        >>> recovered = DataTreeDitto._dataset_to_numpy(ds)
+        >>> recovered.tolist()
+        [1, 2, 3]
+        """
+        var_name = dataset.attrs.get("_ditto_var_name", "data")
+        if var_name not in dataset.data_vars:
+            # Fallback: use first data variable
+            var_name = next(iter(dataset.data_vars.keys()))
+
+        return dataset[var_name].values
+
+    def _convert_to_dataset(self, obj: Any, **kwargs) -> xr.Dataset:
+        """Convert an object to xarray Dataset using registered converters.
+
+        Parameters
+        ----------
+        obj : Any
+            Object to convert to xarray Dataset.
+        **kwargs
+            Additional keyword arguments passed to the converter function.
+
+        Returns
+        -------
+        xarray.Dataset
+            Dataset representation of the input object.
+
+        Raises
+        ------
+        TypeError
+            If no converter is registered for the object's type.
+
+        Examples
+        --------
+        >>> dt = DataTreeDitto()
+        >>> arr = np.array([1, 2, 3])
+        >>> ds = dt._convert_to_dataset(arr)
+        >>> ds.data.values.tolist()
+        [1, 2, 3]
+        """
+        obj_type = type(obj)
+
+        if obj_type not in self._converters:
+            raise TypeError(
+                f"No converter registered for type {obj_type}. "
+                f"Available converters: {list(self._converters.keys())}",
+            )
+
+        converter = self._converters[obj_type]["to_dataset"]
+        return converter(obj, **kwargs)
+
+    def _convert_from_dataset(self, dataset: xr.Dataset) -> Any:
+        """Convert a dataset back to its original type if metadata exists.
+
+        Parameters
+        ----------
+        dataset : xarray.Dataset
+            Dataset to convert back to original type.
+
+        Returns
+        -------
+        Any
+            Original object type if conversion metadata exists, otherwise
+            returns the dataset unchanged.
+
+        Examples
+        --------
+        >>> arr = np.array([1, 2, 3])
+        >>> ds = DataTreeDitto._numpy_to_dataset(arr)
+        >>> dt = DataTreeDitto()
+        >>> recovered = dt._convert_from_dataset(ds)
+        >>> recovered.tolist()
+        [1, 2, 3]
+        """
+        original_type = dataset.attrs.get("_ditto_original_type")
+
+        if original_type is None:
+            return dataset
+
+        # Find converter by original type string
+        for obj_type, converter_dict in self._converters.items():
+            if f"{obj_type.__module__}.{obj_type.__name__}" == original_type:
+                return converter_dict["from_dataset"](dataset)
+
+        # Fallback: return dataset if converter not found
+        return dataset
+
+    def _intercept_assignment(func):
+        """Decorator to intercept and convert assignments.
+
+        Parameters
+        ----------
+        func : callable
+            Function to wrap (typically __setitem__).
+
+        Returns
+        -------
+        callable
+            Wrapped function that automatically converts assigned values.
+        """
+
+        @wraps(func)
+        def wrapper(self, key, value):
+            if isinstance(value, DataTreeDitto):
+                # Already a DataTreeDitto, proceed normally
+                return func(self, key, value)
+            elif isinstance(value, DataTree):
+                # Convert DataTree to DataTreeDitto
+                new_ditto = DataTreeDitto(data=value.ds, name=key)
+                # Recursively convert children
+                for child_name, child in value.children.items():
+                    new_ditto[child_name] = child
+                return func(self, key, new_ditto)
+            elif isinstance(value, (xr.Dataset, xr.DataArray)):
+                # Create new DataTreeDitto with xarray object
+                new_ditto = DataTreeDitto(data=value, name=key)
+                return func(self, key, new_ditto)
+            else:
+                # Convert non-xarray object
+                try:
+                    dataset = self._convert_to_dataset(value)
+                    new_ditto = DataTreeDitto(data=dataset, name=key)
+                    return func(self, key, new_ditto)
+                except TypeError:
+                    raise TypeError(
+                        f"Cannot assign object of type {type(value)} to DataTreeDitto. "
+                        f"No converter registered for this type.",
+                    )
+
+        return wrapper
+
+    @_intercept_assignment
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Override setitem to handle automatic conversion.
+
+        Parameters
+        ----------
+        key : str
+            Name for the child node.
+        value : Any
+            Value to assign. Will be automatically converted to DataTreeDitto
+            if it's not already an xarray object.
+
+        Examples
+        --------
+        >>> dt = DataTreeDitto()
+        >>> dt["child"] = np.array([1, 2, 3])
+        >>> dt["child"].ds.data.values.tolist()
+        [1, 2, 3]
+        """
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key: str) -> Union["DataTreeDitto", Any]:
+        """Override getitem to return DataTreeDitto instances.
+
+        Parameters
+        ----------
+        key : str
+            Name of the child node to retrieve.
+
+        Returns
+        -------
+        DataTreeDitto
+            The child node, converted to DataTreeDitto if necessary.
+
+        Examples
+        --------
+        >>> dt = DataTreeDitto()
+        >>> dt["child"] = np.array([1, 2, 3])
+        >>> child = dt["child"]
+        >>> isinstance(child, DataTreeDitto)
+        True
+        """
+        result = super().__getitem__(key)
+        if isinstance(result, DataTree) and not isinstance(result, DataTreeDitto):
+            # Convert to DataTreeDitto while preserving structure
+            return self._convert_datatree_to_ditto(result)
+        return result
+
+    def _convert_datatree_to_ditto(self, dt: DataTree) -> "DataTreeDitto":
+        """Convert a DataTree to DataTreeDitto recursively.
+
+        Parameters
+        ----------
+        dt : DataTree
+            DataTree instance to convert.
+
+        Returns
+        -------
+        DataTreeDitto
+            Converted DataTreeDitto with all children also converted.
+        """
+        new_ditto = DataTreeDitto(data=dt.ds, name=dt.name)
+        for child_name, child in dt.children.items():
+            new_ditto[child_name] = self._convert_datatree_to_ditto(child)
+        return new_ditto
+
+    def get_original(self, path: str = ".") -> Any:
+        """Get the original object (before conversion) at the specified path.
+
+        Parameters
+        ----------
+        path : str, default "."
+            Path to the node. Use "." for current node, or child names
+            separated by "/" for nested nodes.
+
+        Returns
+        -------
+        Any
+            Original object if conversion metadata exists, otherwise the dataset.
+            Returns None if the node contains no data.
+
+        Examples
+        --------
+        >>> arr = np.array([1, 2, 3])
+        >>> dt = DataTreeDitto(arr)
+        >>> original = dt.get_original()
+        >>> original.tolist()
+        [1, 2, 3]
+        >>> dt["child"] = np.array([4, 5, 6])
+        >>> dt.get_original("child").tolist()
+        [4, 5, 6]
+        """
+        node = self if path == "." else self[path]
+
+        if node.ds is None:
+            return None
+
+        # Get the actual dataset, not the view
+        actual_dataset = node.ds._dataset if hasattr(node.ds, "_dataset") else node.ds
+
+        return self._convert_from_dataset(actual_dataset)
+
+    def to_datatree(self) -> DataTree:
+        """Convert to a standard DataTree with all nodes as xarray objects.
+
+        Returns
+        -------
+        DataTree
+            A standard DataTree instance with all converted objects as datasets.
+            Conversion metadata is preserved in dataset attributes.
+
+        Examples
+        --------
+        >>> arr = np.array([1, 2, 3])
+        >>> dt = DataTreeDitto(arr, name="test")
+        >>> standard_dt = dt.to_datatree()
+        >>> isinstance(standard_dt, DataTree)
+        True
+        >>> standard_dt.ds.data.values.tolist()
+        [1, 2, 3]
+        """
+        # Get the actual dataset, not the view
+        dataset = None
+        if self.ds is not None:
+            dataset = self.ds._dataset if hasattr(self.ds, "_dataset") else self.ds
+
+        # Create new DataTree with current data
+        new_dt = DataTree(dataset=dataset, name=self.name)
+
+        # Recursively convert children
+        for child_name, child in self.children.items():
+            if isinstance(child, DataTreeDitto):
+                new_dt[child_name] = child.to_datatree()
+            else:
+                new_dt[child_name] = child
+
+        return new_dt
+
+    def list_converted_nodes(self) -> dict[str, str]:
+        """List all nodes that contain converted objects and their original types.
+
+        Returns
+        -------
+        dict of str to str
+            Mapping of node paths to original object type names. Paths use "/"
+            as separator, with "/" representing the root node.
+
+        Examples
+        --------
+        >>> dt = DataTreeDitto(np.array([1, 2, 3]))
+        >>> dt["child"] = np.array([4, 5, 6])
+        >>> converted = dt.list_converted_nodes()
+        >>> "/" in converted
+        True
+        >>> "child" in converted
+        True
+        >>> converted["/"]
+        'numpy.ndarray'
+        """
+        converted = {}
+
+        def _check_node(node, path=""):
+            if node.ds is not None:
+                # Get the actual dataset, not the view
+                actual_dataset = node.ds
+                if hasattr(actual_dataset, "_dataset"):
+                    actual_dataset = actual_dataset._dataset
+
+                original_type = actual_dataset.attrs.get("_ditto_original_type")
+                if original_type:
+                    converted[path or "/"] = original_type
+
+            for child_name, child in node.children.items():
+                child_path = f"{path}/{child_name}" if path else child_name
+                _check_node(child, child_path)
+
+        _check_node(self)
+        return converted
+
+    def __repr__(self) -> str:
+        """Enhanced representation showing conversion info.
+
+        Returns
+        -------
+        str
+            String representation including information about converted nodes
+            and their original types.
+
+        Examples
+        --------
+        >>> dt = DataTreeDitto(np.array([1, 2, 3]))
+        >>> repr_str = repr(dt)
+        >>> "Converted nodes:" in repr_str
+        True
+        >>> "numpy.ndarray" in repr_str
+        True
+        """
+        base_repr = super().__repr__()
+
+        # Add conversion information
+        converted_nodes = self.list_converted_nodes()
+        if converted_nodes:
+            conversion_info = "\nConverted nodes:\n"
+            for path, orig_type in converted_nodes.items():
+                conversion_info += f"  {path}: {orig_type}\n"
+            base_repr += conversion_info
+
+        return base_repr

--- a/tests/unit_tests/utils/types/test_datatree_ditto.py
+++ b/tests/unit_tests/utils/types/test_datatree_ditto.py
@@ -1,0 +1,569 @@
+import pytest
+import numpy as np
+import xarray as xr
+from xarray import DataTree
+import pandas as pd
+from typing import Any
+import copy
+
+# Import the module
+from geoips.utils.types.datatree_ditto import DataTreeDitto
+
+
+class TestDataTreeDittoCore:
+    """Test core functionality of DataTreeDitto."""
+
+    def test_initialization_empty(self):
+        """Test creating empty DataTreeDitto."""
+        dt = DataTreeDitto()
+        assert isinstance(dt, DataTreeDitto)
+        assert isinstance(dt, DataTree)
+        # DataTree automatically creates an empty dataset when initialized without data
+        assert dt.ds is not None
+        assert len(dt.ds.data_vars) == 0
+        assert len(dt.ds.dims) == 0
+
+    def test_initialization_with_dataset(self):
+        """Test creating DataTreeDitto with xarray Dataset."""
+        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+        dt = DataTreeDitto(data=ds)
+        # ds property returns a view, so we check the underlying data
+        assert "temp" in dt.ds.data_vars
+        assert isinstance(dt, DataTreeDitto)
+
+    def test_initialization_with_dataarray(self):
+        """Test creating DataTreeDitto with xarray DataArray."""
+        da = xr.DataArray(np.random.rand(2, 3), dims=["x", "y"], name="temp")
+        dt = DataTreeDitto(data=da)
+        assert isinstance(dt.ds, xr.Dataset)
+        assert "temp" in dt.ds.data_vars
+
+    def test_initialization_with_numpy_array(self):
+        """Test creating DataTreeDitto with numpy array."""
+        arr = np.random.rand(3, 4)
+        dt = DataTreeDitto(data=arr)
+        assert isinstance(dt.ds, xr.Dataset)
+        # Check the underlying dataset for attributes
+        actual_ds = dt.ds._dataset if hasattr(dt.ds, "_dataset") else dt.ds
+        assert "_ditto_original_type" in actual_ds.attrs
+        assert actual_ds.attrs["_ditto_original_type"] == "numpy.ndarray"
+
+    def test_initialization_with_unsupported_type(self):
+        """Test creating DataTreeDitto with unsupported type raises error."""
+        with pytest.raises(TypeError, match="No converter registered"):
+            DataTreeDitto(data="unsupported string")
+
+
+class TestConverterSystem:
+    """Test the converter registration and functionality."""
+
+    def test_builtin_numpy_converter_exists(self):
+        """Test that numpy converter is registered by default."""
+        assert np.ndarray in DataTreeDitto._converters
+        assert "to_dataset" in DataTreeDitto._converters[np.ndarray]
+        assert "from_dataset" in DataTreeDitto._converters[np.ndarray]
+
+    def test_register_custom_converter(self):
+        """Test registering a custom converter."""
+
+        def list_to_dataset(obj, name="data", dims=None, **kwargs):
+            arr = np.array(obj)
+            if dims is None:
+                dims = ["dim_0"]
+            da = xr.DataArray(arr, dims=dims, name=name)
+            ds = da.to_dataset()
+            ds.attrs.update(
+                {
+                    "_ditto_original_type": "builtins.list",
+                    "_ditto_var_name": name,
+                    "_ditto_dims": dims,
+                }
+            )
+            return ds
+
+        def dataset_to_list(dataset, **kwargs):
+            var_name = dataset.attrs.get("_ditto_var_name", "data")
+            return dataset[var_name].values.tolist()
+
+        DataTreeDitto.register_converter(list, list_to_dataset, dataset_to_list)
+
+        # Test the converter works
+        dt = DataTreeDitto()
+        test_list = [1, 2, 3, 4, 5]
+        dt["list_data"] = test_list
+
+        assert isinstance(dt["list_data"].ds, xr.Dataset)
+        assert dt.get_original("list_data") == test_list
+
+        # Cleanup
+        del DataTreeDitto._converters[list]
+
+    def test_numpy_to_dataset_conversion(self):
+        """Test numpy array to dataset conversion details."""
+        arr = np.array([[1, 2, 3], [4, 5, 6]])
+        ds = DataTreeDitto._numpy_to_dataset(arr, name="test_data")
+
+        assert isinstance(ds, xr.Dataset)
+        assert "test_data" in ds.data_vars
+        assert ds.attrs["_ditto_original_type"] == "numpy.ndarray"
+        assert ds.attrs["_ditto_original_shape"] == (2, 3)
+        assert ds.attrs["_ditto_var_name"] == "test_data"
+        assert ds.attrs["_ditto_dims"] == ["dim_0", "dim_1"]
+
+    def test_dataset_to_numpy_conversion(self):
+        """Test dataset to numpy array conversion."""
+        arr = np.array([[1, 2, 3], [4, 5, 6]])
+        ds = DataTreeDitto._numpy_to_dataset(arr, name="test_data")
+        converted_back = DataTreeDitto._dataset_to_numpy(ds)
+
+        np.testing.assert_array_equal(arr, converted_back)
+
+    def test_custom_dims_numpy_conversion(self):
+        """Test numpy conversion with custom dimensions."""
+        arr = np.random.rand(2, 3, 4)
+        custom_dims = ["time", "lat", "lon"]
+        ds = DataTreeDitto._numpy_to_dataset(arr, dims=custom_dims)
+
+        assert ds.attrs["_ditto_dims"] == custom_dims
+        assert list(ds["data"].dims) == custom_dims
+
+
+class TestAssignmentAndRetrieval:
+    """Test assignment and retrieval operations."""
+
+    def test_setitem_numpy_array(self):
+        """Test assigning numpy array via setitem."""
+        dt = DataTreeDitto()
+        arr = np.random.rand(3, 4)
+        dt["numpy_node"] = arr
+
+        assert "numpy_node" in dt.children
+        assert isinstance(dt["numpy_node"], DataTreeDitto)
+        assert isinstance(dt["numpy_node"].ds, xr.Dataset)
+
+    def test_setitem_xarray_dataset(self):
+        """Test assigning xarray dataset via setitem."""
+        dt = DataTreeDitto()
+        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+        dt["xarray_node"] = ds
+
+        assert "xarray_node" in dt.children
+        assert isinstance(dt["xarray_node"], DataTreeDitto)
+        assert "temp" in dt["xarray_node"].ds.data_vars
+
+    def test_setitem_datatree(self):
+        """Test assigning DataTree via setitem."""
+        dt = DataTreeDitto()
+        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+        original_dt = DataTree(dataset=ds)
+
+        dt["datatree_node"] = original_dt
+
+        assert "datatree_node" in dt.children
+        assert isinstance(dt["datatree_node"], DataTreeDitto)
+
+    def test_setitem_unsupported_type(self):
+        """Test assigning unsupported type raises error."""
+        dt = DataTreeDitto()
+        with pytest.raises(TypeError, match="Cannot assign object of type"):
+            dt["bad_node"] = "unsupported string"
+
+    def test_getitem_returns_datatree_ditto(self):
+        """Test that getitem returns DataTreeDitto instances."""
+        dt = DataTreeDitto()
+        arr = np.random.rand(2, 3)
+        dt["test_node"] = arr
+
+        retrieved = dt["test_node"]
+        assert isinstance(retrieved, DataTreeDitto)
+
+    def test_nested_assignment(self):
+        """Test nested assignment of various types."""
+        dt = DataTreeDitto()
+
+        # Create nested structure
+        arr1 = np.random.rand(2, 3)
+        arr2 = np.random.rand(4, 5)
+        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(3, 4))})
+
+        dt["level1"] = DataTreeDitto()
+        dt["level1"]["numpy1"] = arr1
+        dt["level1"]["numpy2"] = arr2
+        dt["level1"]["xarray1"] = ds
+
+        assert isinstance(dt["level1"]["numpy1"], DataTreeDitto)
+        assert isinstance(dt["level1"]["xarray1"], DataTreeDitto)
+        np.testing.assert_array_equal(dt.get_original("level1/numpy1"), arr1)
+
+
+class TestOriginalObjectRetrieval:
+    """Test retrieval of original objects."""
+
+    def test_get_original_current_node(self):
+        """Test getting original object from current node."""
+        arr = np.random.rand(3, 4)
+        dt = DataTreeDitto(data=arr)
+
+        original = dt.get_original(".")
+        np.testing.assert_array_equal(original, arr)
+
+    def test_get_original_child_node(self):
+        """Test getting original object from child node."""
+        dt = DataTreeDitto()
+        arr = np.random.rand(2, 5)
+        dt["child"] = arr
+
+        original = dt.get_original("child")
+        np.testing.assert_array_equal(original, arr)
+
+    def test_get_original_xarray_object(self):
+        """Test getting original xarray object returns dataset."""
+        dt = DataTreeDitto()
+        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+        dt["xarray_node"] = ds
+
+        original = dt.get_original("xarray_node")
+        # Since xarray objects don't have conversion metadata, we get back the dataset
+        assert isinstance(original, xr.Dataset)
+        assert "temp" in original.data_vars
+
+    def test_get_original_none_data(self):
+        """Test getting original from node with no data."""
+        dt = DataTreeDitto()
+        dt["empty"] = DataTreeDitto()
+
+        original = dt.get_original("empty")
+        # DataTree automatically creates an empty dataset, so we get that back
+        assert isinstance(original, xr.Dataset)
+        assert len(original.data_vars) == 0
+        assert len(original.dims) == 0
+
+    def test_roundtrip_conversion(self):
+        """Test perfect roundtrip conversion."""
+        original_arrays = [
+            np.array([1, 2, 3]),
+            np.array([[1, 2], [3, 4]]),
+            np.random.rand(2, 3, 4),
+            np.array(["a", "b", "c"]),  # string array
+        ]
+
+        dt = DataTreeDitto()
+        for i, arr in enumerate(original_arrays):
+            dt[f"arr_{i}"] = arr
+            retrieved = dt.get_original(f"arr_{i}")
+            np.testing.assert_array_equal(retrieved, arr)
+            assert retrieved.dtype == arr.dtype
+
+
+class TestDataTreeConversion:
+    """Test conversion to standard DataTree."""
+
+    def test_to_datatree_simple(self):
+        """Test converting simple DataTreeDitto to DataTree."""
+        dt = DataTreeDitto()
+        arr = np.random.rand(2, 3)
+        dt["numpy_data"] = arr
+
+        standard_dt = dt.to_datatree()
+
+        assert isinstance(standard_dt, DataTree)
+        assert not isinstance(standard_dt, DataTreeDitto)
+        assert "numpy_data" in standard_dt.children
+        assert isinstance(standard_dt["numpy_data"].ds, xr.Dataset)
+
+    def test_to_datatree_nested(self):
+        """Test converting nested DataTreeDitto to DataTree."""
+        dt = DataTreeDitto()
+        dt["level1"] = DataTreeDitto()
+        dt["level1"]["numpy_data"] = np.random.rand(2, 3)
+        dt["level1"]["xarray_data"] = xr.Dataset(
+            {"temp": (["x", "y"], np.random.rand(3, 4))}
+        )
+
+        standard_dt = dt.to_datatree()
+
+        assert isinstance(standard_dt, DataTree)
+        assert isinstance(standard_dt["level1"], DataTree)
+        assert not isinstance(standard_dt["level1"], DataTreeDitto)
+
+    def test_to_datatree_preserves_data(self):
+        """Test that conversion to DataTree preserves all data."""
+        dt = DataTreeDitto()
+        arr = np.array([[1, 2], [3, 4]])
+        dt["test"] = arr
+
+        standard_dt = dt.to_datatree()
+
+        # Data should be preserved as dataset
+        assert isinstance(standard_dt["test"].ds, xr.Dataset)
+        # Original conversion metadata should be preserved
+        actual_ds = (
+            standard_dt["test"].ds._dataset
+            if hasattr(standard_dt["test"].ds, "_dataset")
+            else standard_dt["test"].ds
+        )
+        assert "_ditto_original_type" in actual_ds.attrs
+
+
+class TestMetadataAndIntrospection:
+    """Test metadata preservation and introspection methods."""
+
+    def test_list_converted_nodes_empty(self):
+        """Test listing converted nodes on empty tree."""
+        dt = DataTreeDitto()
+        converted = dt.list_converted_nodes()
+        assert converted == {}
+
+    def test_list_converted_nodes_with_conversions(self):
+        """Test listing converted nodes with actual conversions."""
+        dt = DataTreeDitto()
+        dt["numpy1"] = np.random.rand(2, 3)
+        dt["level1"] = DataTreeDitto()
+        dt["level1"]["numpy2"] = np.random.rand(4, 5)
+        dt["level1"]["xarray1"] = xr.Dataset(
+            {"temp": (["x", "y"], np.random.rand(2, 2))}
+        )
+
+        converted = dt.list_converted_nodes()
+
+        assert "numpy1" in converted
+        assert "level1/numpy2" in converted
+        assert converted["numpy1"] == "numpy.ndarray"
+        assert converted["level1/numpy2"] == "numpy.ndarray"
+        # xarray objects shouldn't appear in converted list
+        assert "level1/xarray1" not in converted
+
+    def test_list_converted_nodes_root_conversion(self):
+        """Test listing when root node itself is converted."""
+        arr = np.random.rand(3, 3)
+        dt = DataTreeDitto(data=arr)
+
+        converted = dt.list_converted_nodes()
+        assert "/" in converted
+        assert converted["/"] == "numpy.ndarray"
+
+    def test_enhanced_repr(self):
+        """Test enhanced string representation."""
+        dt = DataTreeDitto()
+        dt["numpy_data"] = np.random.rand(2, 3)
+
+        repr_str = repr(dt)
+        assert "Converted nodes:" in repr_str
+        assert "numpy_data: numpy.ndarray" in repr_str
+
+    def test_repr_no_conversions(self):
+        """Test repr when no conversions exist."""
+        dt = DataTreeDitto()
+        dt["xarray_data"] = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+
+        repr_str = repr(dt)
+        assert "Converted nodes:" not in repr_str
+
+
+class TestInheritance:
+    """Test that DataTree functionality is preserved."""
+
+    def test_is_datatree_subclass(self):
+        """Test that DataTreeDitto is a DataTree subclass."""
+        dt = DataTreeDitto()
+        assert isinstance(dt, DataTree)
+        assert isinstance(dt, DataTreeDitto)
+
+    def test_datatree_methods_available(self):
+        """Test that DataTree methods are available."""
+        dt = DataTreeDitto()
+
+        # Test some DataTree methods exist
+        assert hasattr(dt, "subtree")
+        assert hasattr(dt, "filter")
+        assert hasattr(dt, "match")
+        assert hasattr(dt, "map_over_datasets")
+
+    def test_datatree_properties_available(self):
+        """Test that DataTree properties are available."""
+        dt = DataTreeDitto()
+
+        # Test some DataTree properties exist
+        assert hasattr(dt, "parent")
+        assert hasattr(dt, "children")
+        assert hasattr(dt, "siblings")
+        assert hasattr(dt, "root")
+
+    def test_mixed_tree_operations(self):
+        """Test operations on trees with mixed content."""
+        dt = DataTreeDitto()
+
+        # Add mixed content
+        dt["numpy"] = np.random.rand(2, 3)
+        dt["xarray"] = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
+        dt["empty"] = DataTreeDitto()
+
+        # Test tree navigation works
+        assert len(dt.children) == 3
+        assert dt["numpy"].parent is dt
+        assert dt.root is dt
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_converter_not_found_fallback(self):
+        """Test fallback when converter metadata exists but converter is missing."""
+        # Create a dataset with conversion metadata but no actual converter
+        ds = xr.Dataset({"data": (["x", "y"], np.random.rand(2, 3))})
+        ds.attrs["_ditto_original_type"] = "nonexistent.FakeType"
+
+        dt = DataTreeDitto(data=ds)
+        original = dt.get_original(".")
+
+        # Should fallback to returning the dataset
+        assert isinstance(original, xr.Dataset)
+        assert "data" in original.data_vars
+
+    def test_empty_numpy_array(self):
+        """Test handling empty numpy arrays."""
+        arr = np.array([])
+        dt = DataTreeDitto()
+        dt["empty_array"] = arr
+
+        retrieved = dt.get_original("empty_array")
+        np.testing.assert_array_equal(retrieved, arr)
+
+    def test_scalar_numpy_array(self):
+        """Test handling scalar numpy arrays."""
+        arr = np.array(42)
+        dt = DataTreeDitto()
+        dt["scalar"] = arr
+
+        retrieved = dt.get_original("scalar")
+        assert retrieved == arr
+        assert retrieved.shape == arr.shape
+
+    def test_complex_numpy_arrays(self):
+        """Test handling complex numpy arrays."""
+        arr = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+        dt = DataTreeDitto()
+        dt["complex"] = arr
+
+        retrieved = dt.get_original("complex")
+        np.testing.assert_array_equal(retrieved, arr)
+        assert retrieved.dtype == arr.dtype
+
+    def test_dataset_without_var_name_metadata(self):
+        """Test converting dataset back when var_name metadata is missing."""
+        arr = np.array([1, 2, 3])
+        ds = DataTreeDitto._numpy_to_dataset(arr)
+
+        # Remove the var_name metadata
+        del ds.attrs["_ditto_var_name"]
+
+        # Should still work by using first data variable
+        retrieved = DataTreeDitto._dataset_to_numpy(ds)
+        np.testing.assert_array_equal(retrieved, arr)
+
+
+class TestPerformance:
+    """Test performance-related aspects."""
+
+    def test_large_array_conversion(self):
+        """Test conversion of large numpy arrays."""
+        # Create a reasonably large array
+        large_arr = np.random.rand(100, 100, 10)
+        dt = DataTreeDitto()
+
+        # Should handle large arrays without issues
+        dt["large_array"] = large_arr
+        retrieved = dt.get_original("large_array")
+
+        np.testing.assert_array_equal(retrieved, large_arr)
+
+    def test_many_small_conversions(self):
+        """Test many small conversions."""
+        dt = DataTreeDitto()
+
+        # Add many small arrays
+        arrays = {}
+        for i in range(50):
+            arr = np.random.rand(5, 5)
+            arrays[f"arr_{i}"] = arr
+            dt[f"arr_{i}"] = arr
+
+        # Verify all conversions work
+        for name, original_arr in arrays.items():
+            retrieved = dt.get_original(name)
+            np.testing.assert_array_equal(retrieved, original_arr)
+
+
+# Fixtures for testing
+@pytest.fixture
+def sample_datatree_ditto():
+    """Create a sample DataTreeDitto for testing."""
+    dt = DataTreeDitto()
+    dt["numpy_data"] = np.random.rand(3, 4)
+    dt["xarray_data"] = xr.Dataset(
+        {
+            "temperature": (["x", "y"], np.random.rand(2, 3)),
+            "pressure": (["x", "y"], np.random.rand(2, 3)),
+        }
+    )
+    dt["nested"] = DataTreeDitto()
+    dt["nested"]["more_numpy"] = np.array([1, 2, 3, 4, 5])
+    return dt
+
+
+@pytest.fixture
+def custom_converter_setup():
+    """Setup and teardown for custom converter tests."""
+
+    # Setup: register a string converter
+    def string_to_dataset(obj, name="data", dims=None, **kwargs):
+        # Convert string to char array
+        char_array = np.array(list(obj))
+        if dims is None:
+            dims = ["char_dim"]
+        da = xr.DataArray(char_array, dims=dims, name=name)
+        ds = da.to_dataset()
+        ds.attrs.update(
+            {
+                "_ditto_original_type": "builtins.str",
+                "_ditto_var_name": name,
+                "_ditto_dims": dims,
+                "_ditto_original_string": obj,  # Store original for perfect recovery
+            }
+        )
+        return ds
+
+    def dataset_to_string(dataset, **kwargs):
+        return dataset.attrs["_ditto_original_string"]
+
+    DataTreeDitto.register_converter(str, string_to_dataset, dataset_to_string)
+
+    yield
+
+    # Teardown: remove the converter
+    if str in DataTreeDitto._converters:
+        del DataTreeDitto._converters[str]
+
+
+class TestWithFixtures:
+    """Tests using fixtures."""
+
+    def test_sample_datatree_structure(self, sample_datatree_ditto):
+        """Test the sample DataTreeDitto structure."""
+        dt = sample_datatree_ditto
+
+        assert "numpy_data" in dt.children
+        assert "xarray_data" in dt.children
+        assert "nested" in dt.children
+        assert "more_numpy" in dt["nested"].children
+
+    def test_custom_string_converter(self, custom_converter_setup):
+        """Test custom string converter."""
+        dt = DataTreeDitto()
+        test_string = "Hello, World!"
+        dt["string_data"] = test_string
+
+        assert isinstance(dt["string_data"].ds, xr.Dataset)
+        retrieved = dt.get_original("string_data")
+        assert retrieved == test_string
+        assert isinstance(retrieved, str)

--- a/tests/unit_tests/utils/types/test_datatree_ditto.py
+++ b/tests/unit_tests/utils/types/test_datatree_ditto.py
@@ -26,22 +26,15 @@ class TestDataTreeDittoCore:
     def test_initialization_with_dataset(self):
         """Test creating DataTreeDitto with xarray Dataset."""
         ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
-        dt = DataTreeDitto(data=ds)
+        dt = DataTreeDitto(dataset=ds)
         # ds property returns a view, so we check the underlying data
         assert "temp" in dt.ds.data_vars
         assert isinstance(dt, DataTreeDitto)
 
-    def test_initialization_with_dataarray(self):
-        """Test creating DataTreeDitto with xarray DataArray."""
-        da = xr.DataArray(np.random.rand(2, 3), dims=["x", "y"], name="temp")
-        dt = DataTreeDitto(data=da)
-        assert isinstance(dt.ds, xr.Dataset)
-        assert "temp" in dt.ds.data_vars
-
     def test_initialization_with_numpy_array(self):
         """Test creating DataTreeDitto with numpy array."""
         arr = np.random.rand(3, 4)
-        dt = DataTreeDitto(data=arr)
+        dt = DataTreeDitto(dataset=arr)
         assert isinstance(dt.ds, xr.Dataset)
         # Check the underlying dataset for attributes
         actual_ds = dt.ds._dataset if hasattr(dt.ds, "_dataset") else dt.ds
@@ -51,7 +44,7 @@ class TestDataTreeDittoCore:
     def test_initialization_with_unsupported_type(self):
         """Test creating DataTreeDitto with unsupported type raises error."""
         with pytest.raises(TypeError, match="No converter registered"):
-            DataTreeDitto(data="unsupported string")
+            DataTreeDitto(dataset="unsupported string")
 
 
 class TestConverterSystem:
@@ -151,17 +144,6 @@ class TestAssignmentAndRetrieval:
         assert isinstance(dt["xarray_node"], DataTreeDitto)
         assert "temp" in dt["xarray_node"].ds.data_vars
 
-    def test_setitem_datatree(self):
-        """Test assigning DataTree via setitem."""
-        dt = DataTreeDitto()
-        ds = xr.Dataset({"temp": (["x", "y"], np.random.rand(2, 3))})
-        original_dt = DataTree(dataset=ds)
-
-        dt["datatree_node"] = original_dt
-
-        assert "datatree_node" in dt.children
-        assert isinstance(dt["datatree_node"], DataTreeDitto)
-
     def test_setitem_unsupported_type(self):
         """Test assigning unsupported type raises error."""
         dt = DataTreeDitto()
@@ -202,7 +184,7 @@ class TestOriginalObjectRetrieval:
     def test_get_original_current_node(self):
         """Test getting original object from current node."""
         arr = np.random.rand(3, 4)
-        dt = DataTreeDitto(data=arr)
+        dt = DataTreeDitto(dataset=arr)
 
         original = dt.get_original(".")
         np.testing.assert_array_equal(original, arr)
@@ -336,7 +318,7 @@ class TestMetadataAndIntrospection:
     def test_list_converted_nodes_root_conversion(self):
         """Test listing when root node itself is converted."""
         arr = np.random.rand(3, 3)
-        dt = DataTreeDitto(data=arr)
+        dt = DataTreeDitto(dataset=arr)
 
         converted = dt.list_converted_nodes()
         assert "/" in converted
@@ -413,7 +395,7 @@ class TestEdgeCases:
         ds = xr.Dataset({"data": (["x", "y"], np.random.rand(2, 3))})
         ds.attrs["_ditto_original_type"] = "nonexistent.FakeType"
 
-        dt = DataTreeDitto(data=ds)
+        dt = DataTreeDitto(dataset=ds)
         original = dt.get_original(".")
 
         # Should fallback to returning the dataset

--- a/tests/unit_tests/utils/types/test_datatree_ditto_FROM_XARRAY.py
+++ b/tests/unit_tests/utils/types/test_datatree_ditto_FROM_XARRAY.py
@@ -1,0 +1,2790 @@
+import re
+import sys
+import typing
+from collections.abc import Callable, Mapping
+from copy import copy, deepcopy
+from textwrap import dedent
+
+import numpy as np
+import pytest
+
+import xarray as xr
+from xarray import DataArray, Dataset
+from xarray.core.coordinates import DataTreeCoordinates
+from xarray.core.treenode import NotFoundInTreeError
+from xarray.testing import assert_equal, assert_identical
+from xarray.tests import (
+    assert_array_equal,
+    create_test_data,
+    requires_dask,
+    source_ndarray,
+)
+
+from geoips.utils.types.datatree_ditto import DataTreeDitto as DataTree
+from geoips.utils.types.datatree_ditto import DataTreeDitto
+
+ON_WINDOWS = sys.platform == "win32"
+
+
+@pytest.fixture(scope="module")
+def create_test_datatree():
+    """
+    Create a test datatree with this structure:
+
+    <xarray.DataTree>
+    Group: /
+    │   Dimensions:  (y: 3, x: 2)
+    │   Dimensions without coordinates: y, x
+    │   Data variables:
+    │       a        (y) int64 24B 6 7 8
+    │       set0     (x) int64 16B 9 10
+    ├── Group: /set1
+    │   │   Dimensions:  ()
+    │   │   Data variables:
+    │   │       a        int64 8B 0
+    │   │       b        int64 8B 1
+    │   ├── Group: /set1/set1
+    │   └── Group: /set1/set2
+    ├── Group: /set2
+    │   │   Dimensions:  (x: 2)
+    │   │   Dimensions without coordinates: x
+    │   │   Data variables:
+    │   │       a        (x) int64 16B 2 3
+    │   │       b        (x) float64 16B 0.1 0.2
+    │   └── Group: /set2/set1
+    └── Group: /set3
+
+    The structure has deliberately repeated names of tags, variables, and
+    dimensions in order to better check for bugs caused by name conflicts.
+    """
+
+    def _create_test_datatree(modify=lambda ds: ds):
+        set1_data = modify(xr.Dataset({"a": 0, "b": 1}))
+        set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
+        root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
+
+        root = DataTreeDitto.from_dict(
+            {
+                "/": root_data,
+                "/set1": set1_data,
+                "/set1/set1": None,
+                "/set1/set2": None,
+                "/set2": set2_data,
+                "/set2/set1": None,
+                "/set3": None,
+            }
+        )
+
+        return root
+
+    return _create_test_datatree
+
+
+@pytest.fixture(scope="module")
+def simple_datatree(create_test_datatree):
+    """
+    Invoke create_test_datatree fixture (callback).
+
+    Returns a DataTree.
+    """
+    return create_test_datatree()
+
+
+class TestTreeCreation:
+    def test_empty(self) -> None:
+        dt = DataTree(name="root")
+        assert dt.name == "root"
+        assert dt.parent is None
+        assert dt.children == {}
+        assert_identical(dt.to_dataset(), xr.Dataset())
+
+    def test_name(self) -> None:
+        dt = DataTree()
+        assert dt.name is None
+
+        dt = DataTree(name="foo")
+        assert dt.name == "foo"
+
+        dt.name = "bar"
+        assert dt.name == "bar"
+
+        dt = DataTree(children={"foo": DataTree()})
+        assert dt["/foo"].name == "foo"
+        with pytest.raises(
+            ValueError, match="cannot set the name of a node which already has a parent"
+        ):
+            dt["/foo"].name = "bar"
+
+        detached = dt["/foo"].copy()
+        assert detached.name == "foo"
+        detached.name = "bar"
+        assert detached.name == "bar"
+
+    def test_bad_names(self) -> None:
+        with pytest.raises(TypeError):
+            DataTree(name=5)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError):
+            DataTree(name="folder/data")
+
+    def test_data_arg(self) -> None:
+        ds = xr.Dataset({"foo": 42})
+        tree: DataTree = DataTree(dataset=ds)
+        assert_identical(tree.to_dataset(), ds)
+
+        with pytest.raises(TypeError):
+            DataTree(dataset=xr.DataArray(42, name="foo"))  # type: ignore[arg-type]
+
+    def test_child_data_not_copied(self) -> None:
+        # regression test for https://github.com/pydata/xarray/issues/9683
+        class NoDeepCopy:
+            def __deepcopy__(self, memo):
+                raise TypeError("class can't be deepcopied")
+
+        da = xr.DataArray(NoDeepCopy())
+        ds = xr.Dataset({"var": da})
+        dt1 = xr.DataTree(ds)
+        dt2 = xr.DataTree(ds, children={"child": dt1})
+        dt3 = xr.DataTree.from_dict({"/": ds, "child": ds})
+        assert_identical(dt2, dt3)
+
+
+class TestFamilyTree:
+    def test_dont_modify_children_inplace(self) -> None:
+        # GH issue 9196
+        child = DataTree()
+        DataTree(children={"child": child})
+        assert child.parent is None
+
+    def test_create_two_children(self) -> None:
+        root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
+        set1_data = xr.Dataset({"a": 0, "b": 1})
+        root = DataTree.from_dict(
+            {"/": root_data, "/set1": set1_data, "/set1/set2": None}
+        )
+        assert root["/set1"].name == "set1"
+        assert root["/set1/set2"].name == "set2"
+
+    def test_create_full_tree(self, simple_datatree) -> None:
+        d = simple_datatree.to_dict()
+        d_keys = list(d.keys())
+
+        expected_keys = [
+            "/",
+            "/set1",
+            "/set2",
+            "/set3",
+            "/set1/set1",
+            "/set1/set2",
+            "/set2/set1",
+        ]
+
+        assert d_keys == expected_keys
+
+
+class TestNames:
+    def test_child_gets_named_on_attach(self) -> None:
+        sue = DataTree()
+        mary = DataTree(children={"Sue": sue})
+        assert mary.children["Sue"].name == "Sue"
+
+    def test_dataset_containing_slashes(self) -> None:
+        xda: xr.DataArray = xr.DataArray(
+            [[1, 2]],
+            coords={"label": ["a"], "R30m/y": [30, 60]},
+        )
+        xds: xr.Dataset = xr.Dataset({"group/subgroup/my_variable": xda})
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Given variables have names containing the '/' character: "
+                "['R30m/y', 'group/subgroup/my_variable']. "
+                "Variables stored in DataTree objects cannot have names containing '/' characters, "
+                "as this would make path-like access to variables ambiguous."
+            ),
+        ):
+            DataTree(xds)
+
+
+class TestPaths:
+    def test_path_property(self) -> None:
+        john = DataTree.from_dict(
+            {
+                "/Mary/Sue": DataTree(),
+            }
+        )
+        assert john["/Mary/Sue"].path == "/Mary/Sue"
+        assert john.path == "/"
+
+    def test_path_roundtrip(self) -> None:
+        john = DataTree.from_dict(
+            {
+                "/Mary/Sue": DataTree(),
+            }
+        )
+        assert john["/Mary/Sue"].name == "Sue"
+
+    def test_same_tree(self) -> None:
+        john = DataTree.from_dict(
+            {
+                "/Mary": DataTree(),
+                "/Kate": DataTree(),
+            }
+        )
+        mary = john.children["Mary"]
+        kate = john.children["Kate"]
+        assert mary.same_tree(kate)
+
+    def test_relative_paths(self) -> None:
+        john = DataTree.from_dict(
+            {
+                "/Mary/Sue": DataTree(),
+                "/Annie": DataTree(),
+            }
+        )
+        sue = john.children["Mary"].children["Sue"]
+        annie = john.children["Annie"]
+        assert sue.relative_to(john) == "Mary/Sue"
+        assert john.relative_to(sue) == "../.."
+        assert annie.relative_to(sue) == "../../Annie"
+        assert sue.relative_to(annie) == "../Mary/Sue"
+        assert sue.relative_to(sue) == "."
+
+        evil_kate = DataTree()
+        with pytest.raises(
+            NotFoundInTreeError, match="nodes do not lie within the same tree"
+        ):
+            sue.relative_to(evil_kate)
+
+
+class TestStoreDatasets:
+    def test_create_with_data(self) -> None:
+        dat = xr.Dataset({"a": 0})
+        john = DataTree(name="john", dataset=dat)
+
+        assert_identical(john.to_dataset(), dat)
+
+        with pytest.raises(TypeError):
+            DataTree(name="mary", dataset="junk")  # type: ignore[arg-type]
+
+    def test_set_data(self) -> None:
+        john = DataTree(name="john")
+        dat = xr.Dataset({"a": 0})
+        john.dataset = dat  # type: ignore[assignment,unused-ignore]
+
+        assert_identical(john.to_dataset(), dat)
+
+        with pytest.raises(TypeError):
+            john.dataset = "junk"  # type: ignore[assignment]
+
+    def test_has_data(self) -> None:
+        john = DataTree(name="john", dataset=xr.Dataset({"a": 0}))
+        assert john.has_data
+
+        john_no_data = DataTree(name="john", dataset=None)
+        assert not john_no_data.has_data
+
+    def test_is_hollow(self) -> None:
+        john = DataTree(dataset=xr.Dataset({"a": 0}))
+        assert john.is_hollow
+
+        eve = DataTree(children={"john": john})
+        assert eve.is_hollow
+
+        eve.dataset = xr.Dataset({"a": 1})  # type: ignore[assignment,unused-ignore]
+        assert not eve.is_hollow
+
+
+class TestToDataset:
+    def test_to_dataset_inherited(self) -> None:
+        base = xr.Dataset(coords={"a": [1], "b": 2})
+        sub = xr.Dataset(coords={"c": [3]})
+        tree = DataTree.from_dict({"/": base, "/sub": sub})
+        subtree = typing.cast(DataTree, tree["sub"])
+
+        assert_identical(tree.to_dataset(inherit=False), base)
+        assert_identical(subtree.to_dataset(inherit=False), sub)
+
+        sub_and_base = xr.Dataset(coords={"a": [1], "c": [3]})  # no "b"
+        assert_identical(tree.to_dataset(inherit=True), base)
+        assert_identical(subtree.to_dataset(inherit=True), sub_and_base)
+
+
+class TestVariablesChildrenNameCollisions:
+    def test_parent_already_has_variable_with_childs_name(self) -> None:
+        with pytest.raises(KeyError, match="already contains a variable named a"):
+            DataTree.from_dict({"/": xr.Dataset({"a": [0], "b": 1}), "/a": None})
+
+    def test_parent_already_has_variable_with_childs_name_update(self) -> None:
+        dt = DataTree(dataset=xr.Dataset({"a": [0], "b": 1}))
+        with pytest.raises(ValueError, match="already contains a variable named a"):
+            dt.update({"a": DataTree()})
+
+    def test_assign_when_already_child_with_variables_name(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/a": DataTree(),
+            }
+        )
+
+        with pytest.raises(ValueError, match="node already contains a variable"):
+            dt.dataset = xr.Dataset({"a": 0})  # type: ignore[assignment,unused-ignore]
+
+        dt.dataset = xr.Dataset()  # type: ignore[assignment,unused-ignore]
+
+        new_ds = dt.to_dataset().assign(a=xr.DataArray(0))
+        with pytest.raises(ValueError, match="node already contains a variable"):
+            dt.dataset = new_ds  # type: ignore[assignment,unused-ignore]
+
+
+class TestGet: ...
+
+
+class TestGetItem:
+    def test_getitem_node(self) -> None:
+        folder1 = DataTree.from_dict(
+            {
+                "/results/highres": DataTree(),
+            }
+        )
+
+        assert folder1["results"].name == "results"
+        assert folder1["results/highres"].name == "highres"
+
+    def test_getitem_self(self) -> None:
+        dt = DataTree()
+        assert dt["."] is dt
+
+    def test_getitem_single_data_variable(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        results = DataTree(name="results", dataset=data)
+        assert_identical(results["temp"], data["temp"])
+
+    def test_getitem_single_data_variable_from_node(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        folder1 = DataTree.from_dict(
+            {
+                "/results/highres": data,
+            }
+        )
+        assert_identical(folder1["results/highres/temp"], data["temp"])
+
+    def test_getitem_nonexistent_node(self) -> None:
+        folder1 = DataTree.from_dict({"/results": DataTree()}, name="folder1")
+        with pytest.raises(KeyError):
+            folder1["results/highres"]
+
+    def test_getitem_nonexistent_variable(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        results = DataTree(name="results", dataset=data)
+        with pytest.raises(KeyError):
+            results["pressure"]
+
+    @pytest.mark.xfail(reason="Should be deprecated in favour of .subset")
+    def test_getitem_multiple_data_variables(self) -> None:
+        data = xr.Dataset({"temp": [0, 50], "p": [5, 8, 7]})
+        results = DataTree(name="results", dataset=data)
+        assert_identical(results[["temp", "p"]], data[["temp", "p"]])  # type: ignore[index]
+
+    @pytest.mark.xfail(
+        reason="Indexing needs to return whole tree (GH https://github.com/xarray-contrib/datatree/issues/77)"
+    )
+    def test_getitem_dict_like_selection_access_to_dataset(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        results = DataTree(name="results", dataset=data)
+        assert_identical(results[{"temp": 1}], data[{"temp": 1}])  # type: ignore[index]
+
+
+class TestUpdate:
+    def test_update(self) -> None:
+        dt = DataTree()
+        dt.update({"foo": xr.DataArray(0), "a": DataTree()})
+        expected = DataTree.from_dict({"/": xr.Dataset({"foo": 0}), "a": None})
+        assert_equal(dt, expected)
+        assert dt.groups == ("/", "/a")
+
+    def test_update_new_named_dataarray(self) -> None:
+        da = xr.DataArray(name="temp", data=[0, 50])
+        folder1 = DataTree(name="folder1")
+        folder1.update({"results": da})
+        expected = da.rename("results")
+        assert_equal(folder1["results"], expected)
+
+    def test_update_doesnt_alter_child_name(self) -> None:
+        dt = DataTree()
+        dt.update({"foo": xr.DataArray(0), "a": DataTree(name="b")})
+        assert "a" in dt.children
+        child = dt["a"]
+        assert child.name == "a"
+
+    def test_update_overwrite(self) -> None:
+        actual = DataTree.from_dict({"a": DataTree(xr.Dataset({"x": 1}))})
+        actual.update({"a": DataTree(xr.Dataset({"x": 2}))})
+        expected = DataTree.from_dict({"a": DataTree(xr.Dataset({"x": 2}))})
+        assert_equal(actual, expected)
+
+    def test_update_coordinates(self) -> None:
+        expected = DataTree.from_dict({"/": xr.Dataset(coords={"a": 1})})
+        actual = DataTree.from_dict({"/": xr.Dataset()})
+        actual.update(xr.Dataset(coords={"a": 1}))
+        assert_equal(actual, expected)
+
+    def test_update_inherited_coords(self) -> None:
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"a": 1}),
+                "/b": xr.Dataset(coords={"c": 1}),
+            }
+        )
+        actual = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"a": 1}),
+                "/b": xr.Dataset(),
+            }
+        )
+        actual["/b"].update(xr.Dataset(coords={"c": 1}))
+        assert_identical(actual, expected)
+
+        # DataTree.identical() currently does not require that non-inherited
+        # coordinates are defined identically, so we need to check this
+        # explicitly
+        actual_node = actual.children["b"].to_dataset(inherit=False)
+        expected_node = expected.children["b"].to_dataset(inherit=False)
+        assert_identical(actual_node, expected_node)
+
+
+class TestCopy:
+    def test_copy(self, create_test_datatree) -> None:
+        dt = create_test_datatree()
+
+        for node in dt.root.subtree:
+            node.attrs["Test"] = [1, 2, 3]
+
+        for copied in [dt.copy(deep=False), copy(dt)]:
+            assert_identical(dt, copied)
+
+            for node, copied_node in zip(
+                dt.root.subtree, copied.root.subtree, strict=True
+            ):
+                assert node.encoding == copied_node.encoding
+                # Note: IndexVariable objects with string dtype are always
+                # copied because of xarray.core.util.safe_cast_to_index.
+                # Limiting the test to data variables.
+                for k in node.data_vars:
+                    v0 = node.variables[k]
+                    v1 = copied_node.variables[k]
+                    assert source_ndarray(v0.data) is source_ndarray(v1.data)
+                copied_node["foo"] = xr.DataArray(data=np.arange(5), dims="z")
+                assert "foo" not in node
+
+                copied_node.attrs["foo"] = "bar"
+                assert "foo" not in node.attrs
+                assert node.attrs["Test"] is copied_node.attrs["Test"]
+
+    def test_copy_subtree(self) -> None:
+        dt = DataTree.from_dict({"/level1/level2/level3": xr.Dataset()})
+
+        actual = dt["/level1/level2"].copy()
+        expected = DataTree.from_dict({"/level3": xr.Dataset()}, name="level2")
+
+        assert_identical(actual, expected)
+
+    def test_copy_coord_inheritance(self) -> None:
+        tree = DataTree.from_dict(
+            {"/": xr.Dataset(coords={"x": [0, 1]}), "/c": DataTree()}
+        )
+        actual = tree.copy()
+        node_ds = actual.children["c"].to_dataset(inherit=False)
+        assert_identical(node_ds, xr.Dataset())
+
+        actual = tree.children["c"].copy()
+        expected = DataTree(Dataset(coords={"x": [0, 1]}), name="c")
+        assert_identical(expected, actual)
+
+        actual = tree.children["c"].copy(inherit=False)
+        expected = DataTree(name="c")
+        assert_identical(expected, actual)
+
+    def test_deepcopy(self, create_test_datatree) -> None:
+        dt = create_test_datatree()
+
+        for node in dt.root.subtree:
+            node.attrs["Test"] = [1, 2, 3]
+
+        for copied in [dt.copy(deep=True), deepcopy(dt)]:
+            assert_identical(dt, copied)
+
+            for node, copied_node in zip(
+                dt.root.subtree, copied.root.subtree, strict=True
+            ):
+                assert node.encoding == copied_node.encoding
+                # Note: IndexVariable objects with string dtype are always
+                # copied because of xarray.core.util.safe_cast_to_index.
+                # Limiting the test to data variables.
+                for k in node.data_vars:
+                    v0 = node.variables[k]
+                    v1 = copied_node.variables[k]
+                    assert source_ndarray(v0.data) is not source_ndarray(v1.data)
+                copied_node["foo"] = xr.DataArray(data=np.arange(5), dims="z")
+                assert "foo" not in node
+
+                copied_node.attrs["foo"] = "bar"
+                assert "foo" not in node.attrs
+                assert node.attrs["Test"] is not copied_node.attrs["Test"]
+
+    @pytest.mark.xfail(reason="data argument not yet implemented")
+    def test_copy_with_data(self, create_test_datatree) -> None:
+        orig = create_test_datatree()
+        # TODO use .data_vars once that property is available
+        data_vars = {
+            k: v for k, v in orig.variables.items() if k not in orig._coord_names
+        }
+        new_data = {k: np.random.randn(*v.shape) for k, v in data_vars.items()}
+        actual = orig.copy(data=new_data)
+
+        expected = orig.copy()
+        for k, v in new_data.items():
+            expected[k].data = v
+        assert_identical(expected, actual)
+
+        # TODO test parents and children?
+
+
+class TestSetItem:
+    def test_setitem_new_child_node(self) -> None:
+        john = DataTree(name="john")
+        mary = DataTree(name="mary")
+        john["mary"] = mary
+
+        grafted_mary = john["mary"]
+        assert grafted_mary.parent is john
+        assert grafted_mary.name == "mary"
+
+    def test_setitem_unnamed_child_node_becomes_named(self) -> None:
+        john2 = DataTree(name="john2")
+        john2["sonny"] = DataTree()
+        assert john2["sonny"].name == "sonny"
+
+    def test_setitem_new_grandchild_node(self) -> None:
+        john = DataTree.from_dict({"/Mary/Rose": DataTree()})
+        new_rose = DataTree(dataset=xr.Dataset({"x": 0}))
+        john["Mary/Rose"] = new_rose
+
+        grafted_rose = john["Mary/Rose"]
+        assert grafted_rose.parent is john["/Mary"]
+        assert grafted_rose.name == "Rose"
+
+    def test_grafted_subtree_retains_name(self) -> None:
+        subtree = DataTree(name="original_subtree_name")
+        root = DataTree(name="root")
+        root["new_subtree_name"] = subtree
+        assert subtree.name == "original_subtree_name"
+
+    def test_setitem_new_empty_node(self) -> None:
+        john = DataTree(name="john")
+        john["mary"] = DataTree()
+        mary = john["mary"]
+        assert isinstance(mary, DataTree)
+        assert_identical(mary.to_dataset(), xr.Dataset())
+
+    def test_setitem_overwrite_data_in_node_with_none(self) -> None:
+        john = DataTree.from_dict({"/mary": xr.Dataset()}, name="john")
+
+        john["mary"] = DataTree()
+        assert_identical(john["mary"].to_dataset(), xr.Dataset())
+
+        john.dataset = xr.Dataset()  # type: ignore[assignment,unused-ignore]
+        with pytest.raises(ValueError, match="has no name"):
+            john["."] = DataTree()
+
+    @pytest.mark.xfail(reason="assigning Datasets doesn't yet create new nodes")
+    def test_setitem_dataset_on_this_node(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        results = DataTree(name="results")
+        results["."] = data
+        assert_identical(results.to_dataset(), data)
+
+    def test_setitem_dataset_as_new_node(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        folder1 = DataTree(name="folder1")
+        folder1["results"] = data
+        assert_identical(folder1["results"].to_dataset(), data)
+
+    def test_setitem_dataset_as_new_node_requiring_intermediate_nodes(self) -> None:
+        data = xr.Dataset({"temp": [0, 50]})
+        folder1 = DataTree(name="folder1")
+        folder1["results/highres"] = data
+        assert_identical(folder1["results/highres"].to_dataset(), data)
+
+    def test_setitem_named_dataarray(self) -> None:
+        da = xr.DataArray(name="temp", data=[0, 50])
+        folder1 = DataTree(name="folder1")
+        folder1["results"] = da
+        expected = da.rename("results")
+        assert_equal(folder1["results"], expected)
+
+    def test_setitem_unnamed_dataarray(self) -> None:
+        data = xr.DataArray([0, 50])
+        folder1 = DataTree(name="folder1")
+        folder1["results"] = data
+        assert_equal(folder1["results"], data)
+
+    def test_setitem_variable(self) -> None:
+        var = xr.Variable(data=[0, 50], dims="x")
+        folder1 = DataTree(name="folder1")
+        folder1["results"] = var
+        assert_equal(folder1["results"], xr.DataArray(var))
+
+    @pytest.mark.xfail(reason="This also fails for xarray package.")
+    def test_setitem_coerce_to_dataarray(self) -> None:
+        folder1 = DataTree(name="folder1")
+        folder1["results"] = 0
+        assert_equal(folder1["results"], xr.DataArray(0))
+
+    @pytest.mark.xfail(reason="This also fails for xarray package.")
+    def test_setitem_add_new_variable_to_empty_node(self) -> None:
+        results = DataTree(name="results")
+        results["pressure"] = xr.DataArray(data=[2, 3])
+        assert "pressure" in results.dataset
+        results["temp"] = xr.Variable(data=[10, 11], dims=["x"])
+        assert "temp" in results.dataset
+
+        # What if there is a path to traverse first?
+        results_with_path = DataTree(name="results")
+        results_with_path["highres/pressure"] = xr.DataArray(data=[2, 3])
+        assert "pressure" in results_with_path["highres"].dataset
+        results_with_path["highres/temp"] = xr.Variable(data=[10, 11], dims=["x"])
+        assert "temp" in results_with_path["highres"].dataset
+
+    def test_setitem_dataarray_replace_existing_node(self) -> None:
+        t = xr.Dataset({"temp": [0, 50]})
+        results = DataTree(name="results", dataset=t)
+        p = xr.DataArray(data=[2, 3])
+        results["pressure"] = p
+        expected = t.assign(pressure=p)
+        assert_identical(results.to_dataset(), expected)
+
+
+class TestCoords:
+    def test_properties(self) -> None:
+        # use int64 for repr consistency on windows
+        ds = Dataset(
+            data_vars={
+                "foo": (["x", "y"], np.random.randn(2, 3)),
+            },
+            coords={
+                "x": ("x", np.array([-1, -2], "int64")),
+                "y": ("y", np.array([0, 1, 2], "int64")),
+                "a": ("x", np.array([4, 5], "int64")),
+                "b": np.int64(-10),
+            },
+        )
+        dt = DataTree(dataset=ds)
+        dt["child"] = DataTree()
+
+        coords = dt.coords
+        assert isinstance(coords, DataTreeCoordinates)
+
+        # len
+        assert len(coords) == 4
+
+        # iter
+        assert list(coords) == ["x", "y", "a", "b"]
+
+        assert_identical(coords["x"].variable, dt["x"].variable)
+        assert_identical(coords["y"].variable, dt["y"].variable)
+
+        assert "x" in coords
+        assert "a" in coords
+        assert 0 not in coords
+        assert "foo" not in coords
+        assert "child" not in coords
+
+        with pytest.raises(KeyError):
+            coords["foo"]
+
+        # TODO this currently raises a ValueError instead of a KeyError
+        # with pytest.raises(KeyError):
+        #     coords[0]
+
+        # repr
+        expected = dedent(
+            """\
+        Coordinates:
+          * x        (x) int64 16B -1 -2
+          * y        (y) int64 24B 0 1 2
+            a        (x) int64 16B 4 5
+            b        int64 8B -10"""
+        )
+        actual = repr(coords)
+        assert expected == actual
+
+        # dims
+        assert coords.sizes == {"x": 2, "y": 3}
+
+        # dtypes
+        assert coords.dtypes == {
+            "x": np.dtype("int64"),
+            "y": np.dtype("int64"),
+            "a": np.dtype("int64"),
+            "b": np.dtype("int64"),
+        }
+
+    def test_modify(self) -> None:
+        ds = Dataset(
+            data_vars={
+                "foo": (["x", "y"], np.random.randn(2, 3)),
+            },
+            coords={
+                "x": ("x", np.array([-1, -2], "int64")),
+                "y": ("y", np.array([0, 1, 2], "int64")),
+                "a": ("x", np.array([4, 5], "int64")),
+                "b": np.int64(-10),
+            },
+        )
+        dt = DataTree(dataset=ds)
+        dt["child"] = DataTree()
+
+        actual = dt.copy(deep=True)
+        actual.coords["x"] = ("x", ["a", "b"])
+        assert_array_equal(actual["x"], ["a", "b"])
+
+        actual = dt.copy(deep=True)
+        actual.coords["z"] = ("z", ["a", "b"])
+        assert_array_equal(actual["z"], ["a", "b"])
+
+        actual = dt.copy(deep=True)
+        with pytest.raises(ValueError, match=r"conflicting dimension sizes"):
+            actual.coords["x"] = ("x", [-1])
+        assert_identical(actual, dt)  # should not be modified
+
+        # TODO: re-enable after implementing reset_coords()
+        # actual = dt.copy()
+        # del actual.coords["b"]
+        # expected = dt.reset_coords("b", drop=True)
+        # assert_identical(expected, actual)
+
+        with pytest.raises(KeyError):
+            del dt.coords["not_found"]
+
+        with pytest.raises(KeyError):
+            del dt.coords["foo"]
+
+        # TODO: re-enable after implementing assign_coords()
+        # actual = dt.copy(deep=True)
+        # actual.coords.update({"c": 11})
+        # expected = dt.assign_coords({"c": 11})
+        # assert_identical(expected, actual)
+
+        # # regression test for GH3746
+        # del actual.coords["x"]
+        # assert "x" not in actual.xindexes
+
+        # test that constructors can also handle the `DataTreeCoordinates` object
+        ds2 = Dataset(coords=dt.coords)
+        assert_identical(ds2.coords, dt.coords)
+        da = DataArray(coords=dt.coords)
+        assert_identical(da.coords, dt.coords)
+
+        # DataTree constructor doesn't accept coords= but should still be able to handle DatasetCoordinates
+        dt2 = DataTree(dataset=dt.coords)
+        assert_identical(dt2.coords, dt.coords)
+
+    def test_inherited(self) -> None:
+        ds = Dataset(
+            data_vars={
+                "foo": (["x", "y"], np.random.randn(2, 3)),
+            },
+            coords={
+                "x": ("x", np.array([-1, -2], "int64")),
+                "y": ("y", np.array([0, 1, 2], "int64")),
+                "a": ("x", np.array([4, 5], "int64")),
+                "b": np.int64(-10),
+            },
+        )
+        dt = DataTree(dataset=ds)
+        dt["child"] = DataTree()
+        child = dt["child"]
+
+        assert set(dt.coords) == {"x", "y", "a", "b"}
+        assert set(child.coords) == {"x", "y"}
+
+        actual = child.copy(deep=True)
+        actual.coords["x"] = ("x", ["a", "b"])
+        assert_array_equal(actual["x"], ["a", "b"])
+
+        actual = child.copy(deep=True)
+        actual.coords.update({"c": 11})
+        expected = child.copy(deep=True)
+        expected.coords["c"] = 11
+        # check we have only altered the child node
+        assert_identical(expected.root, actual.root)
+
+        with pytest.raises(KeyError):
+            # cannot delete inherited coordinate from child node
+            del child["x"]
+
+        # TODO requires a fix for #9472
+        # actual = child.copy(deep=True)
+        # actual.coords.update({"c": 11})
+        # expected = child.assign_coords({"c": 11})
+        # assert_identical(expected, actual)
+
+
+def test_delitem() -> None:
+    ds = Dataset({"a": 0}, coords={"x": ("x", [1, 2]), "z": "a"})
+    dt = DataTree(ds, children={"c": DataTree()})
+
+    with pytest.raises(KeyError):
+        del dt["foo"]
+
+    # test delete children
+    del dt["c"]
+    assert dt.children == {}
+    assert set(dt.variables) == {"x", "z", "a"}
+    with pytest.raises(KeyError):
+        del dt["c"]
+
+    # test delete variables
+    del dt["a"]
+    assert set(dt.coords) == {"x", "z"}
+    with pytest.raises(KeyError):
+        del dt["a"]
+
+    # test delete coordinates
+    del dt["z"]
+    assert set(dt.coords) == {"x"}
+    with pytest.raises(KeyError):
+        del dt["z"]
+
+    # test delete indexed coordinates
+    del dt["x"]
+    assert dt.variables == {}
+    assert dt.coords == {}
+    assert dt.indexes == {}
+    with pytest.raises(KeyError):
+        del dt["x"]
+
+
+class TestTreeFromDict:
+    def test_data_in_root(self) -> None:
+        dat = xr.Dataset()
+        dt = DataTree.from_dict({"/": dat})
+        assert dt.name is None
+        assert dt.parent is None
+        assert dt.children == {}
+        assert_identical(dt.to_dataset(), dat)
+
+    def test_one_layer(self) -> None:
+        dat1, dat2 = xr.Dataset({"a": 1}), xr.Dataset({"b": 2})
+        dt = DataTree.from_dict({"run1": dat1, "run2": dat2})
+        assert_identical(dt.to_dataset(), xr.Dataset())
+        assert dt.name is None
+        assert_identical(dt["run1"].to_dataset(), dat1)
+        assert dt["run1"].children == {}
+        assert_identical(dt["run2"].to_dataset(), dat2)
+        assert dt["run2"].children == {}
+
+    def test_two_layers(self) -> None:
+        dat1, dat2 = xr.Dataset({"a": 1}), xr.Dataset({"a": [1, 2]})
+        dt = DataTree.from_dict({"highres/run": dat1, "lowres/run": dat2})
+        assert "highres" in dt.children
+        assert "lowres" in dt.children
+        highres_run = dt["highres/run"]
+        assert_identical(highres_run.to_dataset(), dat1)
+
+    def test_nones(self) -> None:
+        dt = DataTree.from_dict({"d": None, "d/e": None})
+        assert [node.name for node in dt.subtree] == [None, "d", "e"]
+        assert [node.path for node in dt.subtree] == ["/", "/d", "/d/e"]
+        assert_identical(dt["d/e"].to_dataset(), xr.Dataset())
+
+    def test_full(self, simple_datatree) -> None:
+        dt = simple_datatree
+        paths = [node.path for node in dt.subtree]
+        assert paths == [
+            "/",
+            "/set1",
+            "/set2",
+            "/set3",
+            "/set1/set1",
+            "/set1/set2",
+            "/set2/set1",
+        ]
+
+    def test_datatree_values(self) -> None:
+        dat1 = DataTree(dataset=xr.Dataset({"a": 1}))
+        expected = DataTree()
+        expected["a"] = dat1
+
+        actual = DataTree.from_dict({"a": dat1})
+
+        assert_identical(actual, expected)
+
+    def test_roundtrip_to_dict(self, simple_datatree) -> None:
+        tree = simple_datatree
+        roundtrip = DataTree.from_dict(tree.to_dict())
+        assert_identical(tree, roundtrip)
+
+    def test_to_dict(self):
+        tree = DataTree.from_dict({"/a/b/c": None})
+        roundtrip = DataTree.from_dict(tree.to_dict())
+        assert_identical(tree, roundtrip)
+
+        roundtrip = DataTree.from_dict(tree.to_dict(relative=True))
+        assert_identical(tree, roundtrip)
+
+        roundtrip = DataTree.from_dict(tree.children["a"].to_dict(relative=False))
+        assert_identical(tree, roundtrip)
+
+        expected = DataTree.from_dict({"b/c": None})
+        actual = DataTree.from_dict(tree.children["a"].to_dict(relative=True))
+        assert_identical(expected, actual)
+
+    def test_roundtrip_unnamed_root(self, simple_datatree) -> None:
+        # See GH81
+
+        dt = simple_datatree
+        dt.name = "root"
+        roundtrip = DataTree.from_dict(dt.to_dict())
+        assert roundtrip.equals(dt)
+
+    def test_insertion_order(self) -> None:
+        # regression test for GH issue #9276
+        reversed = DataTree.from_dict(
+            {
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/": xr.Dataset({"age": 83}),
+            }
+        )
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"age": 83}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+            }
+        )
+        assert reversed.equals(expected)
+
+        # Check that Bart and Lisa's order is still preserved within the group,
+        # despite 'Bart' coming before 'Lisa' when sorted alphabetically
+        assert list(reversed["Homer"].children.keys()) == ["Lisa", "Bart"]
+
+    @pytest.mark.xfail(reason="This also fails for xarray package.")
+    def test_array_values_dataarray(self) -> None:
+        expected = DataTree(dataset=Dataset({"a": 1}))
+        actual = DataTree.from_dict({"a": DataArray(1)})
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package.")
+    def test_array_values_scalars(self) -> None:
+        expected = DataTree(
+            dataset=Dataset({"a": 1}),
+            children={"b": DataTree(Dataset({"c": 2, "d": 3}))},
+        )
+        actual = DataTree.from_dict({"a": 1, "b/c": 2, "b/d": 3})
+        assert_identical(actual, expected)
+
+    def test_invalid_values(self) -> None:
+        with pytest.raises(
+            TypeError,
+            # match=re.escape(
+            #    r"failed to construct xarray.Dataset for DataTree node at '/' "
+            #    r"with data_vars={'a': set()} and coords={}"
+            # ),
+        ):
+            DataTree.from_dict({"a": set()})
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_array_values_nested_key(self) -> None:
+        expected = DataTree(
+            children={"a": DataTree(children={"b": DataTree(Dataset({"c": 1}))})}
+        )
+        actual = DataTree.from_dict(data={"a/b/c": 1})
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_nested_array_values(self) -> None:
+        expected = DataTree(
+            children={"a": DataTree(children={"b": DataTree(Dataset({"c": 1}))})}
+        )
+        actual = DataTree.from_dict({"a": {"b": {"c": 1}}}, nested=True)
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_nested_array_values_without_nested_kwarg(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                r"data contains a dict value at key='a', which is not a valid "
+                r"argument to DataTree.from_dict() with nested=False: "
+                r"{'b': {'c': 1}}"
+            ),
+        ):
+            DataTree.from_dict({"a": {"b": {"c": 1}}})
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_nested_array_values_duplicates(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("multiple entries found corresponding to node '/a/b'"),
+        ):
+            DataTree.from_dict({"a": {"b": 1}, "a/b": 2}, nested=True)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_array_values_data_and_coords(self) -> None:
+        expected = DataTree(dataset=Dataset({"a": 1}, coords={"b": 2}))
+        actual = DataTree.from_dict(data={"a": 1}, coords={"b": 2})
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_data_and_coords_conflicting(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("multiple entries found corresponding to node '/a'"),
+        ):
+            DataTree.from_dict(data={"a": 1}, coords={"a": 2})
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_array_values_new_name(self) -> None:
+        expected = DataTree(dataset=Dataset({"foo": 1}))
+        data = {"foo": xr.DataArray(1, name="bar")}
+        actual = DataTree.from_dict(data)
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_array_values_at_root(self) -> None:
+        with pytest.raises(ValueError, match="cannot set DataArray value at root"):
+            DataTree.from_dict({"/": 1})
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_array_values_parent_node_also_set(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                r"cannot set DataArray value at '/a' when parent node at '/' is also set"
+            ),
+        ):
+            DataTree.from_dict({"/": Dataset(), "/a": 1})
+
+    def test_relative_paths(self) -> None:
+        tree = DataTree.from_dict({".": None, "foo": None, "./bar": None, "x/y": None})
+        paths = [node.path for node in tree.subtree]
+        assert paths == [
+            "/",
+            "/foo",
+            "/bar",
+            "/x",
+            "/x/y",
+        ]
+
+    def test_root_keys(self):
+        ds = Dataset({"x": 1})
+        expected = DataTree(dataset=ds)
+
+        actual = DataTree.from_dict({"": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({".": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({"/": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({"./": ds})
+        assert_identical(actual, expected)
+
+    @pytest.mark.xfail(reason="This also fails for xarray package")
+    def test_multiple_entries(self):
+        with pytest.raises(
+            ValueError, match="multiple entries found corresponding to node '/'"
+        ):
+            DataTree.from_dict({"": None, ".": None})
+
+        with pytest.raises(
+            ValueError, match="multiple entries found corresponding to node '/a'"
+        ):
+            DataTree.from_dict({"a": None, "/a": None})
+
+    def test_name(self):
+        tree = DataTree.from_dict({"/": None}, name="foo")
+        assert tree.name == "foo"
+
+        tree = DataTree.from_dict({"/": DataTree()}, name="foo")
+        assert tree.name == "foo"
+
+        tree = DataTree.from_dict({"/": DataTree(name="bar")}, name="foo")
+        assert tree.name == "foo"
+
+
+class TestDatasetView:
+    def test_view_contents(self) -> None:
+        ds = create_test_data()
+        dt = DataTree(dataset=ds)
+        assert ds.identical(
+            dt.dataset
+        )  # this only works because Dataset.identical doesn't check types
+        assert isinstance(dt.dataset, xr.Dataset)
+
+    def test_immutability(self) -> None:
+        # See issue https://github.com/xarray-contrib/datatree/issues/38
+        dt = DataTree.from_dict(
+            {
+                "/": None,
+                "/a": None,
+            },
+            name="root",
+        )
+
+        with pytest.raises(
+            AttributeError, match="Mutation of the DatasetView is not allowed"
+        ):
+            dt.dataset["a"] = xr.DataArray(0)
+
+        with pytest.raises(
+            AttributeError, match="Mutation of the DatasetView is not allowed"
+        ):
+            dt.dataset.update({"a": 0})
+
+        # TODO are there any other ways you can normally modify state (in-place)?
+        # (not attribute-like assignment because that doesn't work on Dataset anyway)
+
+    def test_methods(self) -> None:
+        ds = create_test_data()
+        dt = DataTree(dataset=ds)
+        assert ds.mean().identical(dt.dataset.mean())
+        assert isinstance(dt.dataset.mean(), xr.Dataset)
+
+    def test_arithmetic(self, create_test_datatree) -> None:
+        dt = create_test_datatree()
+        expected = create_test_datatree(modify=lambda ds: 10.0 * ds)[
+            "set1"
+        ].to_dataset()
+        result = 10.0 * dt["set1"].dataset
+        assert result.identical(expected)
+
+    def test_init_via_type(self) -> None:
+        # from datatree GH issue https://github.com/xarray-contrib/datatree/issues/188
+        # xarray's .weighted is unusual because it uses type() to create a Dataset/DataArray
+
+        a = xr.DataArray(
+            np.random.rand(3, 4, 10),
+            dims=["x", "y", "time"],
+            coords={"area": (["x", "y"], np.random.rand(3, 4))},
+        ).to_dataset(name="data")
+        dt = DataTree(dataset=a)
+
+        def weighted_mean(ds):
+            return ds.weighted(ds.area).mean(["x", "y"])
+
+        weighted_mean(dt.dataset)
+
+    def test_map_keep_attrs(self) -> None:
+        # test DatasetView.map(..., keep_attrs=...)
+        data = xr.DataArray([1, 2, 3], dims="x", attrs={"da": "attrs"})
+        ds = xr.Dataset({"data": data}, attrs={"ds": "attrs"})
+        dt = DataTree(ds)
+
+        def func_keep(ds):
+            # x.mean() removes the attrs of the data_vars
+            return ds.map(lambda x: x.mean(), keep_attrs=True)
+
+        result = xr.map_over_datasets(func_keep, dt)
+        expected = dt.mean(keep_attrs=True)
+        xr.testing.assert_identical(result, expected.to_datatree())
+
+        # per default DatasetView.map does not keep attrs
+        def func(ds):
+            # x.mean() removes the attrs of the data_vars
+            return ds.map(lambda x: x.mean())
+
+        result = xr.map_over_datasets(func, dt)
+        expected = dt.mean()
+        xr.testing.assert_identical(result, expected.mean().to_datatree())
+
+
+class TestAccess:
+    def test_attribute_access(self, create_test_datatree) -> None:
+        dt = create_test_datatree()
+
+        # vars / coords
+        for key in ["a", "set0"]:
+            assert_equal(dt[key], getattr(dt, key))
+            assert key in dir(dt)
+
+        # dims
+        assert_equal(dt["a"]["y"], dt.a.y)
+        assert "y" in dir(dt["a"])
+
+        # children
+        for key in ["set1", "set2", "set3"]:
+            assert_equal(dt[key], getattr(dt, key))
+            assert key in dir(dt)
+
+        # attrs
+        dt.attrs["meta"] = "NASA"
+        assert dt.attrs["meta"] == "NASA"
+        assert "meta" in dir(dt)
+
+    def test_ipython_key_completions_complex(self, create_test_datatree) -> None:
+        dt = create_test_datatree()
+        key_completions = dt._ipython_key_completions_()
+
+        node_keys = [node.path[1:] for node in dt.descendants]
+        assert all(node_key in key_completions for node_key in node_keys)
+
+        var_keys = list(dt.variables.keys())
+        assert all(var_key in key_completions for var_key in var_keys)
+
+    def test_ipython_key_completitions_subnode(self) -> None:
+        tree = xr.DataTree.from_dict({"/": None, "/a": None, "/a/b/": None})
+        expected = ["b"]
+        actual = tree["a"]._ipython_key_completions_()
+        assert expected == actual
+
+    def test_operation_with_attrs_but_no_data(self) -> None:
+        # tests bug from xarray-datatree GH262
+        xs = xr.Dataset({"testvar": xr.DataArray(np.ones((2, 3)))})
+        dt = DataTree.from_dict({"node1": xs, "node2": xs})
+        dt.attrs["test_key"] = 1  # sel works fine without this line
+        dt.sel(dim_0=0)
+
+
+class TestRepr:
+    def test_repr_four_nodes(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset(
+                    {"e": (("x",), [1.0, 2.0])},
+                    coords={"x": [2.0, 3.0]},
+                ),
+                "/b": xr.Dataset({"f": (("y",), [3.0])}),
+                "/b/c": xr.Dataset(),
+                "/b/d": xr.Dataset({"g": 4.0}),
+            }
+        )
+
+        result = repr(dt)
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            │   Dimensions:  (x: 2)
+            │   Coordinates:
+            │     * x        (x) float64 16B 2.0 3.0
+            │   Data variables:
+            │       e        (x) float64 16B 1.0 2.0
+            └── Group: /b
+                │   Dimensions:  (y: 1)
+                │   Dimensions without coordinates: y
+                │   Data variables:
+                │       f        (y) float64 8B 3.0
+                ├── Group: /b/c
+                └── Group: /b/d
+                        Dimensions:  ()
+                        Data variables:
+                            g        float64 8B 4.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(dt.b)
+        expected = dedent(
+            """
+            <xarray.DataTree 'b'>
+            Group: /b
+            │   Dimensions:  (x: 2, y: 1)
+            │   Inherited coordinates:
+            │     * x        (x) float64 16B 2.0 3.0
+            │   Dimensions without coordinates: y
+            │   Data variables:
+            │       f        (y) float64 8B 3.0
+            ├── Group: /b/c
+            └── Group: /b/d
+                    Dimensions:  ()
+                    Data variables:
+                        g        float64 8B 4.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(dt.b.d)
+        expected = dedent(
+            """
+            <xarray.DataTree 'd'>
+            Group: /b/d
+                Dimensions:  (x: 2, y: 1)
+                Inherited coordinates:
+                  * x        (x) float64 16B 2.0 3.0
+                Dimensions without coordinates: y
+                Data variables:
+                    g        float64 8B 4.0
+            """
+        ).strip()
+        assert result == expected
+
+    def test_repr_two_children(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/": Dataset(coords={"x": [1.0]}),
+                "/first_child": None,
+                "/second_child": Dataset({"foo": ("x", [0.0])}, coords={"z": 1.0}),
+            }
+        )
+
+        result = repr(tree)
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            │   Dimensions:  (x: 1)
+            │   Coordinates:
+            │     * x        (x) float64 8B 1.0
+            ├── Group: /first_child
+            └── Group: /second_child
+                    Dimensions:  (x: 1)
+                    Coordinates:
+                        z        float64 8B 1.0
+                    Data variables:
+                        foo      (x) float64 8B 0.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(tree["first_child"])
+        expected = dedent(
+            """
+            <xarray.DataTree 'first_child'>
+            Group: /first_child
+                Dimensions:  (x: 1)
+                Inherited coordinates:
+                  * x        (x) float64 8B 1.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(tree["second_child"])
+        expected = dedent(
+            """
+            <xarray.DataTree 'second_child'>
+            Group: /second_child
+                Dimensions:  (x: 1)
+                Coordinates:
+                    z        float64 8B 1.0
+                Inherited coordinates:
+                  * x        (x) float64 8B 1.0
+                Data variables:
+                    foo      (x) float64 8B 0.0
+            """
+        ).strip()
+        assert result == expected
+
+    def test_repr_truncates_nodes(self) -> None:
+        # construct a datatree with 50 nodes
+        number_of_files = 10
+        number_of_groups = 5
+        tree_dict = {}
+        for f in range(number_of_files):
+            for g in range(number_of_groups):
+                tree_dict[f"file_{f}/group_{g}"] = Dataset({"g": f * g})
+
+        tree = DataTree.from_dict(tree_dict)
+        with xr.set_options(display_max_children=3):
+            result = repr(tree)
+
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            ├── Group: /file_0
+            │   ├── Group: /file_0/group_0
+            │   │       Dimensions:  ()
+            │   │       Data variables:
+            │   │           g        int64 8B 0
+            │   ├── Group: /file_0/group_1
+            │   │       Dimensions:  ()
+            │   │       Data variables:
+            │   │           g        int64 8B 0
+            │   ...
+            │   └── Group: /file_0/group_4
+            │           Dimensions:  ()
+            │           Data variables:
+            │               g        int64 8B 0
+            ├── Group: /file_1
+            │   ├── Group: /file_1/group_0
+            │   │       Dimensions:  ()
+            │   │       Data variables:
+            │   │           g        int64 8B 0
+            │   ├── Group: /file_1/group_1
+            │   │       Dimensions:  ()
+            │   │       Data variables:
+            │   │           g        int64 8B 1
+            │   ...
+            │   └── Group: /file_1/group_4
+            │           Dimensions:  ()
+            │           Data variables:
+            │               g        int64 8B 4
+            ...
+            └── Group: /file_9
+                ├── Group: /file_9/group_0
+                │       Dimensions:  ()
+                │       Data variables:
+                │           g        int64 8B 0
+                ├── Group: /file_9/group_1
+                │       Dimensions:  ()
+                │       Data variables:
+                │           g        int64 8B 9
+                ...
+                └── Group: /file_9/group_4
+                        Dimensions:  ()
+                        Data variables:
+                            g        int64 8B 36
+            """
+        ).strip()
+        assert expected == result
+
+        with xr.set_options(display_max_children=10):
+            result = repr(tree)
+
+        for key in tree_dict:
+            assert key in result
+
+    def test_repr_inherited_dims(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/": Dataset({"foo": ("x", [1.0])}),
+                "/child": Dataset({"bar": ("y", [2.0])}),
+            }
+        )
+
+        result = repr(tree)
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            │   Dimensions:  (x: 1)
+            │   Dimensions without coordinates: x
+            │   Data variables:
+            │       foo      (x) float64 8B 1.0
+            └── Group: /child
+                    Dimensions:  (y: 1)
+                    Dimensions without coordinates: y
+                    Data variables:
+                        bar      (y) float64 8B 2.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(tree["child"])
+        expected = dedent(
+            """
+            <xarray.DataTree 'child'>
+            Group: /child
+                Dimensions:  (x: 1, y: 1)
+                Dimensions without coordinates: x, y
+                Data variables:
+                    bar      (y) float64 8B 2.0
+            """
+        ).strip()
+        assert result == expected
+
+    @pytest.mark.skipif(
+        ON_WINDOWS, reason="windows (pre NumPy2) uses int32 instead of int64"
+    )
+    def test_doc_example(self) -> None:
+        # regression test for https://github.com/pydata/xarray/issues/9499
+        time = xr.DataArray(
+            data=np.array(["2022-01", "2023-01"], dtype="<U7"), dims="time"
+        )
+        stations = xr.DataArray(
+            data=np.array(list("abcdef"), dtype="<U1"), dims="station"
+        )
+        lon = [-100, -80, -60]
+        lat = [10, 20, 30]
+        # Set up fake data
+        wind_speed = xr.DataArray(np.ones((2, 6)) * 2, dims=("time", "station"))
+        pressure = xr.DataArray(np.ones((2, 6)) * 3, dims=("time", "station"))
+        air_temperature = xr.DataArray(np.ones((2, 6)) * 4, dims=("time", "station"))
+        dewpoint = xr.DataArray(np.ones((2, 6)) * 5, dims=("time", "station"))
+        infrared = xr.DataArray(np.ones((2, 3, 3)) * 6, dims=("time", "lon", "lat"))
+        true_color = xr.DataArray(np.ones((2, 3, 3)) * 7, dims=("time", "lon", "lat"))
+        tree = xr.DataTree.from_dict(
+            {
+                "/": xr.Dataset(
+                    coords={"time": time},
+                ),
+                "/weather": xr.Dataset(
+                    coords={"station": stations},
+                    data_vars={
+                        "wind_speed": wind_speed,
+                        "pressure": pressure,
+                    },
+                ),
+                "/weather/temperature": xr.Dataset(
+                    data_vars={
+                        "air_temperature": air_temperature,
+                        "dewpoint": dewpoint,
+                    },
+                ),
+                "/satellite": xr.Dataset(
+                    coords={"lat": lat, "lon": lon},
+                    data_vars={
+                        "infrared": infrared,
+                        "true_color": true_color,
+                    },
+                ),
+            },
+        )
+
+        result = repr(tree)
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            │   Dimensions:  (time: 2)
+            │   Coordinates:
+            │     * time     (time) <U7 56B '2022-01' '2023-01'
+            ├── Group: /weather
+            │   │   Dimensions:     (station: 6, time: 2)
+            │   │   Coordinates:
+            │   │     * station     (station) <U1 24B 'a' 'b' 'c' 'd' 'e' 'f'
+            │   │   Data variables:
+            │   │       wind_speed  (time, station) float64 96B 2.0 2.0 2.0 2.0 ... 2.0 2.0 2.0 2.0
+            │   │       pressure    (time, station) float64 96B 3.0 3.0 3.0 3.0 ... 3.0 3.0 3.0 3.0
+            │   └── Group: /weather/temperature
+            │           Dimensions:          (time: 2, station: 6)
+            │           Data variables:
+            │               air_temperature  (time, station) float64 96B 4.0 4.0 4.0 4.0 ... 4.0 4.0 4.0
+            │               dewpoint         (time, station) float64 96B 5.0 5.0 5.0 5.0 ... 5.0 5.0 5.0
+            └── Group: /satellite
+                    Dimensions:     (lat: 3, lon: 3, time: 2)
+                    Coordinates:
+                      * lat         (lat) int64 24B 10 20 30
+                      * lon         (lon) int64 24B -100 -80 -60
+                    Data variables:
+                        infrared    (time, lon, lat) float64 144B 6.0 6.0 6.0 6.0 ... 6.0 6.0 6.0
+                        true_color  (time, lon, lat) float64 144B 7.0 7.0 7.0 7.0 ... 7.0 7.0 7.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(tree["weather"])
+        expected = dedent(
+            """
+            <xarray.DataTree 'weather'>
+            Group: /weather
+            │   Dimensions:     (time: 2, station: 6)
+            │   Coordinates:
+            │     * station     (station) <U1 24B 'a' 'b' 'c' 'd' 'e' 'f'
+            │   Inherited coordinates:
+            │     * time        (time) <U7 56B '2022-01' '2023-01'
+            │   Data variables:
+            │       wind_speed  (time, station) float64 96B 2.0 2.0 2.0 2.0 ... 2.0 2.0 2.0 2.0
+            │       pressure    (time, station) float64 96B 3.0 3.0 3.0 3.0 ... 3.0 3.0 3.0 3.0
+            └── Group: /weather/temperature
+                    Dimensions:          (time: 2, station: 6)
+                    Data variables:
+                        air_temperature  (time, station) float64 96B 4.0 4.0 4.0 4.0 ... 4.0 4.0 4.0
+                        dewpoint         (time, station) float64 96B 5.0 5.0 5.0 5.0 ... 5.0 5.0 5.0
+            """
+        ).strip()
+        assert result == expected
+
+
+def _exact_match(message: str) -> str:
+    return re.escape(dedent(message).strip())
+
+
+class TestInheritance:
+    def test_inherited_dims(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"d": (("x",), [1, 2])}),
+                "/b": xr.Dataset({"e": (("y",), [3])}),
+                "/c": xr.Dataset({"f": (("y",), [3, 4, 5])}),
+            }
+        )
+        assert dt.sizes == {"x": 2}
+        # nodes should include inherited dimensions
+        assert dt.b.sizes == {"x": 2, "y": 1}
+        assert dt.c.sizes == {"x": 2, "y": 3}
+        # dataset objects created from nodes should not
+        assert dt.b.dataset.sizes == {"y": 1}
+        assert dt.b.to_dataset(inherit=True).sizes == {"y": 1}
+        assert dt.b.to_dataset(inherit=False).sizes == {"y": 1}
+
+    def test_inherited_coords_index(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"d": (("x",), [1, 2])}, coords={"x": [2, 3]}),
+                "/b": xr.Dataset({"e": (("y",), [3])}),
+            }
+        )
+        assert "x" in dt["/b"].indexes
+        assert "x" in dt["/b"].coords
+        xr.testing.assert_identical(dt["/x"], dt["/b/x"])
+
+    def test_inherit_only_index_coords(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": [1], "y": 2}),
+                "/b": xr.Dataset(coords={"z": 3}),
+            }
+        )
+        assert dt.coords.keys() == {"x", "y"}
+        xr.testing.assert_equal(
+            dt["/x"], xr.DataArray([1], dims=["x"], coords={"x": [1], "y": 2})
+        )
+        xr.testing.assert_equal(dt["/y"], xr.DataArray(2, coords={"y": 2}))
+        assert dt["/b"].coords.keys() == {"x", "z"}
+        xr.testing.assert_equal(
+            dt["/b/x"], xr.DataArray([1], dims=["x"], coords={"x": [1], "z": 3})
+        )
+        xr.testing.assert_equal(dt["/b/z"], xr.DataArray(3, coords={"z": 3}))
+
+    def test_inherited_coords_with_index_are_deduplicated(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": [1, 2]}),
+                "/b": xr.Dataset(coords={"x": [1, 2]}),
+            }
+        )
+        child_dataset = dt.children["b"].to_dataset(inherit=False)
+        expected = xr.Dataset()
+        assert_identical(child_dataset, expected)
+
+        dt["/c"] = xr.Dataset({"foo": ("x", [4, 5])}, coords={"x": [1, 2]})
+        child_dataset = dt.children["c"].to_dataset(inherit=False)
+        expected = xr.Dataset({"foo": ("x", [4, 5])})
+        assert_identical(child_dataset, expected)
+
+    def test_deduplicated_after_setitem(self) -> None:
+        # regression test for GH #9601
+        dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": [1, 2]}),
+                "/b": None,
+            }
+        )
+        dt["b/x"] = dt["x"]
+        child_dataset = dt.children["b"].to_dataset(inherit=False)
+        expected = xr.Dataset()
+        assert_identical(child_dataset, expected)
+
+    def test_inconsistent_dims(self) -> None:
+        expected_msg = _exact_match(
+            """
+            group '/b' is not aligned with its parents:
+            Group:
+                Dimensions:  (x: 1)
+                Dimensions without coordinates: x
+                Data variables:
+                    c        (x) float64 8B 3.0
+            From parents:
+                Dimensions:  (x: 2)
+                Dimensions without coordinates: x
+            """
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree.from_dict(
+                {
+                    "/": xr.Dataset({"a": (("x",), [1.0, 2.0])}),
+                    "/b": xr.Dataset({"c": (("x",), [3.0])}),
+                }
+            )
+
+        dt = DataTree()
+        dt["/a"] = xr.DataArray([1.0, 2.0], dims=["x"])
+        with pytest.raises(ValueError, match=expected_msg):
+            dt["/b/c"] = xr.DataArray([3.0], dims=["x"])
+
+        b = DataTree(dataset=xr.Dataset({"c": (("x",), [3.0])}))
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree(
+                dataset=xr.Dataset({"a": (("x",), [1.0, 2.0])}),
+                children={"b": b},
+            )
+
+    def test_inconsistent_child_indexes(self) -> None:
+        expected_msg = _exact_match(
+            """
+            group '/b' is not aligned with its parents:
+            Group:
+                Dimensions:  (x: 1)
+                Coordinates:
+                  * x        (x) float64 8B 2.0
+                Data variables:
+                    *empty*
+            From parents:
+                Dimensions:  (x: 1)
+                Coordinates:
+                  * x        (x) float64 8B 1.0
+            """
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree.from_dict(
+                {
+                    "/": xr.Dataset(coords={"x": [1.0]}),
+                    "/b": xr.Dataset(coords={"x": [2.0]}),
+                }
+            )
+
+        dt = DataTree()
+        dt.dataset = xr.Dataset(coords={"x": [1.0]})  # type: ignore[assignment,unused-ignore]
+        dt["/b"] = DataTree()
+        with pytest.raises(ValueError, match=expected_msg):
+            dt["/b"].dataset = xr.Dataset(coords={"x": [2.0]})
+
+        b = DataTree(xr.Dataset(coords={"x": [2.0]}))
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree(dataset=xr.Dataset(coords={"x": [1.0]}), children={"b": b})
+
+    def test_inconsistent_grandchild_indexes(self) -> None:
+        expected_msg = _exact_match(
+            """
+            group '/b/c' is not aligned with its parents:
+            Group:
+                Dimensions:  (x: 1)
+                Coordinates:
+                  * x        (x) float64 8B 2.0
+                Data variables:
+                    *empty*
+            From parents:
+                Dimensions:  (x: 1)
+                Coordinates:
+                  * x        (x) float64 8B 1.0
+            """
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree.from_dict(
+                {
+                    "/": xr.Dataset(coords={"x": [1.0]}),
+                    "/b/c": xr.Dataset(coords={"x": [2.0]}),
+                }
+            )
+
+        dt = DataTree()
+        dt.dataset = xr.Dataset(coords={"x": [1.0]})  # type: ignore[assignment,unused-ignore]
+        dt["/b/c"] = DataTree()
+        with pytest.raises(ValueError, match=expected_msg):
+            dt["/b/c"].dataset = xr.Dataset(coords={"x": [2.0]})
+
+        c = DataTree(xr.Dataset(coords={"x": [2.0]}))
+        b = DataTree(children={"c": c})
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree(dataset=xr.Dataset(coords={"x": [1.0]}), children={"b": b})
+
+    def test_inconsistent_grandchild_dims(self) -> None:
+        expected_msg = _exact_match(
+            """
+            group '/b/c' is not aligned with its parents:
+            Group:
+                Dimensions:  (x: 1)
+                Dimensions without coordinates: x
+                Data variables:
+                    d        (x) float64 8B 3.0
+            From parents:
+                Dimensions:  (x: 2)
+                Dimensions without coordinates: x
+            """
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            DataTree.from_dict(
+                {
+                    "/": xr.Dataset({"a": (("x",), [1.0, 2.0])}),
+                    "/b/c": xr.Dataset({"d": (("x",), [3.0])}),
+                }
+            )
+
+        dt = DataTree()
+        dt["/a"] = xr.DataArray([1.0, 2.0], dims=["x"])
+        with pytest.raises(ValueError, match=expected_msg):
+            dt["/b/c/d"] = xr.DataArray([3.0], dims=["x"])
+
+
+class TestRestructuring:
+    def test_drop_nodes(self) -> None:
+        sue = DataTree.from_dict({"Mary": None, "Kate": None, "Ashley": None})
+
+        # test drop just one node
+        dropped_one = sue.drop_nodes(names="Mary")
+        assert "Mary" not in dropped_one.children
+
+        # test drop multiple nodes
+        dropped = sue.drop_nodes(names=["Mary", "Kate"])
+        assert not {"Mary", "Kate"}.intersection(set(dropped.children))
+        assert "Ashley" in dropped.children
+
+        # test raise
+        with pytest.raises(KeyError, match="nodes {'Mary'} not present"):
+            dropped.drop_nodes(names=["Mary", "Ashley"])
+
+        # test ignore
+        childless = dropped.drop_nodes(names=["Mary", "Ashley"], errors="ignore")
+        assert childless.children == {}
+
+    def test_assign(self) -> None:
+        dt = DataTree()
+        expected = DataTree.from_dict({"/": xr.Dataset({"foo": 0}), "/a": None})
+
+        # kwargs form
+        result = dt.assign(foo=xr.DataArray(0), a=DataTree())
+        assert_equal(result, expected)
+
+        # dict form
+        result = dt.assign({"foo": xr.DataArray(0), "a": DataTree()})
+        assert_equal(result, expected)
+
+    def test_filter_like(self) -> None:
+        flower_tree = DataTree.from_dict(
+            {"root": None, "trunk": None, "leaves": None, "flowers": None}
+        )
+        fruit_tree = DataTree.from_dict(
+            {"root": None, "trunk": None, "leaves": None, "fruit": None}
+        )
+        barren_tree = DataTree.from_dict({"root": None, "trunk": None})
+
+        # test filter_like tree
+        filtered_tree = flower_tree.filter_like(barren_tree)
+
+        assert filtered_tree.equals(barren_tree)
+        assert "flowers" not in filtered_tree.children
+
+        # test symmetrical pruning results in isomorphic trees
+        assert flower_tree.filter_like(fruit_tree).isomorphic(
+            fruit_tree.filter_like(flower_tree)
+        )
+
+        # test "deep" pruning
+        dt = DataTree.from_dict(
+            {"/a/A": None, "/a/B": None, "/b/A": None, "/b/B": None}
+        )
+        other = DataTree.from_dict({"/a/A": None, "/b/A": None})
+
+        filtered = dt.filter_like(other)
+        assert filtered.equals(other)
+
+
+class TestPipe:
+    def test_noop(self, create_test_datatree: Callable[[], DataTree]) -> None:
+        dt = create_test_datatree()
+
+        actual = dt.pipe(lambda tree: tree)
+        assert actual.identical(dt)
+
+    def test_args(self, create_test_datatree: Callable[[], DataTree]) -> None:
+        dt = create_test_datatree()
+
+        def f(tree: DataTree, x: int, y: int) -> DataTree:
+            return tree.assign(
+                arr_with_attrs=xr.Variable("dim0", [], attrs=dict(x=x, y=y))
+            )
+
+        actual = dt.pipe(f, 1, 2)
+        assert actual["arr_with_attrs"].attrs == dict(x=1, y=2)
+
+    def test_kwargs(self, create_test_datatree: Callable[[], DataTree]) -> None:
+        dt = create_test_datatree()
+
+        def f(tree: DataTree, *, x: int, y: int, z: int) -> DataTree:
+            return tree.assign(
+                arr_with_attrs=xr.Variable("dim0", [], attrs=dict(x=x, y=y, z=z))
+            )
+
+        attrs = {"x": 1, "y": 2, "z": 3}
+
+        actual = dt.pipe(f, **attrs)
+        assert actual["arr_with_attrs"].attrs == attrs
+
+    def test_args_kwargs(self, create_test_datatree: Callable[[], DataTree]) -> None:
+        dt = create_test_datatree()
+
+        def f(tree: DataTree, x: int, *, y: int, z: int) -> DataTree:
+            return tree.assign(
+                arr_with_attrs=xr.Variable("dim0", [], attrs=dict(x=x, y=y, z=z))
+            )
+
+        attrs = {"x": 1, "y": 2, "z": 3}
+
+        actual = dt.pipe(f, attrs["x"], y=attrs["y"], z=attrs["z"])
+        assert actual["arr_with_attrs"].attrs == attrs
+
+    def test_named_self(self, create_test_datatree: Callable[[], DataTree]) -> None:
+        dt = create_test_datatree()
+
+        def f(x: int, tree: DataTree, y: int):
+            tree.attrs.update({"x": x, "y": y})
+            return tree
+
+        attrs = {"x": 1, "y": 2}
+
+        actual = dt.pipe((f, "tree"), **attrs)
+
+        assert actual is dt and actual.attrs == attrs
+
+
+class TestIsomorphicEqualsAndIdentical:
+    def test_isomorphic(self):
+        tree = DataTree.from_dict({"/a": None, "/a/b": None, "/c": None})
+
+        diff_data = DataTree.from_dict(
+            {"/a": None, "/a/b": None, "/c": xr.Dataset({"foo": 1})}
+        )
+        assert tree.isomorphic(diff_data)
+
+        diff_order = DataTree.from_dict({"/c": None, "/a": None, "/a/b": None})
+        assert tree.isomorphic(diff_order)
+
+        diff_nodes = DataTree.from_dict({"/a": None, "/a/b": None, "/d": None})
+        assert not tree.isomorphic(diff_nodes)
+
+        more_nodes = DataTree.from_dict(
+            {"/a": None, "/a/b": None, "/c": None, "/d": None}
+        )
+        assert not tree.isomorphic(more_nodes)
+
+    def test_minimal_variations(self):
+        tree = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 1}),
+                "/child": Dataset({"x": 2}),
+            }
+        )
+        assert tree.equals(tree)
+        assert tree.identical(tree)
+
+        child = tree.children["child"]
+        assert child.equals(child)
+        assert child.identical(child)
+
+        new_child = DataTree(dataset=Dataset({"x": 2}), name="child")
+        assert child.equals(new_child)
+        assert child.identical(new_child)
+
+        anonymous_child = DataTree(dataset=Dataset({"x": 2}))
+        # TODO: re-enable this after fixing .equals() not to require matching
+        # names on the root node (i.e., after switching to use zip_subtrees)
+        # assert child.equals(anonymous_child)
+        assert not child.identical(anonymous_child)
+
+        different_variables = DataTree.from_dict(
+            {
+                "/": Dataset(),
+                "/other": Dataset({"x": 2}),
+            }
+        )
+        assert not tree.equals(different_variables)
+        assert not tree.identical(different_variables)
+
+        different_root_data = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 4}),
+                "/child": Dataset({"x": 2}),
+            }
+        )
+        assert not tree.equals(different_root_data)
+        assert not tree.identical(different_root_data)
+
+        different_child_data = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 1}),
+                "/child": Dataset({"x": 3}),
+            }
+        )
+        assert not tree.equals(different_child_data)
+        assert not tree.identical(different_child_data)
+
+        different_child_node_attrs = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 1}),
+                "/child": Dataset({"x": 2}, attrs={"foo": "bar"}),
+            }
+        )
+        assert tree.equals(different_child_node_attrs)
+        assert not tree.identical(different_child_node_attrs)
+
+        different_child_variable_attrs = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 1}),
+                "/child": Dataset({"x": ((), 2, {"foo": "bar"})}),
+            }
+        )
+        assert tree.equals(different_child_variable_attrs)
+        assert not tree.identical(different_child_variable_attrs)
+
+        different_name = DataTree.from_dict(
+            {
+                "/": Dataset({"x": 1}),
+                "/child": Dataset({"x": 2}),
+            },
+            name="different",
+        )
+        # TODO: re-enable this after fixing .equals() not to require matching
+        # names on the root node (i.e., after switching to use zip_subtrees)
+        # assert tree.equals(different_name)
+        assert not tree.identical(different_name)
+
+    def test_differently_inherited_coordinates(self):
+        root = DataTree.from_dict(
+            {
+                "/": Dataset(coords={"x": [1, 2]}),
+                "/child": Dataset(),
+            }
+        )
+        child = root.children["child"]
+        assert child.equals(child)
+        assert child.identical(child)
+
+        new_child = DataTree(dataset=Dataset(coords={"x": [1, 2]}), name="child")
+        assert child.equals(new_child)
+        assert not child.identical(new_child)
+
+        deeper_root = DataTree(children={"root": root})
+        grandchild = deeper_root.children["root"].children["child"]
+        assert child.equals(grandchild)
+        assert child.identical(grandchild)
+
+
+class TestSubset:
+    def test_match(self) -> None:
+        # TODO is this example going to cause problems with case sensitivity?
+        dt = DataTree.from_dict(
+            {
+                "/a/A": None,
+                "/a/B": None,
+                "/b/A": None,
+                "/b/B": None,
+            }
+        )
+        result = dt.match("*/B")
+        expected = DataTree.from_dict(
+            {
+                "/a/B": None,
+                "/b/B": None,
+            }
+        )
+        assert_identical(result, expected)
+
+        result = dt.children["a"].match("B")
+        expected = DataTree.from_dict({"/B": None}, name="a")
+        assert_identical(result, expected)
+
+    def test_filter(self) -> None:
+        simpsons = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"age": 83}),
+                "/Herbert": xr.Dataset({"age": 40}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
+                "/Homer/Maggie": xr.Dataset({"age": 1}),
+            },
+            name="Abe",
+        )
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"age": 83}),
+                "/Herbert": xr.Dataset({"age": 40}),
+                "/Homer": xr.Dataset({"age": 39}),
+            },
+            name="Abe",
+        )
+        elders = simpsons.filter(lambda node: node["age"].item() > 18)
+        assert_identical(elders, expected)
+
+        expected = DataTree.from_dict({"/Bart": xr.Dataset({"age": 10})}, name="Homer")
+        actual = simpsons.children["Homer"].filter(
+            lambda node: node["age"].item() == 10
+        )
+        assert_identical(actual, expected)
+
+    def test_prune_basic(self) -> None:
+        tree = DataTree.from_dict(
+            {"/a": xr.Dataset({"foo": ("x", [1, 2])}), "/b": xr.Dataset()}
+        )
+
+        pruned = tree.prune()
+
+        assert "a" in pruned.children
+        assert "b" not in pruned.children
+        assert_identical(
+            pruned.children["a"].to_dataset(), tree.children["a"].to_dataset()
+        )
+
+    def test_prune_with_zero_size_vars(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"foo": ("x", [1, 2])}),
+                "/b": xr.Dataset({"empty": ("dim", [])}),
+                "/c": xr.Dataset(),
+            }
+        )
+
+        pruned_default = tree.prune()
+        expected_default = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"foo": ("x", [1, 2])}),
+                "/b": xr.Dataset({"empty": ("dim", [])}),
+            }
+        )
+        assert_identical(pruned_default, expected_default)
+
+        pruned_strict = tree.prune(drop_size_zero_vars=True)
+        expected_strict = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"foo": ("x", [1, 2])}),
+            }
+        )
+        assert_identical(pruned_strict, expected_strict)
+
+    def test_prune_with_intermediate_nodes(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/": xr.Dataset(),
+                "/group1": xr.Dataset(),
+                "/group1/subA": xr.Dataset({"temp": ("x", [1, 2])}),
+                "/group1/subB": xr.Dataset(),
+                "/group2": xr.Dataset({"empty": ("dim", [])}),
+            }
+        )
+        pruned = tree.prune()
+        expected_tree = DataTree.from_dict(
+            {
+                "/group1/subA": xr.Dataset({"temp": ("x", [1, 2])}),
+                "/group2": xr.Dataset({"empty": ("dim", [])}),
+            }
+        )
+        assert_identical(pruned, expected_tree)
+
+    def test_prune_after_filtering(self) -> None:
+        from pandas import date_range
+
+        ds1 = xr.Dataset(
+            {"foo": ("time", [1, 2, 3, 4, 5])},
+            coords={"time": date_range("2023-01-01", periods=5, freq="D")},
+        )
+        ds2 = xr.Dataset(
+            {"var": ("time", [1, 2, 3, 4, 5])},
+            coords={"time": date_range("2023-01-04", periods=5, freq="D")},
+        )
+
+        tree = DataTree.from_dict({"a": ds1, "b": ds2})
+        filtered = tree.sel(time=slice("2023-01-01", "2023-01-03"))
+
+        pruned = filtered.prune(drop_size_zero_vars=True)
+        expected_tree = DataTree.from_dict(
+            {"a": ds1.sel(time=slice("2023-01-01", "2023-01-03"))}
+        )
+        assert_identical(pruned, expected_tree)
+
+
+class TestIndexing:
+    def test_isel_siblings(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": ("x", [1, 2])}),
+                "/second": xr.Dataset({"b": ("x", [1, 2, 3])}),
+            }
+        )
+
+        expected = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": 2}),
+                "/second": xr.Dataset({"b": 3}),
+            }
+        )
+        actual = tree.isel(x=-1)
+        assert_identical(actual, expected)
+
+        expected = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": ("x", [1])}),
+                "/second": xr.Dataset({"b": ("x", [1])}),
+            }
+        )
+        actual = tree.isel(x=slice(1))
+        assert_identical(actual, expected)
+
+        actual = tree.isel(x=[0])
+        assert_identical(actual, expected)
+
+        actual = tree.isel(x=slice(None))
+        assert_identical(actual, tree)
+
+    def test_isel_inherited(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": [1, 2]}),
+                "/child": xr.Dataset({"foo": ("x", [3, 4])}),
+            }
+        )
+
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": 2}),
+                "/child": xr.Dataset({"foo": 4}),
+            }
+        )
+        actual = tree.isel(x=-1)
+        assert_identical(actual, expected)
+
+        expected = DataTree.from_dict(
+            {
+                "/child": xr.Dataset({"foo": 4}),
+            }
+        )
+        actual = tree.isel(x=-1, drop=True)
+        assert_identical(actual, expected)
+
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset(coords={"x": [1]}),
+                "/child": xr.Dataset({"foo": ("x", [3])}),
+            }
+        )
+        actual = tree.isel(x=[0])
+        assert_identical(actual, expected)
+
+        actual = tree.isel(x=slice(None))
+
+        # TODO: re-enable after the fix to copy() from #9628 is submitted
+        # actual = tree.children["child"].isel(x=slice(None))
+        # expected = tree.children["child"].copy()
+        # assert_identical(actual, expected)
+
+        actual = tree.children["child"].isel(x=0)
+        expected = DataTree(
+            dataset=xr.Dataset({"foo": 3}, coords={"x": 1}),
+            name="child",
+        )
+        assert_identical(actual, expected)
+
+    def test_sel(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": ("x", [1, 2, 3])}, coords={"x": [1, 2, 3]}),
+                "/second": xr.Dataset({"b": ("x", [4, 5])}, coords={"x": [2, 3]}),
+            }
+        )
+        expected = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": 2}, coords={"x": 2}),
+                "/second": xr.Dataset({"b": 4}, coords={"x": 2}),
+            }
+        )
+        actual = tree.sel(x=2)
+        assert_identical(actual, expected)
+
+        actual = tree.children["first"].sel(x=2)
+        expected = DataTree(
+            dataset=xr.Dataset({"a": 2}, coords={"x": 2}),
+            name="first",
+        )
+        assert_identical(actual, expected)
+
+    def test_sel_isel_error_has_node_info(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/first": xr.Dataset({"a": ("x", [1, 2, 3])}, coords={"x": [1, 2, 3]}),
+                "/second": xr.Dataset({"b": ("x", [4, 5])}, coords={"x": [2, 3]}),
+            }
+        )
+
+        with pytest.raises(
+            KeyError,
+            match="Raised whilst mapping function over node with path 'second'",
+        ):
+            tree.sel(x=1)
+
+        with pytest.raises(
+            IndexError,
+            match="Raised whilst mapping function over node with path 'first'",
+        ):
+            tree.isel(x=4)
+
+
+class TestAggregations:
+    def test_reduce_method(self) -> None:
+        ds = xr.Dataset({"a": ("x", [False, True, False])})
+        dt = DataTree.from_dict({"/": ds, "/results": ds})
+
+        expected = DataTree.from_dict({"/": ds.any(), "/results": ds.any()})
+
+        result = dt.any()
+        assert_equal(result, expected)
+
+    def test_nan_reduce_method(self) -> None:
+        ds = xr.Dataset({"a": ("x", [1, 2, 3])})
+        dt = DataTree.from_dict({"/": ds, "/results": ds})
+
+        expected = DataTree.from_dict({"/": ds.mean(), "/results": ds.mean()})
+
+        result = dt.mean()
+        assert_equal(result, expected)
+
+    def test_cum_method(self) -> None:
+        ds = xr.Dataset({"a": ("x", [1, 2, 3])})
+        dt = DataTree.from_dict({"/": ds, "/results": ds})
+
+        expected = DataTree.from_dict(
+            {
+                "/": ds.cumsum(),
+                "/results": ds.cumsum(),
+            }
+        )
+
+        result = dt.cumsum()
+        assert_equal(result, expected)
+
+    def test_dim_argument(self) -> None:
+        dt = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"A": ("x", [1, 2])}),
+                "/b": xr.Dataset({"B": ("y", [1, 2])}),
+            }
+        )
+
+        expected = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"A": 1.5}),
+                "/b": xr.Dataset({"B": 1.5}),
+            }
+        )
+        actual = dt.mean()
+        assert_equal(expected, actual)
+
+        actual = dt.mean(dim=...)
+        assert_equal(expected, actual)
+
+        expected = DataTree.from_dict(
+            {
+                "/a": xr.Dataset({"A": 1.5}),
+                "/b": xr.Dataset({"B": ("y", [1.0, 2.0])}),
+            }
+        )
+        actual = dt.mean("x")
+        assert_equal(expected, actual)
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Dimension(s) 'invalid' do not exist."),
+        ):
+            dt.mean("invalid")
+
+    def test_subtree(self) -> None:
+        tree = DataTree.from_dict(
+            {
+                "/child": Dataset({"a": ("x", [1, 2])}),
+            }
+        )
+        expected = DataTree(dataset=Dataset({"a": 1.5}), name="child")
+        actual = tree.children["child"].mean()
+        assert_identical(expected, actual)
+
+
+class TestOps:
+    def test_unary_op(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict({"/": ds1, "/subnode": ds2})
+
+        expected = DataTree.from_dict({"/": (-ds1), "/subnode": (-ds2)})
+
+        result = -dt
+        assert_equal(result, expected)
+
+    def test_unary_op_inherited_coords(self) -> None:
+        tree = DataTree(xr.Dataset(coords={"x": [1, 2, 3]}))
+        tree["/foo"] = DataTree(xr.Dataset({"bar": ("x", [4, 5, 6])}))
+        actual = -tree
+
+        actual_dataset = actual.children["foo"].to_dataset(inherit=False)
+        assert "x" not in actual_dataset.coords
+
+        expected = tree.copy()
+        # unary ops are not applied to coordinate variables, only data variables
+        expected["/foo/bar"].data = np.array([-4, -5, -6])
+        assert_identical(actual, expected)
+
+    def test_binary_op_on_int(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict({"/": ds1, "/subnode": ds2})
+
+        expected = DataTree.from_dict({"/": ds1 * 5, "/subnode": ds2 * 5})
+
+        result = dt * 5
+        assert_equal(result, expected)
+
+    def test_binary_op_on_dataarray(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict(
+            {
+                "/": ds1,
+                "/subnode": ds2,
+            }
+        )
+
+        other_da = xr.DataArray(name="z", data=[0.1, 0.2], dims="z")
+
+        expected = DataTree.from_dict(
+            {
+                "/": ds1 * other_da,
+                "/subnode": ds2 * other_da,
+            }
+        )
+
+        result = dt * other_da
+        assert_equal(result, expected)
+
+    def test_binary_op_on_dataset(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict(
+            {
+                "/": ds1,
+                "/subnode": ds2,
+            }
+        )
+
+        other_ds = xr.Dataset({"z": ("z", [0.1, 0.2])})
+
+        expected = DataTree.from_dict(
+            {
+                "/": ds1 * other_ds,
+                "/subnode": ds2 * other_ds,
+            }
+        )
+
+        result = dt * other_ds
+        assert_equal(result, expected)
+
+    def test_binary_op_on_datatree(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+
+        dt = DataTree.from_dict({"/": ds1, "/subnode": ds2})
+
+        expected = DataTree.from_dict({"/": ds1 * ds1, "/subnode": ds2 * ds2})
+
+        result = dt * dt
+        assert_equal(result, expected)
+
+    def test_binary_op_order_invariant(self) -> None:
+        tree_ab = DataTree.from_dict({"/a": Dataset({"a": 1}), "/b": Dataset({"b": 2})})
+        tree_ba = DataTree.from_dict({"/b": Dataset({"b": 2}), "/a": Dataset({"a": 1})})
+        expected = DataTree.from_dict(
+            {"/a": Dataset({"a": 2}), "/b": Dataset({"b": 4})}
+        )
+        actual = tree_ab + tree_ba
+        assert_identical(expected, actual)
+
+    def test_arithmetic_inherited_coords(self) -> None:
+        tree = DataTree(xr.Dataset(coords={"x": [1, 2, 3]}))
+        tree["/foo"] = DataTree(xr.Dataset({"bar": ("x", [4, 5, 6])}))
+        actual = 2 * tree
+
+        actual_dataset = actual.children["foo"].to_dataset(inherit=False)
+        assert "x" not in actual_dataset.coords
+
+        expected = tree.copy()
+        expected["/foo/bar"].data = np.array([8, 10, 12])
+        assert_identical(actual, expected)
+
+    def test_binary_op_commutativity_with_dataset(self) -> None:
+        # regression test for #9365
+
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict(
+            {
+                "/": ds1,
+                "/subnode": ds2,
+            }
+        )
+
+        other_ds = xr.Dataset({"z": ("z", [0.1, 0.2])})
+
+        expected = DataTree.from_dict(
+            {
+                "/": ds1 * other_ds,
+                "/subnode": ds2 * other_ds,
+            }
+        )
+
+        result = other_ds * dt
+        assert_equal(result, expected)
+
+    def test_inplace_binary_op(self) -> None:
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTreeDitto.from_dict({"/": ds1, "/subnode": ds2})
+
+        expected = DataTreeDitto.from_dict({"/": ds1 + 1, "/subnode": ds2 + 1})
+
+        dt += 1
+        assert_equal(dt, expected)
+
+    def test_dont_broadcast_single_node_tree(self) -> None:
+        # regression test for https://github.com/pydata/xarray/issues/9365#issuecomment-2291622577
+        ds1 = xr.Dataset({"a": [5], "b": [3]})
+        ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
+        dt = DataTree.from_dict({"/": ds1, "/subnode": ds2})
+        node = dt["/subnode"]
+
+        with pytest.raises(
+            xr.TreeIsomorphismError,
+            match=re.escape(r"children at root node do not match: ['subnode'] vs []"),
+        ):
+            dt * node
+
+
+class TestUFuncs:
+    @pytest.mark.xfail(reason="__array_ufunc__ not implemented yet")
+    def test_tree(self, create_test_datatree):
+        dt = create_test_datatree()
+        expected = create_test_datatree(modify=np.sin)
+        result_tree = np.sin(dt)
+        assert_equal(result_tree, expected)
+
+
+class Closer:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        if self.closed:
+            raise RuntimeError("already closed")
+        self.closed = True
+
+
+@pytest.fixture
+def tree_and_closers():
+    tree = DataTree.from_dict({"/child/grandchild": None})
+    closers = {
+        "/": Closer(),
+        "/child": Closer(),
+        "/child/grandchild": Closer(),
+    }
+    for path, closer in closers.items():
+        tree[path].set_close(closer.close)
+    return tree, closers
+
+
+class TestClose:
+    def test_close(self, tree_and_closers):
+        tree, closers = tree_and_closers
+        assert not any(closer.closed for closer in closers.values())
+        tree.close()
+        assert all(closer.closed for closer in closers.values())
+        tree.close()  # should not error
+
+    def test_context_manager(self, tree_and_closers):
+        tree, closers = tree_and_closers
+        assert not any(closer.closed for closer in closers.values())
+        with tree:
+            pass
+        assert all(closer.closed for closer in closers.values())
+
+    def test_close_child(self, tree_and_closers):
+        tree, closers = tree_and_closers
+        assert not any(closer.closed for closer in closers.values())
+        tree["child"].close()  # should only close descendants
+        assert not closers["/"].closed
+        assert closers["/child"].closed
+        assert closers["/child/grandchild"].closed
+
+    def test_close_datasetview(self, tree_and_closers):
+        tree, _ = tree_and_closers
+
+        with pytest.raises(
+            AttributeError,
+            match=re.escape(
+                r"cannot close a DatasetView(). Close the associated DataTree node instead"
+            ),
+        ):
+            tree.dataset.close()
+
+        with pytest.raises(
+            AttributeError, match=re.escape(r"cannot modify a DatasetView()")
+        ):
+            tree.dataset.set_close(None)
+
+    def test_close_dataset(self, tree_and_closers):
+        tree, closers = tree_and_closers
+        ds = tree.to_dataset()  # should discard closers
+        ds.close()
+        assert not closers["/"].closed
+
+    # with tree:
+    #     pass
+
+
+@requires_dask
+class TestDask:
+    def test_chunksizes(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        groups = {
+            "/": ds1.chunk({"x": 5}),
+            "/group1": ds2.chunk({"y": 3}),
+            "/group2": ds3.chunk({"z": 2}),
+            "/group1/subgroup1": ds4.chunk({"x": 5}),
+        }
+
+        tree = xr.DataTree.from_dict(groups)
+
+        expected_chunksizes = {path: node.chunksizes for path, node in groups.items()}
+
+        assert tree.chunksizes == expected_chunksizes
+
+    def test_load(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        groups = {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
+
+        expected = xr.DataTree.from_dict(groups)
+        tree = xr.DataTree.from_dict(
+            {
+                "/": ds1.chunk({"x": 5}),
+                "/group1": ds2.chunk({"y": 3}),
+                "/group2": ds3.chunk({"z": 2}),
+                "/group1/subgroup1": ds4.chunk({"x": 5}),
+            }
+        )
+        expected_chunksizes: Mapping[str, Mapping]
+        expected_chunksizes = {node.path: {} for node in tree.subtree}
+        actual = tree.load()
+
+        assert_identical(actual, expected)
+        assert tree.chunksizes == expected_chunksizes
+        assert actual.chunksizes == expected_chunksizes
+
+        tree = xr.DataTree.from_dict(groups)
+        actual = tree.load()
+        assert_identical(actual, expected)
+        assert actual.chunksizes == expected_chunksizes
+
+    def test_compute(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        expected = xr.DataTree.from_dict(
+            {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
+        )
+        tree = xr.DataTree.from_dict(
+            {
+                "/": ds1.chunk({"x": 5}),
+                "/group1": ds2.chunk({"y": 3}),
+                "/group2": ds3.chunk({"z": 2}),
+                "/group1/subgroup1": ds4.chunk({"x": 5}),
+            }
+        )
+        original_chunksizes = tree.chunksizes
+        expected_chunksizes: Mapping[str, Mapping]
+        expected_chunksizes = {node.path: {} for node in tree.subtree}
+        actual = tree.compute()
+
+        assert_identical(actual, expected)
+
+        assert actual.chunksizes == expected_chunksizes, "mismatching chunksizes"
+        assert tree.chunksizes == original_chunksizes, "original tree was modified"
+
+    def test_persist(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        def fn(x):
+            return 2 * x
+
+        expected = xr.DataTree.from_dict(
+            {
+                "/": fn(ds1).chunk({"x": 5}),
+                "/group1": fn(ds2).chunk({"y": 3}),
+                "/group2": fn(ds3).chunk({"z": 2}),
+                "/group1/subgroup1": fn(ds4).chunk({"x": 5}),
+            }
+        )
+        # Add trivial second layer to the task graph, persist should reduce to one
+        tree = xr.DataTree.from_dict(
+            {
+                "/": fn(ds1.chunk({"x": 5})),
+                "/group1": fn(ds2.chunk({"y": 3})),
+                "/group2": fn(ds3.chunk({"z": 2})),
+                "/group1/subgroup1": fn(ds4.chunk({"x": 5})),
+            }
+        )
+        original_chunksizes = tree.chunksizes
+        original_hlg_depths = {
+            node.path: len(node.dataset.__dask_graph__().layers)
+            for node in tree.subtree
+        }
+
+        actual = tree.persist()
+        actual_hlg_depths = {
+            node.path: len(node.dataset.__dask_graph__().layers)
+            for node in actual.subtree
+        }
+
+        assert_identical(actual, expected)
+
+        assert actual.chunksizes == original_chunksizes, "chunksizes were modified"
+        assert (
+            tree.chunksizes == original_chunksizes
+        ), "original chunksizes were modified"
+        assert all(
+            d == 1 for d in actual_hlg_depths.values()
+        ), "unexpected dask graph depth"
+        assert all(
+            d == 2 for d in original_hlg_depths.values()
+        ), "original dask graph was modified"
+
+    def test_chunk(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        expected = xr.DataTree.from_dict(
+            {
+                "/": ds1.chunk({"x": 5}),
+                "/group1": ds2.chunk({"y": 3}),
+                "/group2": ds3.chunk({"z": 2}),
+                "/group1/subgroup1": ds4.chunk({"x": 5}),
+            }
+        )
+
+        tree = xr.DataTree.from_dict(
+            {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
+        )
+        actual = tree.chunk({"x": 5, "y": 3, "z": 2})
+
+        assert_identical(actual, expected)
+        assert actual.chunksizes == expected.chunksizes
+
+        with pytest.raises(TypeError, match="invalid type"):
+            tree.chunk(None)
+
+        with pytest.raises(TypeError, match="invalid type"):
+            tree.chunk((1, 2))
+
+        with pytest.raises(ValueError, match="not found in data dimensions"):
+            tree.chunk({"u": 2})

--- a/tests/unit_tests/utils/types/test_datatree_ditto_mapping_FROM_XARRAY.py
+++ b/tests/unit_tests/utils/types/test_datatree_ditto_mapping_FROM_XARRAY.py
@@ -1,0 +1,322 @@
+import re
+
+import numpy as np
+import pytest
+
+import xarray as xr
+from xarray.core.datatree_mapping import map_over_datasets
+from xarray.core.treenode import TreeIsomorphismError
+from xarray.testing import assert_equal, assert_identical
+
+empty = xr.Dataset()
+
+from geoips.utils.types.datatree_ditto import DataTreeDitto
+
+
+@pytest.fixture(scope="module")
+def create_test_datatree():
+    """
+    Create a test datatree with this structure:
+
+    <xarray.DataTree>
+    Group: /
+    │   Dimensions:  (y: 3, x: 2)
+    │   Dimensions without coordinates: y, x
+    │   Data variables:
+    │       a        (y) int64 24B 6 7 8
+    │       set0     (x) int64 16B 9 10
+    ├── Group: /set1
+    │   │   Dimensions:  ()
+    │   │   Data variables:
+    │   │       a        int64 8B 0
+    │   │       b        int64 8B 1
+    │   ├── Group: /set1/set1
+    │   └── Group: /set1/set2
+    ├── Group: /set2
+    │   │   Dimensions:  (x: 2)
+    │   │   Dimensions without coordinates: x
+    │   │   Data variables:
+    │   │       a        (x) int64 16B 2 3
+    │   │       b        (x) float64 16B 0.1 0.2
+    │   └── Group: /set2/set1
+    └── Group: /set3
+
+    The structure has deliberately repeated names of tags, variables, and
+    dimensions in order to better check for bugs caused by name conflicts.
+    """
+
+    def _create_test_datatree(modify=lambda ds: ds):
+        set1_data = modify(xr.Dataset({"a": 0, "b": 1}))
+        set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
+        root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
+
+        root = DataTreeDitto.from_dict(
+            {
+                "/": root_data,
+                "/set1": set1_data,
+                "/set1/set1": None,
+                "/set1/set2": None,
+                "/set2": set2_data,
+                "/set2/set1": None,
+                "/set3": None,
+            }
+        )
+
+        return root
+
+    return _create_test_datatree
+
+
+@pytest.fixture(scope="module")
+def simple_datatree(create_test_datatree):
+    """
+    Invoke create_test_datatree fixture (callback).
+
+    Returns a DataTree.
+    """
+    return create_test_datatree()
+
+
+class TestMapOverSubTree:
+    def test_no_trees_passed(self):
+        with pytest.raises(TypeError, match="must pass at least one tree object"):
+            map_over_datasets(lambda x: x, "dt")
+
+    def test_not_isomorphic(self, create_test_datatree):
+        dt1 = create_test_datatree()
+        dt2 = create_test_datatree()
+        dt2["set1/set2/extra"] = DataTreeDitto(name="extra")
+
+        with pytest.raises(
+            TreeIsomorphismError,
+            match=re.escape(
+                r"children at node 'set1/set2' do not match: [] vs ['extra']"
+            ),
+        ):
+            map_over_datasets(lambda x, y: None, dt1, dt2)
+
+    def test_no_trees_returned(self, create_test_datatree):
+        dt1 = create_test_datatree()
+        dt2 = create_test_datatree()
+        expected = DataTreeDitto.from_dict(dict.fromkeys(dt1.to_dict()))
+        actual = map_over_datasets(lambda x, y: None, dt1, dt2)
+        assert_equal(expected.to_datatree(), actual)
+
+    def test_single_tree_arg(self, create_test_datatree):
+        dt = create_test_datatree()
+        expected = create_test_datatree(modify=lambda x: 10.0 * x)
+        result_tree = map_over_datasets(lambda x: 10 * x, dt)
+        assert_equal(result_tree, expected.to_datatree())
+
+    def test_single_tree_arg_plus_arg(self, create_test_datatree):
+        dt = create_test_datatree()
+        expected = create_test_datatree(modify=lambda ds: (10.0 * ds))
+        result_tree = map_over_datasets(lambda x, y: x * y, dt, 10.0)
+        assert_equal(result_tree, expected.to_datatree())
+
+        result_tree = map_over_datasets(lambda x, y: x * y, 10.0, dt)
+        assert_equal(result_tree, expected.to_datatree())
+
+    def test_single_tree_arg_plus_kwarg(self, create_test_datatree):
+        dt = create_test_datatree()
+        expected = create_test_datatree(modify=lambda ds: (10.0 * ds))
+
+        def multiply_by_kwarg(ds, **kwargs):
+            ds = ds * kwargs.pop("multiplier")
+            return ds
+
+        result_tree = map_over_datasets(
+            multiply_by_kwarg, dt, kwargs=dict(multiplier=10.0)
+        )
+        assert_equal(result_tree, expected.to_datatree())
+
+    def test_multiple_tree_args(self, create_test_datatree):
+        dt1 = create_test_datatree()
+        dt2 = create_test_datatree()
+        expected = create_test_datatree(modify=lambda ds: 2.0 * ds)
+        result = map_over_datasets(lambda x, y: x + y, dt1, dt2)
+        assert_equal(result, expected.to_datatree())
+
+    def test_return_multiple_trees(self, create_test_datatree):
+        dt = create_test_datatree()
+        dt_min, dt_max = map_over_datasets(lambda x: (x.min(), x.max()), dt)
+        expected_min = create_test_datatree(modify=lambda ds: ds.min())
+        assert_equal(dt_min, expected_min.to_datatree())
+        expected_max = create_test_datatree(modify=lambda ds: ds.max())
+        assert_equal(dt_max, expected_max.to_datatree())
+
+    def test_return_wrong_type(self, simple_datatree):
+        dt1 = simple_datatree
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "the result of calling func on the node at position '.' is not a "
+                "Dataset or None or a tuple of such types"
+            ),
+        ):
+            map_over_datasets(lambda x: "string", dt1)  # type: ignore[arg-type,return-value]
+
+    def test_return_tuple_of_wrong_types(self, simple_datatree):
+        dt1 = simple_datatree
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "the result of calling func on the node at position '.' is not a "
+                "Dataset or None or a tuple of such types"
+            ),
+        ):
+            map_over_datasets(lambda x: (x, "string"), dt1)  # type: ignore[arg-type,return-value]
+
+    def test_return_inconsistent_number_of_results(self, simple_datatree):
+        dt1 = simple_datatree
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                r"Calling func on the nodes at position set1 returns a tuple "
+                "of 0 datasets, whereas calling func on the nodes at position "
+                ". instead returns a tuple of 2 datasets."
+            ),
+        ):
+            # Datasets in simple_datatree have different numbers of dims
+            map_over_datasets(lambda ds: tuple((None,) * len(ds.dims)), dt1)
+
+    def test_wrong_number_of_arguments_for_func(self, simple_datatree):
+        dt = simple_datatree
+
+        with pytest.raises(
+            TypeError, match="takes 1 positional argument but 2 were given"
+        ):
+            map_over_datasets(lambda x: 10 * x, dt, dt)
+
+    def test_map_single_dataset_against_whole_tree(self, create_test_datatree):
+        dt = create_test_datatree()
+
+        def nodewise_merge(node_ds, fixed_ds):
+            return xr.merge([node_ds, fixed_ds])
+
+        other_ds = xr.Dataset({"z": ("z", [0])})
+        expected = create_test_datatree(modify=lambda ds: xr.merge([ds, other_ds]))
+        result_tree = map_over_datasets(nodewise_merge, dt, other_ds)
+        assert_equal(result_tree, expected.to_datatree())
+
+    @pytest.mark.xfail(reason="This also fails for xarray package.")
+    def test_trees_with_different_node_names(self):
+        # TODO test this after I've got good tests for renaming nodes
+        raise NotImplementedError
+
+    def test_tree_method(self, create_test_datatree):
+        dt = create_test_datatree()
+
+        def multiply(ds, times):
+            return times * ds
+
+        expected = create_test_datatree(modify=lambda ds: 10.0 * ds)
+        result_tree = dt.map_over_datasets(multiply, 10.0)
+        assert_equal(result_tree, expected)
+
+    def test_tree_method_with_kwarg(self, create_test_datatree):
+        dt = create_test_datatree()
+
+        def multiply(ds, **kwargs):
+            return kwargs.pop("times") * ds
+
+        expected = create_test_datatree(modify=lambda ds: 10.0 * ds)
+        result_tree = dt.map_over_datasets(multiply, kwargs=dict(times=10.0))
+        assert_equal(result_tree, expected)
+
+    def test_discard_ancestry(self, create_test_datatree):
+        # Check for datatree GH issue https://github.com/xarray-contrib/datatree/issues/48
+        dt = create_test_datatree()
+        subtree = dt["set1"]
+        expected = create_test_datatree(modify=lambda ds: 10.0 * ds)["set1"]
+        result_tree = map_over_datasets(lambda x: 10.0 * x, subtree)
+        assert_equal(result_tree, expected.to_datatree())
+
+    def test_keep_attrs_on_empty_nodes(self, create_test_datatree):
+        # GH278
+        dt = create_test_datatree()
+        dt["set1/set2"].attrs["foo"] = "bar"
+
+        def empty_func(ds):
+            return ds
+
+        result = dt.map_over_datasets(empty_func)
+        assert result["set1/set2"].attrs == dt["set1/set2"].attrs
+
+    @pytest.mark.xfail
+    def test_error_contains_path_of_offending_node(self, create_test_datatree):
+        dt = create_test_datatree()
+        dt["set1"]["bad_var"] = 0
+        print(dt)
+
+        def fail_on_specific_node(ds):
+            if "bad_var" in ds:
+                raise ValueError("Failed because 'bar_var' present in dataset")
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                r"Raised whilst mapping function over node with path 'set1'"
+            ),
+        ):
+            dt.map_over_datasets(fail_on_specific_node)
+
+    def test_inherited_coordinates_with_index(self):
+        root = xr.Dataset(coords={"x": [1, 2]})
+        child = xr.Dataset({"foo": ("x", [0, 1])})  # no coordinates
+        tree = DataTreeDitto.from_dict({"/": root, "/child": child})
+        actual = tree.to_datatree().map_over_datasets(lambda ds: ds)  # identity
+        assert isinstance(actual, xr.DataTree)
+        assert_identical(tree.to_datatree(), actual)
+
+        actual_child = actual.children["child"].to_dataset(inherit=False)
+        assert_identical(actual_child, child)
+
+
+class TestMutableOperations:
+    def test_construct_using_type(self):
+        # from datatree GH issue https://github.com/xarray-contrib/datatree/issues/188
+        # xarray's .weighted is unusual because it uses type() to create a Dataset/DataArray
+
+        a = xr.DataArray(
+            np.random.rand(3, 4, 10),
+            dims=["x", "y", "time"],
+            coords={"area": (["x", "y"], np.random.rand(3, 4))},
+        ).to_dataset(name="data")
+        b = xr.DataArray(
+            np.random.rand(2, 6, 14),
+            dims=["x", "y", "time"],
+            coords={"area": (["x", "y"], np.random.rand(2, 6))},
+        ).to_dataset(name="data")
+        dt = DataTreeDitto.from_dict({"a": a, "b": b})
+
+        def weighted_mean(ds):
+            if "area" not in ds.coords:
+                return None
+            return ds.weighted(ds.area).mean(["x", "y"])
+
+        dt.map_over_datasets(weighted_mean)
+
+    def test_alter_inplace_forbidden(self):
+        simpsons = DataTreeDitto.from_dict(
+            {
+                "/": xr.Dataset({"age": 83}),
+                "/Herbert": xr.Dataset({"age": 40}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
+                "/Homer/Maggie": xr.Dataset({"age": 1}),
+            },
+            name="Abe",
+        )
+
+        def fast_forward(ds: xr.Dataset, years: float) -> xr.Dataset:
+            """Add some years to the age, but by altering the given dataset"""
+            ds["age"] = ds["age"] + years
+            return ds
+
+        with pytest.raises(AttributeError):
+            simpsons.map_over_datasets(fast_forward, 10)


### PR DESCRIPTION
Validate the following plugins in the OBP and ensure that their SSP-to-OBP execution flows match the existing SSP behavior: 

- [x] `reader` 
- [x] `algorithm` 
- [x] `interpolator` 
- [x] `coverage-checker`
- [x]  `colormapper` 
- [x] `coverage-checker`
- [x] `output-formatter`
  - [x] `title-formatter`
  - [x] `feature-annotator`
  - [x] `gridline-annotator` 
  - [x]  `coverage-checker`
  - [x] `filename-formatter`
- [x] `output-checker` 

<!-- 💖✨ PULL REQUEST CHECKLIST ✨💖 -->

Before setting your PR to "Ready to Review", please make sure everything is set. 📋 

- **Tags/Attributes** (on the right-hand side):
  - 👩‍💻👨‍💻**Reviewers**: Add at least 2 reviewers (or ask us on slack if you're new)
  - 😵‍💫 **Assignees**: Assign the person responsible for finalizing the PR and resolving comments (this is probably you!)
  - 🏷️ **Label**: Add appropriate descriptors
  - ✂️ **Projects**: Select GeoIPS - All Repos and All Functionality, and other Projects as appropriate

 
- **GitHub Actions will check that you have done the following:**:
  - 🧠  **Release note**: Add a release note using [brassy](https://github.com/biosafetylvl5/brassy)
  - 🧪 **Unit tests**: Make sure your PR does not reduce code coverage (add tests if you write new code)
  - 📝 **Write docs**: If you contributed, changed or deprecated a feature, document it!

- **Related Issue**:  
  Ensure the related Issue is properly linked and finalized (follow the instructions below) 🔗

Delete this section when you're done editing and change your PR to **"Ready to Review"**! 🌈🐱

---

## ✨ Summary

Please write a short summary of the changes you made - feel free to copy things from your YAML change log!

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
