### PR TITLE
update legacy commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-       wget git libopenblas-dev g++ make gfortran \
+    wget git libopenblas-dev g++ make gfortran \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip
@@ -56,17 +56,17 @@ RUN mkdir -p "${GEOIPS_OUTDIRS}" \
     && mkdir -p "${GEOIPS_TESTDATA_DIR}" \
     && mkdir -p "${GEOIPS_PACKAGES_DIR}/geoips" \
     && chown -R "${USER}:${GROUP_ID}" \
-           "${GEOIPS_OUTDIRS}" \
-           "${GEOIPS_DEPENDENCIES_DIR}" \
-           "${GEOIPS_TESTDATA_DIR}" \
-           "${GEOIPS_PACKAGES_DIR}" \
+    "${GEOIPS_OUTDIRS}" \
+    "${GEOIPS_DEPENDENCIES_DIR}" \
+    "${GEOIPS_TESTDATA_DIR}" \
+    "${GEOIPS_PACKAGES_DIR}" \
     && if [ "${UNSAFE_PERMS}" != "False" ]; then \
-         chmod -R a+rw \
-           "${GEOIPS_OUTDIRS}" \
-           "${GEOIPS_DEPENDENCIES_DIR}" \
-           "${GEOIPS_TESTDATA_DIR}" \
-           "${GEOIPS_PACKAGES_DIR}"; \
-       fi
+    chmod -R a+rw \
+    "${GEOIPS_OUTDIRS}" \
+    "${GEOIPS_DEPENDENCIES_DIR}" \
+    "${GEOIPS_TESTDATA_DIR}" \
+    "${GEOIPS_PACKAGES_DIR}"; \
+    fi
 
 USER ${USER}
 
@@ -85,7 +85,7 @@ RUN git config --global --add safe.directory '*'
 
 # Install GeoIPS in editable mode
 RUN python -m pip install --no-cache-dir -e "." \
-    && create_plugin_registries
+    && geoips config create-registries
 
 ###############################################################################
 #                          FULL BUILD STAGE
@@ -96,7 +96,7 @@ FROM build AS full_build
 RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/" \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_install.sh \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_install.sh \
-    && create_plugin_registries
+    && geoips config create-registries
 
 ###############################################################################
 #                          SYSTEM BUILD STAGE
@@ -108,7 +108,7 @@ RUN python -m pip install --no-cache-dir -e "$GEOIPS_PACKAGES_DIR/geoips/" \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_install.sh \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_install.sh \
     && bash $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/system_install.sh \
-    && create_plugin_registries
+    && geoips config create-registries
 
 ###############################################################################
 #                          BASE TEST STAGE
@@ -179,33 +179,33 @@ USER root
 # Remove unnecessary files for smaller production image
 RUN cd "$GEOIPS_PACKAGES_DIR/geoips" \
     && rm -rf \
-       CHANGELOG_TEMPLATE.rst \
-       environments \
-       .github \
-       pyproject.toml \
-       tests \
-       CODE_OF_CONDUCT.md \
-       Dockerfile \
-       .flake8 \
-       .gitignore \
-       pytest.ini \
-       update_this_release_note \
-       bandit.yml \
-       COMMIT_MESSAGE_TEMPLATE.md \
-       .dockerignore \
-       interface_notes.md \
-       README.md \
-       CHANGELOG.rst \
-       .config \
-       docs \
-       setup \
-       requirements.txt \
+    CHANGELOG_TEMPLATE.rst \
+    environments \
+    .github \
+    pyproject.toml \
+    tests \
+    CODE_OF_CONDUCT.md \
+    Dockerfile \
+    .flake8 \
+    .gitignore \
+    pytest.ini \
+    update_this_release_note \
+    bandit.yml \
+    COMMIT_MESSAGE_TEMPLATE.md \
+    .dockerignore \
+    interface_notes.md \
+    README.md \
+    CHANGELOG.rst \
+    .config \
+    docs \
+    setup \
+    requirements.txt \
     && apt-get remove -y \
-       git \
-       make \
-       g++ \
-       wget \
-       gfortran \
+    git \
+    make \
+    g++ \
+    wget \
+    gfortran \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/source/concepts/architecture/interfaces/module_based/output-checkers/index.rst
+++ b/docs/source/concepts/architecture/interfaces/module_based/output-checkers/index.rst
@@ -59,8 +59,7 @@ Example command:
 
 .. code-block:: bash
 
-    run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/goes16/20200918/1950/* \
-                 --procflow single_source \
+    geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/goes16/20200918/1950/* \
                  --reader_name abi_netcdf \
                  --product_name Infrared \
                  --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/abi.static.<product>.imagery_annotated" \

--- a/docs/source/concepts/architecture/plugin-registries.rst
+++ b/docs/source/concepts/architecture/plugin-registries.rst
@@ -57,7 +57,7 @@ definition for ``denver``
     abspath: /local/home/user/geoips/geoips_packages/geoips/geoips/plugins/yaml/sectors/static/denver.yaml
     package: geoips
 
-when 'create_plugin_registries' is ran, an entry representing sector-plugin
+when ``geoips config create-registries`` is ran, an entry representing sector-plugin
 'denver' will be added to the registry at the path ``"yaml_based/sectors/denver"``
 as shown below:
 

--- a/docs/source/concepts/functionality/command-line/index.rst
+++ b/docs/source/concepts/functionality/command-line/index.rst
@@ -629,7 +629,7 @@ An additional output directory can be specified with ``--outdir``. For example:
 
     geoips test sector <sector_name> --outdir <output_directory_path>
 
-After creating a new sector plugin, run ``create_plugin_registries``
+After creating a new sector plugin, run ``geoips config create-registries``
 to add the sector to your registry.
 
 Once added, this command can produce an image to

--- a/docs/source/concepts/functionality/plugin-registries.rst
+++ b/docs/source/concepts/functionality/plugin-registries.rst
@@ -62,7 +62,7 @@ occurs:
 
 How to Create/Update the Plugin Registries
 ------------------------------------------
-``create_plugin_registries`` executable can be called to create or update the
+``geoips config create-registries`` executable can be called to create or update the
 plugin registries.
 
 This executable will create a separate registry for each installed GeoIPS
@@ -76,7 +76,7 @@ format as YAML rather than JSON. This is useful for debugging since YAML is,
 arguably, easier to read than JSON. The YAML registries will be ignored by
 GeoIPS, though, because they are significantly slower to load than JSON.
 
-.. admonition:: Usage: create_plugin_registries
+.. admonition:: Usage: geoips config create-registries
 
     .. autoprogram:: geoips.create_plugin_registries:get_parser()
-        :prog: create_plugin_registries
+        :prog: geoips config create-registries

--- a/docs/source/contribute/dev_mac_with_conda.rst
+++ b/docs/source/contribute/dev_mac_with_conda.rst
@@ -138,7 +138,7 @@ To test your installation you will call two scripts:
     $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_install.sh
 
     # Create the GeoIPS plugin registries
-    create_plugin_registries
+    geoips config create-registries
 
     # Run integration tests
     $GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/base_test.sh

--- a/docs/source/releases/latest/1059-update-legacy-commands.yaml
+++ b/docs/source/releases/latest/1059-update-legacy-commands.yaml
@@ -10,6 +10,7 @@ deprecation:
     commands were found. These updates do not impact any actual logic in the codebase.
   files:
     modified:
+      - Dockerfile
       - docs/source/concepts/architecture/interfaces/module_based/output-checkers/index.rst
       - docs/source/concepts/architecture/plugin-registries.rst
       - docs/source/concepts/functionality/command-line/index.rst
@@ -20,6 +21,9 @@ deprecation:
       - docs/source/tutorials/extending-with-plugins/gridline_annotator.rst
       - docs/source/tutorials/extending-with-plugins/output_formatter.rst
       - docs/source/tutorials/extending-with-plugins/product/index.rst
+      - geoips/commandline/geoips_test.py
+      - geoips/create_plugin_registries.py
+      - geoips/geoips_utils.py
       - tests/integration_tests/full_install.sh
       - tests/integration_tests/site_install.sh
       - tests/scripts/abi.static.Infrared.netcdf_geoips.sh
@@ -44,6 +48,7 @@ deprecation:
       - tests/scripts/viirs.static.visible.imagery_clean.sh
       - tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.imagery_annotated.sh
       - tests/scripts/viirsday.global.Night-Vis-IR.cogeotiff_rgba.sh
+      - tests/unit_tests/plugins/test_get_plugin.py
   related-issue:
     number: 1059
     repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips/'

--- a/docs/source/releases/latest/1059-update-legacy-commands.yaml
+++ b/docs/source/releases/latest/1059-update-legacy-commands.yaml
@@ -1,3 +1,4 @@
+# :cspell: ignore viirsday
 deprecation:
 - title: 'Update Legacy Commands'
   description: |

--- a/docs/source/releases/latest/1059-update-legacy-commands.yaml
+++ b/docs/source/releases/latest/1059-update-legacy-commands.yaml
@@ -1,0 +1,51 @@
+deprecation:
+- title: 'Update Legacy Commands'
+  description: |
+    This PR updates all references to legacy GeoIPS commands (I.e.
+    'create_plugin_registries' and 'run_procflow') to use their new counterparts (
+    'geoips config create-registries' and 'geoips run <procflow_name>', respectively).
+
+    This includes updates to scripts, docstrings, and documentation where the offending
+    commands were found. These updates do not impact any actual logic in the codebase.
+  files:
+    modified:
+      - docs/source/concepts/architecture/interfaces/module_based/output-checkers/index.rst
+      - docs/source/concepts/architecture/plugin-registries.rst
+      - docs/source/concepts/functionality/command-line/index.rst
+      - docs/source/concepts/functionality/plugin-registries.rst
+      - docs/source/contribute/dev_mac_with_conda.rst
+      - docs/source/tutorials/extending-with-plugins/colormapper/index.rst
+      - docs/source/tutorials/extending-with-plugins/feature_annotator/index.rst
+      - docs/source/tutorials/extending-with-plugins/gridline_annotator.rst
+      - docs/source/tutorials/extending-with-plugins/output_formatter.rst
+      - docs/source/tutorials/extending-with-plugins/product/index.rst
+      - tests/integration_tests/full_install.sh
+      - tests/integration_tests/site_install.sh
+      - tests/scripts/abi.static.Infrared.netcdf_geoips.sh
+      - tests/scripts/ami.WV-Upper.unprojected_image.sh
+      - tests/scripts/ami.static.Infrared.imagery_clean.sh
+      - tests/scripts/ami.static.Visible.imagery_clean.sh
+      - tests/scripts/ami.tc.WV.geotiff.sh
+      - tests/scripts/amsr2.global.89H-Physical.cogeotiff.sh
+      - tests/scripts/amsr2.tc.89H-Physical.histogram_netcdf.sh
+      - tests/scripts/aws_TB165.imagery_clean.sh
+      - tests/scripts/aws_TB180.imagery_clean.sh
+      - tests/scripts/aws_TB325-1.imagery_clean.sh
+      - tests/scripts/aws_TB50.imagery_clean.sh
+      - tests/scripts/aws_TB89.imagery_clean.sh
+      - tests/scripts/aws_tc_TB165.imagery_clean.sh
+      - tests/scripts/aws_tc_TB180.imagery_clean.sh
+      - tests/scripts/aws_tc_TB325-1.imagery_clean.sh
+      - tests/scripts/aws_tc_TB50.imagery_clean.sh
+      - tests/scripts/aws_tc_TB89.imagery_clean.sh
+      - tests/scripts/gfs.static.waveheight.imagery_clean.sh
+      - tests/scripts/gfs.static.windspeed.imagery_clean.sh
+      - tests/scripts/viirs.static.visible.imagery_clean.sh
+      - tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.imagery_annotated.sh
+      - tests/scripts/viirsday.global.Night-Vis-IR.cogeotiff_rgba.sh
+  related-issue:
+    number: 1059
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips/'
+  date:
+    start: 12/08/2025
+    finish: 12/08/2025

--- a/docs/source/tutorials/extending-with-plugins/colormapper/index.rst
+++ b/docs/source/tutorials/extending-with-plugins/colormapper/index.rst
@@ -326,9 +326,8 @@ done that, copy and paste the code below into that file.
 
 .. code-block:: bash
 
-    run_procflow \
+    geoips run single_source \
         $GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-        --procflow single_source \
         --reader_name clavrx_hdf4 \
         --product_name "Cloud-Base-Python-Colors" \
         --output_formatter imagery_annotated \

--- a/docs/source/tutorials/extending-with-plugins/feature_annotator/index.rst
+++ b/docs/source/tutorials/extending-with-plugins/feature_annotator/index.rst
@@ -127,9 +127,8 @@ annotator
 
 .. code-block:: bash
 
-  run_procflow \
+  geoips run single_source \
       $GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-      --procflow single_source \
       --reader_name clavrx_hdf4 \
       --product_name My-Cloud-Depth \
       --output_formatter imagery_annotated \

--- a/docs/source/tutorials/extending-with-plugins/gridline_annotator.rst
+++ b/docs/source/tutorials/extending-with-plugins/gridline_annotator.rst
@@ -119,9 +119,8 @@ Copy and paste the code below into that file, which will use our new gridline an
 
 .. code-block:: bash
 
-  run_procflow \
+  geoips run single_source \
       GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-      --procflow single_source \
       --reader_name clavrx_hdf4 \
       --product_name My-Cloud-Depth \
       --output_formatter imagery_annotated \

--- a/docs/source/tutorials/extending-with-plugins/output_formatter.rst
+++ b/docs/source/tutorials/extending-with-plugins/output_formatter.rst
@@ -167,9 +167,8 @@ copy and paste the code below into that file.
 
 .. code-block:: bash
 
-  run_procflow \
+  geoips run single_source \
       $GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-      --procflow single_source \
       --reader_name clavrx_hdf4 \
       --product_name My-Cloud-Top-Height \
       --output_formatter my_netcdf_output \

--- a/docs/source/tutorials/extending-with-plugins/product/index.rst
+++ b/docs/source/tutorials/extending-with-plugins/product/index.rst
@@ -70,17 +70,18 @@ they just describe what each property does.
             variables: ["cld_height_acha", "latitude", "longitude"]
 
 To use your product that you just created, you'll need to create a bash script that
-implements ``run_procflow`` (run-process-workflow). This is a script which defines the
-*process-workflow* needed to generate your product. We'll keep this short for now, but you
-are able to strictly define how you want your product to be created, as well as what
-format you'd like it outputted as. You can also define the sector you'd like your data
-to be plotted on, as well as compare the output product to a validated product if wanted.
+implements ``geoips run <procflow_name>`` (run-process-workflow). This is a script which
+defines the *process-workflow* needed to generate your product. We'll keep this short
+for now, but you are able to strictly define how you want your product to be created, as
+well as what format you'd like it outputted as. You can also define the sector you'd
+like your data to be plotted on, as well as compare the output product to a validated
+product if wanted.
 
-GeoIPS is called via a command line interface (CLI). The main command that you will use is
-run_procflow which will run your data through the selected procflow using the specified
-plugins. It's easiest to do this via a script, and scripts are stored in your plugin
-package's ``tests/`` directory because they can be used later to regression test your
-package.
+GeoIPS is called via a command line interface (CLI). The main command that you will use
+is ``geoips run <procflow_name>`` which will run your data through the selected procflow
+using the specified plugins. It's easiest to do this via a script, and scripts are
+stored in your plugin package's ``tests/`` directory because they can be used later to
+regression test your package.
 
 Creating a Script to Visualize Your Product
 -------------------------------------------
@@ -97,9 +98,8 @@ We'll now create a test script to generate an image for the product you just cre
 
 .. code-block:: bash
 
-    run_procflow \
+    geoips run single_source \
         $GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-        --procflow single_source \
         --reader_name clavrx_hdf4 \
         --product_name My-Cloud-Top-Height \
         --output_formatter imagery_annotated \
@@ -294,9 +294,8 @@ like the code shown below.
 
 .. code-block:: bash
 
-  run_procflow \
+  geoips run single_source \
       $GEOIPS_TESTDATA_DIR/test_data_clavrx/data/goes16_2023101_1600/clavrx_OR_ABI-L1b-RadF-M6C01_G16_s20231011600207.level2.hdf \
-      --procflow single_source \
       --reader_name clavrx_hdf4 \
       --product_name My-Cloud-Depth \
       --output_formatter imagery_annotated \

--- a/geoips/commandline/geoips_test.py
+++ b/geoips/commandline/geoips_test.py
@@ -194,7 +194,7 @@ class GeoipsTestSector(GeoipsExecutableCommand):
             raise self.parser.error(
                 f"Sector '{sector_name}' is not a valid plugin.\nPlease use a plugin "
                 "found under 'geoips list interface sectors' or create a new plugin "
-                f"named '{sector_name}' and run 'create_plugin_registries'."
+                f"named '{sector_name}' and run 'geoips config create-registries'."
             )
         print(f"Creating {fname}.")
         sect.create_test_plot(fname, overlay=overlay)

--- a/geoips/create_plugin_registries.py
+++ b/geoips/create_plugin_registries.py
@@ -89,7 +89,7 @@ def remove_registries(plugin_packages):
     LOG.interactive(
         "\n\n\n\nERROR: Removing registries due to improperly formatted plugins.\n"
         "You must fix the error(s) shown below before GeoIPS can operate correctly.\n"
-        "Once fixed, please run 'create_plugin_registries' to set up GeoIPS "
+        "Once fixed, please run 'geoips config create-registries' to set up GeoIPS "
         "appropriately\n\n\n"
     )
     # Remove registered_plugins.yaml and registered_plugins.json if they exist
@@ -903,7 +903,7 @@ def add_module_plugin(package, relpath, plugins):
                     f" plugin '{name}' is using a deprecated source_names "
                     "implementation. Please add a module-level 'source_names' "
                     "attribute to this plugin and re-run "
-                    "'create_plugin_registries'. This will be fully deprecated "
+                    "'geoips config create-registries'. This will be fully deprecated "
                     "when GeoIPS v2.0.0 is released."
                 ),
                 DeprecationWarning,

--- a/geoips/geoips_utils.py
+++ b/geoips/geoips_utils.py
@@ -105,7 +105,7 @@ def load_all_yaml_plugins():
         if not os.path.exists(pkg_plug_path):
             raise PluginRegistryError(
                 f"Plugin registry {pkg_plug_path} did not exist, "
-                "please run 'create_plugin_registries'"
+                "please run 'geoips config create-registries'"
             )
         # This will include all plugins, including schemas, yaml_based,
         # and module_based plugins.

--- a/tests/integration_tests/full_install.sh
+++ b/tests/integration_tests/full_install.sh
@@ -29,5 +29,5 @@ if [[ "$include_reference_repos" == "true" ]]; then
   geoips config install test_data_modis test_data_smos test_data_tpw
 fi
 
-create_plugin_registries
+geoips config create-registries
 

--- a/tests/integration_tests/site_install.sh
+++ b/tests/integration_tests/site_install.sh
@@ -27,7 +27,7 @@ fi
 . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh source_repo template_basic_plugin $test_exit $install_script
 geoips config install test_data_amsub test_data_atms test_data_arctic_weather_satellite test_data_cygnss test_data_fci \
                       test_data_gfs test_data_tpw test_data_clavrx test_data_modis test_data_saphir \
-                      test_data_fusion test_data_smos 
+                      test_data_fusion test_data_smos
 
 if [[ "$include_reference_repos" == "true" ]]; then
   # Currently these need to be installed in this order, until the fortran pyproject.toml builds are working.
@@ -47,4 +47,4 @@ if [[ "$include_reference_repos" == "true" ]]; then
   # . $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data_github test_data_mint_analysis $test_exit $install_script
 fi
 
-create_plugin_registries
+geoips config create-registries

--- a/tests/scripts/abi.static.Infrared.netcdf_geoips.sh
+++ b/tests/scripts/abi.static.Infrared.netcdf_geoips.sh
@@ -7,8 +7,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/goes16/20200918/1950/* \
-             --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/goes16/20200918/1950/* \
              --reader_name abi_netcdf \
              --product_name Infrared \
              --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/abi.static.<product>.netcdf_geoips" \

--- a/tests/scripts/ami.WV-Upper.unprojected_image.sh
+++ b/tests/scripts/ami.WV-Upper.unprojected_image.sh
@@ -5,8 +5,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
-             --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
              --reader_name ami_netcdf \
              --reader_kwargs '{"self_register": "LOW"}' \
              --product_name WV-Upper \

--- a/tests/scripts/ami.static.Infrared.imagery_clean.sh
+++ b/tests/scripts/ami.static.Infrared.imagery_clean.sh
@@ -5,8 +5,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
-             --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
              --reader_name ami_netcdf \
              --product_name Infrared \
              --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/ami.static.<product>.imagery_clean" \

--- a/tests/scripts/ami.static.Visible.imagery_clean.sh
+++ b/tests/scripts/ami.static.Visible.imagery_clean.sh
@@ -5,8 +5,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
-             --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
              --reader_name ami_netcdf \
              --product_name Visible \
              --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/ami.static.<product>.imagery_clean" \

--- a/tests/scripts/ami.tc.WV.geotiff.sh
+++ b/tests/scripts/ami.tc.WV.geotiff.sh
@@ -7,8 +7,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
-          --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_noaa_aws/data/geokompsat/20231208/0300/*.nc \
           --reader_name ami_netcdf \
           --product_name WV \
           --filename_formatter geotiff_fname \

--- a/tests/scripts/amsr2.global.89H-Physical.cogeotiff.sh
+++ b/tests/scripts/amsr2.global.89H-Physical.cogeotiff.sh
@@ -7,8 +7,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_amsr2/data/AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc \
-          --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_amsr2/data/AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc \
           --reader_name amsr2_netcdf \
           --product_name 89H-Physical \
           --filename_formatter geotiff_fname \

--- a/tests/scripts/amsr2.tc.89H-Physical.histogram_netcdf.sh
+++ b/tests/scripts/amsr2.tc.89H-Physical.histogram_netcdf.sh
@@ -7,8 +7,7 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_amsr2/data/AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc \
-          --procflow single_source \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_amsr2/data/AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc \
           --reader_name amsr2_netcdf \
           --reader_kwargs \
             '{"test_arg": "AMSR2 single source command line reader test_arg"}' \

--- a/tests/scripts/aws_TB165.imagery_clean.sh
+++ b/tests/scripts/aws_TB165.imagery_clean.sh
@@ -7,9 +7,8 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250416/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250416161751_G_O_20250416142833_20250416160447*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB165 \
     --filename_formatter geoips_fname \

--- a/tests/scripts/aws_TB180.imagery_clean.sh
+++ b/tests/scripts/aws_TB180.imagery_clean.sh
@@ -7,9 +7,8 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250416/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250416161751_G_O_20250416142833_20250416160447*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB180 \
     --filename_formatter geoips_fname  \

--- a/tests/scripts/aws_TB325-1.imagery_clean.sh
+++ b/tests/scripts/aws_TB325-1.imagery_clean.sh
@@ -7,9 +7,8 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250416/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250416161751_G_O_20250416142833_20250416160447*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB325-1 \
     --filename_formatter geoips_fname  \

--- a/tests/scripts/aws_TB50.imagery_clean.sh
+++ b/tests/scripts/aws_TB50.imagery_clean.sh
@@ -7,9 +7,8 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250416/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250416161751_G_O_20250416142833_20250416160447*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB50 \
     --filename_formatter geoips_fname  \

--- a/tests/scripts/aws_TB89.imagery_clean.sh
+++ b/tests/scripts/aws_TB89.imagery_clean.sh
@@ -7,9 +7,8 @@
 
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250416/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250416161751_G_O_20250416142833_20250416160447*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB89 \
     --filename_formatter geoips_fname  \

--- a/tests/scripts/aws_tc_TB165.imagery_clean.sh
+++ b/tests/scripts/aws_tc_TB165.imagery_clean.sh
@@ -8,9 +8,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250428/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250428133939*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB165 \
     --filename_formatter tc_clean_fname  \

--- a/tests/scripts/aws_tc_TB180.imagery_clean.sh
+++ b/tests/scripts/aws_tc_TB180.imagery_clean.sh
@@ -8,9 +8,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250428/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250428133939*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB180 \
     --filename_formatter tc_clean_fname  \

--- a/tests/scripts/aws_tc_TB325-1.imagery_clean.sh
+++ b/tests/scripts/aws_tc_TB325-1.imagery_clean.sh
@@ -8,9 +8,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250428/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250428133939*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB325-1 \
     --filename_formatter tc_clean_fname  \

--- a/tests/scripts/aws_tc_TB50.imagery_clean.sh
+++ b/tests/scripts/aws_tc_TB50.imagery_clean.sh
@@ -8,9 +8,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250428/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250428133939*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB50 \
     --filename_formatter tc_clean_fname  \

--- a/tests/scripts/aws_tc_TB89.imagery_clean.sh
+++ b/tests/scripts/aws_tc_TB89.imagery_clean.sh
@@ -8,9 +8,8 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow \
+geoips run single_source \
     $GEOIPS_TESTDATA_DIR/test_data_arctic_weather_satellite/data/20250428/W_NO-KSAT-Tromso%2CSAT%2CAWS1-MWR-1B-RAD_C_OHB__20250428133939*.nc \
-    --procflow single_source \
     --reader_name aws_netcdf \
     --product_name TB89 \
     --filename_formatter tc_clean_fname  \

--- a/tests/scripts/gfs.static.waveheight.imagery_clean.sh
+++ b/tests/scripts/gfs.static.waveheight.imagery_clean.sh
@@ -4,14 +4,13 @@
 #!/bin/bash
 
 geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_gfs/data/gfswave.t06z.wcoast.0p16.f000.grib2 \
-    --procflow single_source \
     --reader_name gfs_grib \
     --output_formatter imagery_clean \
     --filename_formatter geoips_fname \
     --sector_list conus \
     --minimum_coverage 0 \
     --product_name Model-WaveHeight \
-    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/gfs.static.waveheight.imagery_clean" 
+    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/gfs.static.waveheight.imagery_clean"
 
 ss_retval=$?
 

--- a/tests/scripts/gfs.static.windspeed.imagery_clean.sh
+++ b/tests/scripts/gfs.static.windspeed.imagery_clean.sh
@@ -4,14 +4,13 @@
 #!/bin/bash
 
 geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_gfs/data/gfs.t06z.pgrb2.0p25.f000 \
-    --procflow single_source \
     --reader_name gfs_grib \
     --output_formatter imagery_clean \
     --filename_formatter geoips_fname \
     --sector_list himawari \
     --minimum_coverage 0 \
     --product_name Model-Windspeed \
-    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/gfs.static.windspeed.imagery_clean" 
+    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/gfs.static.windspeed.imagery_clean"
 
 ss_retval=$?
 

--- a/tests/scripts/viirs.static.visible.imagery_clean.sh
+++ b/tests/scripts/viirs.static.visible.imagery_clean.sh
@@ -4,14 +4,13 @@
 #!/bin/bash
 
 geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_viirs/data/j02_sdr_20240925/*.h5 \
-    --procflow single_source \
     --reader_name viirs_sdr_hdf5 \
     --output_formatter imagery_clean \
     --filename_formatter geoips_fname \
     --sector_list se_asia \
     --minimum_coverage 0 \
     --product_name Visible \
-    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/viirs.static.visible.imagery_clean" 
+    --compare_path "$GEOIPS_PACKAGES_DIR/geoips/tests/outputs/viirs.static.visible.imagery_clean"
 
 ss_retval=$?
 

--- a/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.imagery_annotated.sh
+++ b/tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.imagery_annotated.sh
@@ -8,13 +8,12 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP02DNB.A2024017.1724.002.2024018012054.nc \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP02DNB.A2024017.1724.002.2024018012054.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP02IMG.A2024017.1724.002.2024018012054.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP02MOD.A2024017.1724.002.2024018012054.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP03DNB.A2024017.1724.002.2024018003923.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP03IMG.A2024017.1724.002.2024018003923.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/npp/20240117/172400/VNP03MOD.A2024017.1724.002.2024018003923.nc \
-             --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Night-Vis-IR-GeoIPS1 \
              --output_formatter imagery_annotated \

--- a/tests/scripts/viirsday.global.Night-Vis-IR.cogeotiff_rgba.sh
+++ b/tests/scripts/viirsday.global.Night-Vis-IR.cogeotiff_rgba.sh
@@ -8,7 +8,7 @@
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
 # set of arguments.
 
-run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102DNB.A2021040.0736.002.2021040145245.nc \
+geoips run single_source $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102DNB.A2021040.0736.002.2021040145245.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ102MOD.A2021040.0736.002.2021040145245.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103DNB.A2021040.0736.002.2021040142228.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ103MOD.A2021040.0736.002.2021040142228.nc \
@@ -16,7 +16,6 @@ run_procflow $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/073600/VJ10
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ102MOD.A2021040.0742.002.2021040143010.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103DNB.A2021040.0742.002.2021040140938.nc \
              $GEOIPS_TESTDATA_DIR/test_data_viirs/data/jpss/20210209/074200/VJ103MOD.A2021040.0742.002.2021040140938.nc \
-             --procflow single_source \
              --reader_name viirs_netcdf \
              --product_name Night-Vis-IR \
              --filename_formatter geotiff_fname \

--- a/tests/unit_tests/plugins/test_get_plugin.py
+++ b/tests/unit_tests/plugins/test_get_plugin.py
@@ -67,8 +67,8 @@ def yield_interface_plugin_tuples():
     registry["module_based"]["algorithms"][
         "out_of_sync_single_channel"
     ] = single_channel_entry
-    # Test that an out of sync plugin causes 'create_plugin_registries' to be ran so it
-    # is synced up again
+    # Test that an out of sync plugin causes 'geoips config create-registries' to be
+    # ran so it is synced up again
     yield ("algorithms", ("single_channel",), "out_of_sync")
     reload(plugin_registry_module)
     registry = plugin_registry_module.plugin_registry.registered_plugins


### PR DESCRIPTION
## ✨ Summary

This PR updates all references to legacy GeoIPS commands (I.e.
'create_plugin_registries' and 'run_procflow') to use their new counterparts (
'geoips config create-registries' and 'geoips run <procflow_name>', respectively).

This includes updates to scripts, docstrings, and documentation where the offending
commands were found. These updates do not impact any actual logic in the codebase.

Files modified:

    - Dockerfile
    - docs/source/concepts/architecture/interfaces/module_based/output-checkers/index.rst
    - docs/source/concepts/architecture/plugin-registries.rst
    - docs/source/concepts/functionality/command-line/index.rst
    - docs/source/concepts/functionality/plugin-registries.rst
    - docs/source/contribute/dev_mac_with_conda.rst
    - docs/source/tutorials/extending-with-plugins/colormapper/index.rst
    - docs/source/tutorials/extending-with-plugins/feature_annotator/index.rst
    - docs/source/tutorials/extending-with-plugins/gridline_annotator.rst
    - docs/source/tutorials/extending-with-plugins/output_formatter.rst
    - docs/source/tutorials/extending-with-plugins/product/index.rst
    - geoips/commandline/geoips_test.py
    - geoips/create_plugin_registries.py
    - geoips/geoips_utils.py
    - tests/integration_tests/full_install.sh
    - tests/integration_tests/site_install.sh
    - tests/scripts/abi.static.Infrared.netcdf_geoips.sh
    - tests/scripts/ami.WV-Upper.unprojected_image.sh
    - tests/scripts/ami.static.Infrared.imagery_clean.sh
    - tests/scripts/ami.static.Visible.imagery_clean.sh
    - tests/scripts/ami.tc.WV.geotiff.sh
    - tests/scripts/amsr2.global.89H-Physical.cogeotiff.sh
    - tests/scripts/amsr2.tc.89H-Physical.histogram_netcdf.sh
    - tests/scripts/aws_TB165.imagery_clean.sh
    - tests/scripts/aws_TB180.imagery_clean.sh
    - tests/scripts/aws_TB325-1.imagery_clean.sh
    - tests/scripts/aws_TB50.imagery_clean.sh
    - tests/scripts/aws_TB89.imagery_clean.sh
    - tests/scripts/aws_tc_TB165.imagery_clean.sh
    - tests/scripts/aws_tc_TB180.imagery_clean.sh
    - tests/scripts/aws_tc_TB325-1.imagery_clean.sh
    - tests/scripts/aws_tc_TB50.imagery_clean.sh
    - tests/scripts/aws_tc_TB89.imagery_clean.sh
    - tests/scripts/gfs.static.waveheight.imagery_clean.sh
    - tests/scripts/gfs.static.windspeed.imagery_clean.sh
    - tests/scripts/viirs.static.visible.imagery_clean.sh
    - tests/scripts/viirsclearnight.Night-Vis-IR-GeoIPS1.imagery_annotated.sh
    - tests/scripts/viirsday.global.Night-Vis-IR.cogeotiff_rgba.sh
    - tests/unit_tests/plugins/test_get_plugin.py

---
## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

---
## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips#1059
- **Fixes:** NRLMMD-GEOIPS/geoips#1227

---

## 🧪 Testing Instructions

Run ``pytest -v`` from the top level directory of your GeoIPS package.