### PR TITLE
Add new image modes to image output checker unit tests

### DIFF
--- a/geoips/plugins/classes/output_checkers/image.py
+++ b/geoips/plugins/classes/output_checkers/image.py
@@ -3,6 +3,8 @@
 
 """Test script for representative product comparisons."""
 
+# cspell:ignore RGBX
+
 import logging
 from PIL import Image
 import numpy as np
@@ -35,6 +37,13 @@ class ImageOutputCheckerPlugin(BaseOutputCheckerPlugin):
             makedirs(savedir)
 
         thresholds = ["lenient", "medium", "strict"]
+        # I decided to use these modes from inspecting the
+        # PIL.ImageMode:ModeDescriptor:getmode function. In a comment, it's denoted that
+        # these are the core image modes.
+        # ndim2 = ["1", "L", "I", "F", "P"]
+        ndim3 = ["RGB", "RGBX", "RGBA", "CMYK", "YCbCr"]
+        # image_modes = [*ndim2, *ndim3]
+        image_modes = [*ndim3]
         # thresholds is used for naming files.
         # Relates to thresholds [0.1, 0.05, 0.0]
         compare_files = []
@@ -42,23 +51,41 @@ class ImageOutputCheckerPlugin(BaseOutputCheckerPlugin):
 
         predictable_random = get_numpy_seeded_random_generator()
 
-        for threshold in thresholds:
-            for i in range(3):
-                comp_arr = predictable_random.rand(100, 100, 3)
-                test_arr = np.copy(comp_arr)
-                if i == 1:
-                    rand = predictable_random.randint(0, 100)
-                    test_arr[rand][:] = predictable_random.rand(3)
-                elif i == 2:
-                    test_arr = predictable_random.rand(100, 100, 3)
-                comp_img = Image.fromarray((comp_arr * 255).astype(np.uint8))
-                test_img = Image.fromarray((test_arr * 255).astype(np.uint8))
-                comp_file = join(savedir, f"comp_img_{threshold}{str(i)}.png")
-                test_file = join(savedir, f"test_img_{threshold}{str(i)}.png")
-                comp_img.save(comp_file)
-                test_img.save(test_file)
-                compare_files.append(comp_file)
-                test_files.append(test_file)
+        for mode in image_modes:
+            for threshold in thresholds:
+                for i in range(3):
+                    if mode in ["1", "L", "I", "P", "F"]:
+                        shape = (100, 100)
+                    else:
+                        shape = (100, 100, 3)
+                    comp_arr = predictable_random.random(shape)
+                    test_arr = np.copy(comp_arr)
+                    if i == 1:
+                        rand = predictable_random.random((100,)).round().astype(int)
+                        if len(shape) == 3:
+                            test_arr[rand][:] = predictable_random.random((3))
+                        else:
+                            test_arr[rand][:] = predictable_random.random()
+
+                    elif i == 2:
+                        test_arr = predictable_random.random(shape)
+                    print(comp_arr.shape)
+                    comp_img = Image.fromarray(
+                        (comp_arr * 255).astype(np.uint8), mode=mode
+                    )
+                    test_img = Image.fromarray(
+                        (test_arr * 255).astype(np.uint8), mode=mode
+                    )
+                    comp_file = join(
+                        savedir, f"comp_img_{mode}_{threshold}{str(i)}.png"
+                    )
+                    test_file = join(
+                        savedir, f"test_img_{mode}_{threshold}{str(i)}.png"
+                    )
+                    comp_img.save(comp_file)
+                    test_img.save(test_file)
+                    compare_files.append(comp_file)
+                    test_files.append(test_file)
         return compare_files, test_files
 
     def perform_test_comparisons(self, compare_files, test_files):

--- a/tests/unit_tests/plugins/modules/output_checkers/test_output_checkers.py
+++ b/tests/unit_tests/plugins/modules/output_checkers/test_output_checkers.py
@@ -31,7 +31,7 @@ class TestOutputCheckers:
             compare_paths, output_paths = plugin.get_test_files(permanent_test_data_dir)
         else:
             compare_paths, output_paths = plugin.get_test_files(tmp_path)
-        plugin.perform_test_comparisons(plugin, compare_paths, output_paths)
+        plugin.perform_test_comparisons(compare_paths, output_paths)
 
     @pytest.mark.parametrize("checker_name", available_output_checkers)
     def test_plugins(self, tmp_path, checker_name):
@@ -41,10 +41,10 @@ class TestOutputCheckers:
         # supported.  For now, xfail if we come across a "long" unit test.
         # We will eventually implement "long" running unit tests, but for
         # not just xfail.
-        if hasattr(plugin, "get_test_files_long") or not hasattr(
-            plugin, "perform_test_comparisons_long"
-        ):
-            pytest.xfail(checker_name + " should be run with the long unit tests.")
+        # if hasattr(plugin, "get_test_files_long") or not hasattr(
+        #     plugin, "perform_test_comparisons_long"
+        # ):
+        #     pytest.xfail(checker_name + " should be run with the long unit tests.")
         if not hasattr(plugin, "get_test_files") or not hasattr(
             plugin, "perform_test_comparisons"
         ):


### PR DESCRIPTION
## ✨ Summary

Please write a short summary of the changes you made - feel free to copy things from your YAML change log!

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ] **Full test**: Yes, full test *is passing*.
- [ ] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
