### PR TITLE
Adding missing init file in memusg directory

### DIFF
--- a/docs/source/releases/latest/1292-adding-memusg-init.yaml
+++ b/docs/source/releases/latest/1292-adding-memusg-init.yaml
@@ -1,0 +1,20 @@
+bug fix:
+- title: 'Adding missing init file in memusg directory'
+  description: |
+    GeoIPS pytest causes many errors because of a missing __init__.py file in the /geoips/utils/memusg directory.
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - 'docs/source/releases/latest/1292-adding-memusg-init.yaml'
+    - 'geoips/utils/memusg/__init__.py'
+    modified:
+    - ''
+  related-issue:
+    number: 1293
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips'
+  date:
+    start: 2026/04/14
+    finish: 2026/04/14

--- a/geoips/utils/memusg/__init__.py
+++ b/geoips/utils/memusg/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for memory usage tracking and reporting."""
+
+from geoips.utils.memusg.memusg_tracker import PidLog, print_mem_usage
+
+__all__ = ["PidLog", "print_mem_usage"]


### PR DESCRIPTION


## ✨ Summary

GeoIPS pytest causes many errors because of a missing __init__.py file in the /geoips/utils/memusg directory.

Adding the missing file, along with brassy documentation for the PR.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [X] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [X] **Full test**: Yes, full test *is passing*.
- [X] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [X] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips#1292
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

`pytest`

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`


---

💖🌟🌎🌟💖
