### PR TITLE
Replace import of Console with Console from rich.console

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -18,7 +18,7 @@ import brassy.actions.build_release_notes as brassy_build
 import brassy.utils.CLI  # noqa # because of a brassy bug; will be fixed in next vers
 from rich.logging import RichHandler
 from rich.traceback import install as install_rich_tracebacks
-from rich.logging import Console
+from rich.console import Console
 from rich.progress import Progress
 import rich_argparse
 import pygit2

--- a/docs/source/releases/latest/biosafetylvl5-patch-4.yaml
+++ b/docs/source/releases/latest/biosafetylvl5-patch-4.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Fix broken docs imports'
+  description: 'This fixes rich imports.'
+  files:
+    modified:
+    - 'docs/build_docs.py'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/docs/source/releases/latest/biosafetylvl5-patch-4.yaml
+++ b/docs/source/releases/latest/biosafetylvl5-patch-4.yaml
@@ -10,3 +10,14 @@ bug fix:
   date:
     start: null
     finish: null
+- title: 'Fix broken memusg imports'
+  description: 'Use relative imports to fix broken imports in memusg.'
+  files:
+    modified:
+    - 'geoips/utils/memusg/plot_json_files.py'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/geoips/utils/memusg/plot_json_files.py
+++ b/geoips/utils/memusg/plot_json_files.py
@@ -11,8 +11,8 @@ import isodate
 from pathlib import Path
 import pytz
 
-from boxplots import boxplot, checkpoint_boxplot
-from dataframe_utils import create_checkpoint_dataframe, sort_resource_stats
+from .boxplots import boxplot, checkpoint_boxplot
+from .dataframe_utils import create_checkpoint_dataframe, sort_resource_stats
 
 # Geoips libraries
 from geoips.filenames.base_paths import PATHS as gpaths


### PR DESCRIPTION
## ✨ Summary

[x] This fixes broken imports on all docs builds..... the old syntax was deprecated in 2020!!
[x] Also fixes memusg import problems by using relative imports

This should pass CI now.