### PR TITLE
Update Order-Based Procflow documentation

### DIFF
--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -111,7 +111,7 @@ Output Formatter step in the code block below includes two additional plugins,
     package: geoips
     spec:
       steps:
-        reader_1:
+        read_data:
           kind: reader
           name: abi_netcdf
           arguments:

--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -116,6 +116,17 @@ Output Formatter step in the code block below includes two additional plugins,
       command_line_args:
         compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
       logging_level: info
+    test:
+      fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_abi/data/goes16_20200918_1950/*
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      overrides:
+        steps:
+          - abi_Infrared.spec.steps.algorithm.output_units='Kelvin'
+        kinds:
+          - readers.self_register=False
+        globals:
+          - sector_list='global_cylindrical'
+          - logging_level='info'
     spec:
       global-arguments:
         window_start_time: None

--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -104,8 +104,10 @@ Output Formatter step in the code block below includes two additional plugins,
 
 .. code-block:: yaml
 
+    apiVersion: geoips/v1
     interface: products
     family: order_based
+    is_registered: false
     name: read_test
     docstring: Read test.
     package: geoips

--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -110,6 +110,15 @@ Output Formatter step in the code block below includes two additional plugins,
     docstring: Read test.
     package: geoips
     spec:
+      global-arguments:
+        window_start_time: None
+        window_end_time: None
+        product_name: None
+        reader_defined_area_def: False
+        no_presectoring: True
+        product_db: False
+        product_db_writer: None
+        product_db_writer_kwargs: None
       steps:
         read_data:
           kind: reader

--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -113,11 +113,6 @@ Output Formatter step in the code block below includes two additional plugins,
     package: geoips
     test:
       fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_abi/data/goes16_20200918_1950/*
-      command_line_args:
-        compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
-      logging_level: info
-    test:
-      fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_abi/data/goes16_20200918_1950/*
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
       overrides:
         steps:

--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -111,6 +111,11 @@ Output Formatter step in the code block below includes two additional plugins,
     name: read_test
     docstring: Read test.
     package: geoips
+    test:
+      fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_abi/data/goes16_20200918_1950/*
+      command_line_args:
+        compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      logging_level: info
     spec:
       global-arguments:
         window_start_time: None

--- a/docs/source/releases/latest/1302-update-order-based-procflow-documentation.yaml
+++ b/docs/source/releases/latest/1302-update-order-based-procflow-documentation.yaml
@@ -1,0 +1,18 @@
+documentation:
+- title: 'Update Order-Based Procflow documentation'
+  description: 'Align the OBP workflow example with the latest changes'
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'docs/dev/order_based_procflow.rst'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null


### PR DESCRIPTION
## ✨ Summary

This PR is intended to update the OBP workflow example in the documentation to reflect the latest changes. 

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
