### PR TITLE
Add `PLUGIN_PROIVDED` as an additional default value in OBP Pydantic models.

### DIFF
--- a/docs/dev/order_based_procflow.rst
+++ b/docs/dev/order_based_procflow.rst
@@ -182,7 +182,7 @@ Output Formatter step in the code block below includes two additional plugins,
                 kind: colormapper
                 name: Infrared
                 arguments:
-                  data_range: [-90.0, 30.0]
+                  data_range: PLUGIN_PROVIDED
             apply_geoips_fname_filename_formatter:
                 kind: filename_formatter
                 name: geoips_fname

--- a/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
+++ b/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
@@ -1,0 +1,21 @@
+feature:
+- title: 'Add PLUGIN_PROIVDED as an additional default value in OBP Pydantic models'
+  description: 'This PR introduces a new default value called PLUGIN_PROVIDED that would help us to sanitize the workflow: drop the fields/arguments with the value = "PLUGIN_PROVIDED". This will make these fields omitted letting the call signature fill in the required default value.'
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - 'tests/unit_tests/plugins/modules/procflows/conftest.py'
+    - 'tests/unit_tests/plugins/modules/procflows/test_obp_utils.py'
+    - 'geoips/docs/source/releases/latest/update-dev-staging.yaml'
+    - 'geoips/plugins/modules/procflows/obp_utils.py'
+    modified:
+    - 'geoips/plugins/modules/procflows/order_based.py'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
+++ b/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
@@ -1,6 +1,15 @@
 feature:
 - title: 'Add PLUGIN_PROIVDED as an additional default value in OBP Pydantic models'
-  description: 'This PR introduces a new default value called PLUGIN_PROVIDED that would help us to sanitize the workflow: drop the fields/arguments with the value = "PLUGIN_PROVIDED". This will make these fields omitted letting the call signature fill in the required default value.'
+  description: | 
+    'This PR introduces a new default value called PLUGIN_PROVIDED that would help us to
+     sanitize the workflow: drop the fields/arguments with the value = "PLUGIN_PROVIDED".
+      This will make these fields omitted letting the call signature fill in the required
+       default value.'
+
+    Note-1: This is a breaking change.
+    Note-2: If we do not specify the default value as "PLUGIN_PROVIDED" and set it to
+      `None`, Pydantic-Python behavior will not allow the plugin-defined defaults to
+      actually take effect.
   files:
     deleted:
     - ''

--- a/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
+++ b/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
@@ -2,14 +2,15 @@ feature:
 - title: 'Add PLUGIN_PROIVDED as an additional default value in OBP Pydantic models'
   description: | 
     'This PR introduces a new default value called PLUGIN_PROVIDED that would help us to
-     sanitize the workflow: drop the fields/arguments with the value = "PLUGIN_PROVIDED".
-      This will make these fields omitted letting the call signature fill in the required
-       default value.'
+    sanitize the workflow: drop the fields/arguments with the value = "PLUGIN_PROVIDED".
+    This will make these fields omitted letting the call signature fill in the required
+    default value.'
 
     Note-1: This is a breaking change.
+
     Note-2: If we do not specify the default value as "PLUGIN_PROVIDED" and set it to
-      `None`, Pydantic-Python behavior will not allow the plugin-defined defaults to
-      actually take effect.
+    `None`, Pydantic-Python behavior will not allow the plugin-defined defaults to
+    actually take effect.
   files:
     deleted:
     - ''

--- a/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
+++ b/docs/source/releases/latest/1345-add-plugin-provided-as-secondary-default-value-in-obp-pydantic-models.yaml
@@ -11,6 +11,7 @@ feature:
     - 'tests/unit_tests/plugins/modules/procflows/test_obp_utils.py'
     - 'geoips/docs/source/releases/latest/update-dev-staging.yaml'
     - 'geoips/plugins/modules/procflows/obp_utils.py'
+    - 'geoips/constants.py'
     modified:
     - 'geoips/plugins/modules/procflows/order_based.py'
   related-issue:

--- a/geoips/constants.py
+++ b/geoips/constants.py
@@ -1,0 +1,9 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+"""Scientific and data-processing constants used across GeoIPS."""
+
+# used as secondary default value in OBP Pydantic models processing
+# OBP uses this to transform the fields as omitted ones so that
+# module plugins can populate the arguments with required default values accordingly
+PLUGIN_PROVIDED = "plugin_provided"

--- a/geoips/plugins/modules/procflows/obp_utils.py
+++ b/geoips/plugins/modules/procflows/obp_utils.py
@@ -12,6 +12,7 @@ from geoips.constants import PLUGIN_PROVIDED
 
 interface = None
 
+
 def validate_arguments(apiVersion, interface, arguments):
     """Load the correct pydantic argument model and validate arguments.
 

--- a/geoips/plugins/modules/procflows/obp_utils.py
+++ b/geoips/plugins/modules/procflows/obp_utils.py
@@ -1,0 +1,79 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+"""Order-Based Procflow (OBP) utility functions."""
+
+# Python Standard Libraries
+from importlib import import_module
+
+# GeoIPS imports
+from geoips.utils.types.partial_lexeme import Lexeme
+from geoips.constants import PLUGIN_PROVIDED
+
+
+def validate_arguments(apiVersion, interface, arguments):
+    """Load the correct pydantic argument model and validate arguments.
+
+    Where the 'correct' argument model is based on apiVersion and interface.
+
+    Parameters
+    ----------
+    apiVersion : str
+        The apiVersion of the workflow model that contained these arguments.
+    interface : str
+        The name of the interface we'll provide arguments to.
+    arguments : dict[str, Any]
+        A dictionary of arguments to validate against a certain model.
+
+    Returns
+    -------
+    validated_arguments : dict[str, Any]
+        A validated representation of the input arguments.
+    """
+    package, version = apiVersion.split("/")
+    try:
+        module = import_module(f"{package}.pydantic_models.{version}.{interface}")
+    except ImportError as e:
+        raise ImportError(f"Could not import models from '{version}': {e}") from e
+
+    interface_base = str(Lexeme(interface).singular)
+    model_name = f"{interface_base.title().replace('_', '')}ArgumentsModel"
+
+    try:
+        model_class = getattr(module, model_name)
+    except AttributeError as e:
+        raise ValueError(f"Model '{model_name}' not found in '{apiVersion}'") from e
+
+    return model_class(**arguments).model_dump()
+
+
+def remove_keys_with_default_value_plugin_provided(workflow_dict: dict) -> dict:
+    """Sanitize the workflow by removing keys with value 'PLUGIN_PROVIDED'.
+
+    'PLUGIN_PROVIDED' acts as a secondary default value in the OBP. It is used when the
+    same argument across different plugins of the same type has different default
+    values.
+
+    This function recursively removes workflow arguments whose value is
+     'PLUGIN_PROVIDED'. The plugin call signature would process these arguemnts as
+     ommited and populates the default value accordingly.
+
+    Parameters
+    ----------
+    workflow: dict
+        The workflow plugin dictionary to process.
+
+    Returns
+    -------
+    dict
+        workflow dictionary with all keys containing the value 'plugin_provided'
+         removed.
+    """
+    
+    if isinstance(workflow_dict, dict):
+        return {
+            key: remove_keys_with_default_value_plugin_provided(val)
+            for key, val in workflow_dict.items()
+            if val != PLUGIN_PROVIDED
+        }
+    return workflow_dict

--- a/geoips/plugins/modules/procflows/obp_utils.py
+++ b/geoips/plugins/modules/procflows/obp_utils.py
@@ -57,8 +57,8 @@ def remove_keys_with_default_value_plugin_provided(workflow_dict: dict) -> dict:
     values.
 
     This function recursively removes workflow arguments whose value is
-     'PLUGIN_PROVIDED'. The plugin call signature would process these arguemnts as
-     ommited and populates the default value accordingly.
+    'PLUGIN_PROVIDED'. The plugin call signature would process these arguments as
+    omitted and populates the default value accordingly.
 
     Parameters
     ----------
@@ -69,7 +69,7 @@ def remove_keys_with_default_value_plugin_provided(workflow_dict: dict) -> dict:
     -------
     dict
         workflow dictionary with all keys containing the value 'plugin_provided'
-         removed.
+        removed.
     """
     if isinstance(workflow_dict, dict):
         return {

--- a/geoips/plugins/modules/procflows/obp_utils.py
+++ b/geoips/plugins/modules/procflows/obp_utils.py
@@ -69,7 +69,6 @@ def remove_keys_with_default_value_plugin_provided(workflow_dict: dict) -> dict:
         workflow dictionary with all keys containing the value 'plugin_provided'
          removed.
     """
-    
     if isinstance(workflow_dict, dict):
         return {
             key: remove_keys_with_default_value_plugin_provided(val)

--- a/geoips/plugins/modules/procflows/obp_utils.py
+++ b/geoips/plugins/modules/procflows/obp_utils.py
@@ -10,6 +10,7 @@ from importlib import import_module
 from geoips.utils.types.partial_lexeme import Lexeme
 from geoips.constants import PLUGIN_PROVIDED
 
+interface = None
 
 def validate_arguments(apiVersion, interface, arguments):
     """Load the correct pydantic argument model and validate arguments.

--- a/geoips/plugins/modules/procflows/order_based.py
+++ b/geoips/plugins/modules/procflows/order_based.py
@@ -7,54 +7,19 @@
 from argparse import ArgumentParser
 from glob import glob
 import logging
-from importlib import import_module
 
 # GeoIPS imports
 from geoips import interfaces
 from geoips.commandline.log_setup import setup_logging
+from geoips.constants import PLUGIN_PROVIDED
 from geoips.utils.types.partial_lexeme import Lexeme
+from geoips.plugins.modules.procflows import obp_utils
 
 LOG = logging.getLogger(__name__)
 
 interface = "procflows"
 family = "standard"
 name = "order_based"
-
-
-def validate_arguments(apiVersion, interface, arguments):
-    """Load the correct pydantic argument model and validate arguments.
-
-    Where the 'correct' argument model is based on apiVersion and interface.
-
-    Parameters
-    ----------
-    apiVersion : str
-        The apiVersion of the workflow model that contained these arguments.
-    interface : str
-        The name of the interface we'll provide arguments to.
-    arguments : dict[str, Any]
-        A dictionary of arguments to validate against a certain model.
-
-    Returns
-    -------
-    validated_arguments : dict[str, Any]
-        A validated representation of the input arguments.
-    """
-    package, version = apiVersion.split("/")
-    try:
-        module = import_module(f"{package}.pydantic_models.{version}.{interface}")
-    except ImportError as e:
-        raise ImportError(f"Could not import models from '{version}': {e}") from e
-
-    interface_base = str(Lexeme(interface).singular)
-    model_name = f"{interface_base.title().replace('_', '')}ArgumentsModel"
-
-    try:
-        model_class = getattr(module, model_name)
-    except AttributeError as e:
-        raise ValueError(f"Model '{model_name}' not found in '{apiVersion}'") from e
-
-    return model_class(**arguments).model_dump()
 
 
 def call(workflow, fnames, command_line_args=None):
@@ -78,6 +43,7 @@ def call(workflow, fnames, command_line_args=None):
 
     LOG.interactive(f"Begin processing '{workflow.get('name', 'embedded')}' workflow.")
 
+    workflow = obp_utils.remove_keys_with_default_value_plugin_provided(workflow)
     apiVersion = workflow.get("apiVersion", "geoips/v1")
     handled_interfaces = ["readers", "coverage_checkers", "workflows"]
     for step_id, step_def in workflow["spec"]["steps"].items():
@@ -121,7 +87,7 @@ def call(workflow, fnames, command_line_args=None):
                 # through without being validated. For example, we use the 'add_args'
                 # function which validates args differently than our pydantic models
                 # do
-                validate_arguments(apiVersion, interface, step_def["arguments"])
+                obp_utils.validate_arguments(apiVersion, interface, step_def["arguments"])
                 # pass in the original arguments as not all readers implement the same
                 # arg / kwarg set.
                 data = plg(**step_def["arguments"])

--- a/geoips/plugins/modules/procflows/order_based.py
+++ b/geoips/plugins/modules/procflows/order_based.py
@@ -11,7 +11,6 @@ import logging
 # GeoIPS imports
 from geoips import interfaces
 from geoips.commandline.log_setup import setup_logging
-from geoips.constants import PLUGIN_PROVIDED
 from geoips.utils.types.partial_lexeme import Lexeme
 from geoips.plugins.modules.procflows import obp_utils
 
@@ -87,7 +86,9 @@ def call(workflow, fnames, command_line_args=None):
                 # through without being validated. For example, we use the 'add_args'
                 # function which validates args differently than our pydantic models
                 # do
-                obp_utils.validate_arguments(apiVersion, interface, step_def["arguments"])
+                obp_utils.validate_arguments(
+                    apiVersion, interface, step_def["arguments"]
+                )
                 # pass in the original arguments as not all readers implement the same
                 # arg / kwarg set.
                 data = plg(**step_def["arguments"])
@@ -97,7 +98,9 @@ def call(workflow, fnames, command_line_args=None):
                 # weird bugs.
                 data = plg(
                     data,
-                    **validate_arguments(apiVersion, interface, step_def["arguments"]),
+                    **obp_utils.validate_arguments(
+                        apiVersion, interface, step_def["arguments"]
+                    ),
                 )
             LOG.interactive(
                 "Completed Step: step_id: '%s', plugin_kind: '%s', plugin_name: '%s'.",

--- a/tests/unit_tests/plugins/modules/procflows/conftest.py
+++ b/tests/unit_tests/plugins/modules/procflows/conftest.py
@@ -1,0 +1,30 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+"""Fixtures for testing Order-Based Procflow-specific utility functions."""
+
+import copy
+
+# Third-Party Libraries
+import pytest
+
+# GeoIPS imports
+from geoips.constants import PLUGIN_PROVIDED
+
+
+@pytest.fixture
+def workflow_with_plugin_provided():
+    """Return workflow containing plugin-provided values."""
+    return {
+        "spec": {
+            "steps": {
+                "reader": {
+                    "kind": "reader",
+                    "arguments": {
+                        "test": PLUGIN_PROVIDED,
+                        "variables": ["B14BT"],
+                    },
+                }
+            }
+        }
+    }

--- a/tests/unit_tests/plugins/modules/procflows/conftest.py
+++ b/tests/unit_tests/plugins/modules/procflows/conftest.py
@@ -3,8 +3,6 @@
 
 """Fixtures for testing Order-Based Procflow-specific utility functions."""
 
-import copy
-
 # Third-Party Libraries
 import pytest
 

--- a/tests/unit_tests/plugins/modules/procflows/test_obp_utils.py
+++ b/tests/unit_tests/plugins/modules/procflows/test_obp_utils.py
@@ -3,12 +3,11 @@
 
 """Unit tests for Order-Based Procflow specific utility functions."""
 
-# Python Standard Libraries
-from typing import Any
-
 # GeoIPS imports
-from geoips.constants import PLUGIN_PROVIDED
-from geoips.plugins.modules.procflows.obp_utils import remove_keys_with_default_value_plugin_provided
+from geoips.plugins.modules.procflows.obp_utils import (
+    remove_keys_with_default_value_plugin_provided,
+)
+
 
 def test_remove_plugin_provided_root_level_key(workflow_with_plugin_provided):
     """Ensure keys wtih value PLUGIN_PROVIDED are removed."""

--- a/tests/unit_tests/plugins/modules/procflows/test_obp_utils.py
+++ b/tests/unit_tests/plugins/modules/procflows/test_obp_utils.py
@@ -1,0 +1,22 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+"""Unit tests for Order-Based Procflow specific utility functions."""
+
+# Python Standard Libraries
+from typing import Any
+
+# GeoIPS imports
+from geoips.constants import PLUGIN_PROVIDED
+from geoips.plugins.modules.procflows.obp_utils import remove_keys_with_default_value_plugin_provided
+
+def test_remove_plugin_provided_root_level_key(workflow_with_plugin_provided):
+    """Ensure keys wtih value PLUGIN_PROVIDED are removed."""
+    actual = remove_keys_with_default_value_plugin_provided(
+        workflow_with_plugin_provided
+    )
+
+    reader_arguments = actual["spec"]["steps"]["reader"]["arguments"]
+
+    assert "test" not in reader_arguments
+    assert reader_arguments["variables"] == ["B14BT"]


### PR DESCRIPTION
## ✨ Summary

This PR introduces a new default value called `PLUGIN_PROVIDED` for use in OBP Pydantic models. 

`PLUGIN_PROVIDED`  is intended for workflow arguments whose actual default values must be defined by the underlying plugin call signatures and may across plugins of the same interface type. During the workflow sanitization, fields with value "PLUGIN_PROVIDED" are removed from the workflow before invocation. This causes the corresponding keyword arguments to be omitted entirely, allowing the plugin call signature to populate the appropriate default value. 

This change addresses a limitation in the current Pydantic workflow generation approach. Pydantic does not provide a built-in mechanism for leaving an optional field truly "unset" while still keeping the field optional within the model definition. As a result, optional fields currently require an explicit default value, with None being used in many cases.

However, Python treats None as an explicitly provided keyword argument value. Consequently, when None is passed to a plugin call, the default value defined in the function signature is not applied.

By introducing PLUGIN_PROVIDED and sanitizing those fields before plugin invocation, the workflow can preserve plugin-defined defaults while still maintaining valid optional Pydantic fields within the OBP models


In addition, this PR also introduces, a designated file at `geoips/constants.py` to define constants used across GeoIPS for both scientific and data-processing purposes. This is to ensure that the value of constant stays consistently constant throughout the codebase. 

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ✅] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ✅] **Full test**: Yes, full test *is passing*.
- [ ✅] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ✅] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips#1340  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Run `pytest` at `/geoips/tests/unit_tests/plugins/modules/procflows`

<img width="3468" height="562" alt="image" src="https://github.com/user-attachments/assets/392db3c3-1da2-4a88-a561-aedbbd6f31fc" />




---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
