### PR TITLE
Workflow Output Checker Overrides

### DIFF
--- a/geoips/commandline/geoips_run.py
+++ b/geoips/commandline/geoips_run.py
@@ -131,8 +131,6 @@ class GeoipsRunOrderBased(GeoipsWorkflowCommand):
     source would use.
     """
 
-    # add something to this command 'that would generate tokens' maybe '--write-tokens'
-
     name = "order_based"
     command_classes = []
     warning_with_color = (


### PR DESCRIPTION
## ✨ Summary

``NOTE``: Lots of the files changed in this PR are a result of black formatting changes.

Adds the support for output_checker overrides for the ``geoips test workflow``
command. Output checker overrides are specified in the following format:

```yaml
test:
  outputs:
    <step_id>: &output-step-definition
      # name: <output_checker_name>                 # optional, derived from compare path if not provided
      # full_test_policy: "on_token_mismatch" | "always" | "never"         # optional
      # compare_path: /path/to/comparison/file.ext  # optional, but usually should exist
      # threshold: float [0,1] # Only works for image output checker
    <step_idX>:
      spec:
        steps:
          <step_idY>:
            <nested_keys>: *output-step-definition
```

Output checker steps are not intended to be placed directly in a workflow. This is
due to the structure of output checker plugins, and how they are intended to be used.
It is not efficient to compare outputs of one or more steps every time you run a
workflow, nor will a workflow always have a comparison file for one or more steps.
These are intended to be used in testing settings where comparison to known outputs
will be performed in the instance a token comparison fails or we want to do more
thorough comparison of certain outputs.

Output checker overrides under the hood insert a new step DIRECTLY after the step
ID that referenced the output checker override. So, for example, if we had a step
ID named ``apply_algorithm`` in a workflow definition, then at runtime a new step
would be inserted in the workflow directly after ``apply_algorithm`` named
``output_checkerX`` (X == number of output checker steps found prior + 1) containing
the definition of the output checker override.

Take the following workflow.

```yaml
apiVersion: geoips/v1
interface: workflows
family: order_based
name: test_product
docstring: |
  11.2 µm Infrared.

  This product utilizes channel 14 (11.2 µm) and highlights areas of deep convection within a Tropical Cyclone.
description: 11.2 µm Infrared.
test:
  fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_abi/data/goes16_20200918_1950/*
  outputs:
    abi:Infrared:
      full_test_policy: on_token_mismatch # always | never
      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Infrared.imagery_clean/20200918.195020.goes-16.abi.Infrared.test_goes16_eqc_3km_day_20200918T1950Z.100p00.noaa.3p0.png
  steps:
    reader:
      area_def: null
    abi:Infrared:
      spec:
        steps:
          algorithm:
            output_units: Kelvin
  kinds:
    readers:
      satellite_zenith_angle_cutoff: 80
  globals:
    sector_list: global_cylindrical
    logging_level: info
spec:
  steps:
    reader:
      kind: reader
      name: abi_netcdf
      arguments:
        chans: ['B14BT']
    abi:Infrared:
      kind: product
      name: [abi, Infrared]
      arguments: {}
```

When we run ``geoips test workflow test_product``, the resulting runtime workflow
would take on the following format:

```yaml
apiVersion: geoips/v1
interface: workflows
family: order_based
name: test_product
docstring: |
  11.2 µm Infrared.

  This product utilizes channel 14 (11.2 µm) and highlights areas of deep convection within a Tropical Cyclone.
description: 11.2 µm Infrared.
spec:
  steps:
    reader:
      kind: reader
      name: abi_netcdf
      depends_on: []
      keep: False
      arguments:
        chans: ['B14BT']
        sector_list: global_cylindrical
        logging_level: info
        satellite_zenith_angle_cutoff: 80
    abi:Infrared:
      kind: workflow
      spec:
        outputs: ['colormapper']
        retention: keep_referenced
        keep: False,
        depends_on: ['reader']
        arguments: None
        steps:
          interpolator:
            kind: interpolator
            name: interp_nearest
            depends_on: []
            keep: False
            arguments:
              sector_list: global_cylindrical
              logging_level: info
          algorithm:
            kind: algorithm
            name: single_channel
            depends_on: ['interpolator']
            keep: False
            arguments:
              output_data_range: [-90.0, 30.0]
              input_units: Kelvin
              output_units: Kelvin
              min_outbounds: crop
              max_outbounds: crop
              norm: False
              inverse: False
              sector_list: global_cylindrical
              logging_level: info
          colormapper:
            kind: colormapper
            name: Infrared
            depends_on: ['algorithm']
            keep: False
            arguments:
              data_range: [-90.0, 30.0]
              sector_list: global_cylindrical
              logging_level: info
    output_checker1:
      policy: on_failure
      name: image
      kind: output_checker
      depends_on: ['abi:Infrared']
      arguments:
        compare_path: /home/evan/geoips/geoips_packages/geoips/tests/outputs/abi.static.Infrared.imagery_clean/20200918.195020.goes-16.abi.Infrared.test_goes16_eqc_3km_day_20200918T1950Z.100p00.noaa.3p0.png
```

files:
```
  modified:
      - docs/dev/class_based_plugins.rst
      - docs/dev/order_based_procflow.rst
      - docs/dev/running_order_based_procflow.rst
      - docs/source/releases/latest/geoips-obp-output-checker-overrides.yaml
      - geoips/commandline/geoips_command.py
      - geoips/commandline/geoips_run.py
      - geoips/commandline/geoips_test.py
      - geoips/dev/output_config.py
      - geoips/image_utils/maps.py
      - geoips/interfaces/class_based/coverage_checkers.py
      - geoips/interfaces/class_based/procflows.py
      - geoips/interfaces/class_based/workflow.py
      - geoips/interfaces/class_based_plugin.py
      - geoips/interfaces/yaml_based/sectors.py
      - geoips/interfaces/yaml_based/workflows.py
      - geoips/plugins/modules/procflows/order_based.py
      - geoips/plugins/yaml/workflows/unit_tests/full_run.yaml
      - geoips/plugins/yaml/workflows/unit_tests/test_product.yaml
      - geoips/pydantic_models/v1/output_checkers.py
      - geoips/pydantic_models/v1/readers.py
      - geoips/pydantic_models/v1/workflows.py
      - geoips/utils/types/converter_registry.py
      - geoips/utils/types/converters.py
      - geoips/utils/types/family_conversions.py
      - geoips/utils/types/tokenization.py
      - tests/integration_tests/conftest.py
      - tests/integration_tests/test_obp_datatree.py
      - tests/integration_tests/test_obp_family_conversions.py
      - tests/unit_tests/interfaces/class_based/test_workflow.py
      - tests/unit_tests/plugins/yaml/workflows/test_workflow_overrides.py
```
---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ] **Full test**: Yes, full test *is passing*.
- [ ] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
