### PR TITLE
OBP -- Add default coverage checker step when products are encountered

### DIFF
--- a/docs/source/releases/latest/obp-coverage-checker-insertion.yaml
+++ b/docs/source/releases/latest/obp-coverage-checker-insertion.yaml
@@ -1,0 +1,17 @@
+enhancement:
+- title: Default Coverage Checkers when product encountered
+  description: |
+    Any time a product is encountered as a step in a workflow, fully expand that product
+    as a nested series of steps in the original workflow, then add a coverage checker as
+    the final step of the product nested steps if it doesn't already exist as a step.
+    Use the masked arrays coverage checker in this case and set minimum coverage to 10.
+  files:
+    modified:
+      - geoips/pydantic_models/v1/workflows.py
+      - geoips/interfaces/class_based/coverage_checkers.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/geoips/interfaces/class_based/coverage_checkers.py
+++ b/geoips/interfaces/class_based/coverage_checkers.py
@@ -51,6 +51,9 @@ class BaseCoverageCheckerPlugin(BaseClassPlugin, abstract=True):
             When ``minimum_coverage`` is set and any variable's
             coverage percentage falls below it.
         """
+        if _obp_initiated and "variable_name" not in kwargs:
+            kwargs["variable_name"] = self._infer_variable_name(data)
+
         variables = kwargs.get("variables")
         if not _obp_initiated or not isinstance(variables, list):
             return super()._invoke(data, *args, _obp_initiated=_obp_initiated, **kwargs)
@@ -74,6 +77,32 @@ class BaseCoverageCheckerPlugin(BaseClassPlugin, abstract=True):
                 min_cov = cov
                 result = res
         return result
+
+    def _infer_variable_name(self, data):
+        """Infer the coverage-checker variable from upstream data when unambiguous.
+
+        Coverage checker steps may be inserted automatically while expanding legacy
+        product definitions. In those cases, the product configuration often does not
+        name the algorithm output variable. Use the actual upstream dataset at call
+        time to infer the variable only when exactly one data variable is available.
+        """
+        dataset = self._to_mutable_dataset(data)
+        data_vars = list(getattr(dataset, "data_vars", []))
+
+        if len(data_vars) == 1:
+            return data_vars[0]
+
+        if not data_vars:
+            raise ValueError(
+                f"Coverage checker plugin '{self.name}' requires 'variable_name', "
+                "but no data variables were found in the upstream data."
+            )
+
+        raise ValueError(
+            f"Coverage checker plugin '{self.name}' requires 'variable_name' when "
+            "upstream data contains multiple data variables. Available variables: "
+            f"{data_vars}."
+        )
 
     def _pre_call(self, data=None, *args, _obp_initiated=False, **kwargs):
         r"""Normalize upstream ``DataTreeDitto`` input into a mutable ``xr.Dataset``.

--- a/geoips/interfaces/class_based/coverage_checkers.py
+++ b/geoips/interfaces/class_based/coverage_checkers.py
@@ -55,7 +55,7 @@ class BaseCoverageCheckerPlugin(BaseClassPlugin, abstract=True):
         if not _obp_initiated or not isinstance(variables, list):
             return super()._invoke(data, *args, _obp_initiated=_obp_initiated, **kwargs)
 
-        minimum_coverage = kwargs.pop("minimum_coverage", 0.0)
+        minimum_coverage = kwargs.pop("minimum_coverage", 10.0)
         kwargs.pop("variables")
 
         min_cov = 100.0

--- a/geoips/interfaces/class_based/coverage_checkers.py
+++ b/geoips/interfaces/class_based/coverage_checkers.py
@@ -87,7 +87,7 @@ class BaseCoverageCheckerPlugin(BaseClassPlugin, abstract=True):
         name the algorithm output variable. Use the actual upstream dataset at call
         time to infer the variable only when exactly one data variable is available.
         """
-        dataset = self._to_mutable_dataset(data)
+        dataset = to_mutable_dataset(data)
         data_vars = list(getattr(dataset, "data_vars", []))
 
         if len(data_vars) == 1:

--- a/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
@@ -1,0 +1,48 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
+# script migration = done
+# product testing = ongoing
+
+# Default values - if you do not have this exact test case available, call with available data files / sectors.
+# This exact test case required for valid comparisons - remove "compare_path" argument if running a different
+# set of arguments.
+
+apiVersion: geoips/v1
+interface: workflows
+family: order_based
+name: seviri_dust_rgb_imagery_clean
+docstring: ADD THIS.
+package: geoips
+test:
+  fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_seviri/data/20250624/1200/H-000-MSG3*
+  outputs:
+    output_formatter:
+      full_test_policy: on_token_mismatch # always | never
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Dust_RGB.imagery_clean
+      output_checker_name: ADD THIS
+spec:
+  globals:
+    product_name: Dust_RGB
+    reader_defined_area_def: False
+    # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+  steps:
+    sector:
+      kind: sector
+      name: test_meteoeu_eqc_3km_landocean
+      depends_on: []
+    reader:
+      kind: reader
+      name: seviri_hrit
+      depends_on: [sector]
+    seviri_Dust_RGB:
+      kind: product
+      name: [seviri, Dust_RGB]
+      depends_on: [sector, reader]
+    filename_formatter:
+      kind: filename_formatter
+      name: geoips_fname
+      depends_on: [seviri_Dust_RGB.algorithm, sector]
+    output_formatter:
+      kind: output_formatter
+      name: imagery_clean

--- a/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
@@ -20,7 +20,7 @@ test:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Dust_RGB.imagery_clean
-      output_checker_name: ADD THIS
+      output_checker_name: image
 spec:
   globals:
     product_name: Dust_RGB

--- a/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
@@ -12,8 +12,8 @@ apiVersion: geoips/v1
 interface: workflows
 family: order_based
 name: seviri_dust_rgb_imagery_clean
-docstring: ADD THIS.
-package: geoips
+docstring: |
+  SEVIRI Dust RGB imagery over a European equidistant cylindrical sector.
 test:
   fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_seviri/data/20250624/1200/H-000-MSG3*
   outputs:

--- a/geoips/plugins/yaml/workflows/unit_tests/test_product.yaml
+++ b/geoips/plugins/yaml/workflows/unit_tests/test_product.yaml
@@ -15,18 +15,6 @@ test:
       full_test_policy: on_token_mismatch
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Infrared.imagery_clean
       output_checker_name: image
-  steps:
-    abi_Infrared:
-      spec:
-        steps:
-          algorithm:
-            output_units: Kelvin
-  kinds:
-    readers:
-      satellite_zenith_angle_cutoff: 80
-  globals:
-    sector_list: global_cylindrical
-    logging_level: info
 
 spec:
   steps:
@@ -56,17 +44,10 @@ spec:
       name: default
       depends_on: []
 
-    check_coverage:
-      kind: coverage_checker
-      name: masked_arrays
-      depends_on: [abi_Infrared.algorithm, sector]
-      arguments:
-        variable_name: data
-
     create_filenames:
       kind: filename_formatter
       name: geoips_fname
-      depends_on: [abi_Infrared.algorithm, sector, check_coverage]
+      depends_on: [abi_Infrared.algorithm, sector, abi_Infrared.coverage_checker]
       arguments:
         product_name: Infrared
 

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -819,15 +819,6 @@ class WorkflowSpecModel(FrozenModel):
                 steps["coverage_checker"] = spec["coverage_checker"].get("plugin")
                 steps["coverage_checker"]["kind"] = "coverage_checker"
                 steps["coverage_checker"]["depends_on"] = last_data_step
-            else:
-                # add an argument to coverage checkers where in the post call performs
-                # coverage checkers and adds minimum_coverage = 10.
-                steps["coverage_checker"] = {
-                    "kind": "coverage_checker",
-                    "name": "masked_arrays",
-                    "depends_on": last_data_step,
-                    "arguments": {"minimum_coverage": 10},
-                }
         else:
             for key, value in spec.items():
                 if key in ["mtif_type", "variables"]:
@@ -839,6 +830,16 @@ class WorkflowSpecModel(FrozenModel):
 
                 steps[key] = value.get("plugin")
                 steps[key]["kind"] = kind
+
+        if "coverage_checker" not in list(steps.keys()):
+            # add an argument to coverage checkers where in the post call performs
+            # coverage checkers and adds minimum_coverage = 10.
+            steps["coverage_checker"] = {
+                "kind": "coverage_checker",
+                "name": "masked_arrays",
+                "depends_on": last_data_step,
+                "arguments": {"minimum_coverage": 10},
+            }
 
         return steps, global_vars
 

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -825,6 +825,7 @@ class WorkflowSpecModel(FrozenModel):
                 steps["coverage_checker"] = {
                     "kind": "coverage_checker",
                     "name": "masked_arrays",
+                    "depends_on": last_data_step,
                     "arguments": {"minimum_coverage": 10},
                 }
         else:

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -832,8 +832,7 @@ class WorkflowSpecModel(FrozenModel):
                 steps[key]["kind"] = kind
 
         if "coverage_checker" not in list(steps.keys()):
-            # add an argument to coverage checkers where in the post call performs
-            # coverage checkers and adds minimum_coverage = 10.
+            # Add default coverage checker step if one doesn't already exist
             steps["coverage_checker"] = {
                 "kind": "coverage_checker",
                 "name": "masked_arrays",

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -819,6 +819,14 @@ class WorkflowSpecModel(FrozenModel):
                 steps["coverage_checker"] = spec["coverage_checker"].get("plugin")
                 steps["coverage_checker"]["kind"] = "coverage_checker"
                 steps["coverage_checker"]["depends_on"] = last_data_step
+            else:
+                # add an argument to coverage checkers where in the post call performs
+                # coverage checkers and adds minimum_coverage = 10.
+                steps["coverage_checker"] = {
+                    "kind": "coverage_checker",
+                    "name": "masked_arrays",
+                    "arguments": {"minimum_coverage": 10},
+                }
         else:
             for key, value in spec.items():
                 if key in ["mtif_type", "variables"]:

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -416,14 +416,14 @@ class BaseCliTest(abc.ABC):
             output, error = prc.communicate()
             output, error = output.decode(), error.decode()
             prc.terminate()
-        # If caplog was provided and logging statements were caught, add those to
-        # output before asserting that the command produced output.
-        if caplog and len(caplog.text):
-            output += caplog.text
         assert len(output) or len(error)  # assert that some output was created
         # Extract log statements
         if len(error) and (not len(output) or output == "\n"):
             self.check_error(args, error)
         else:
             print(output)
+            # If caplog was provided and logging statements were caught, add those to
+            # output.
+            if caplog and len(caplog.text):
+                output += caplog.text
             self.check_output(args, output)

--- a/tests/unit_tests/commandline/cli_top_level_tester.py
+++ b/tests/unit_tests/commandline/cli_top_level_tester.py
@@ -416,15 +416,14 @@ class BaseCliTest(abc.ABC):
             output, error = prc.communicate()
             output, error = output.decode(), error.decode()
             prc.terminate()
+        # If caplog was provided and logging statements were caught, add those to
+        # output before asserting that the command produced output.
+        if caplog and len(caplog.text):
+            output += caplog.text
         assert len(output) or len(error)  # assert that some output was created
         # Extract log statements
         if len(error) and (not len(output) or output == "\n"):
             self.check_error(args, error)
         else:
             print(output)
-            # if caplog was provided and logging statements were caught, add those to
-            # output.
-            if caplog and len(caplog.text):
-                output += caplog.text
-
             self.check_output(args, output)


### PR DESCRIPTION
## ✨ Summary

Any time a product is encountered as a step in a workflow, fully expand that product
as a nested series of steps in the original workflow, then add a coverage checker as
the final step of the product nested steps if it doesn't already exist as a step.
Use the masked arrays coverage checker in this case and set minimum coverage to 10.
```
  files:
    modified:
      - geoips/pydantic_models/v1/workflows.py
      - geoips/interfaces/class_based/coverage_checkers.py
```
---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️

---

## 📸 Output 

Please think about including these in documentation where appropriate.

### 🧪 Demonstrate new test scripts operate as expected
- Command line outputs or imagery outputs demonstrating passed tests.
- For imagery outputs commited to the repository, include clean imagery using very small test sectors with minimal formatting (no extra YAML metadata, or extra image annotations!).
- If you've added new image products, remember to create tests in:
  - `<repo>/tests/scripts/<testname>.sh`
  - And update `<repo>/tests/integration/integration_tests.py`

### 🖼️ Pretty imagery demonstrating functionality

- You can drop "pretty" imagery outputs directly in this section - these are for reference only, and can be used to share the beauty of your updates with others! Imagery you drop directly in the PR can have any formatting you wish - the prettier the better.

### 🧙🔎 Image difference files

Sometimes matplotlib or numpy will cause very minor differences in image outputs, causing an updated image with no visible change within the github files changed tab
In these cases, it can sometimes be useful to drop the image diff output from the geoips run directly in this section (lives in tests/outputs/[folder]/diff_*)
These image diff outputs are a faded out version of the image, with bright red highlighting where there were changes in the image between the old and new version.

---

💖🌟🌎🌟💖
