### PR TITLE
OBP Argument Overrides Refactor

### DIFF
--- a/docs/dev/running_order_based_procflow.rst
+++ b/docs/dev/running_order_based_procflow.rst
@@ -42,14 +42,13 @@ String-based Overrides
 Specifying a dictionary at the commandline can be arduous and time consuming. Therefore
 we've created string-based overrides which encapsulate the exact same override
 functionality as dictionary-based overrides do. These are specified via lowercase
-``-s``, ``-k``, and ``-g`` flags which represent ``[s]tep``, ``[k]ind``, and ``[g]lobal``
+``-s`` and ``-g`` flags which represent ``[s]tep`` and ``[g]lobal``
 overrides.
 
 A step override tells the CLI to override the value of an argument at a given workflow
-step. A kind override tells the CLI to override the value of an argument for any
-instance a step is of a certain interface ``kind``. Global overrides tell the CLI to
-override or add an argument at every step. In any instance an argument passed to a
-plugin is not supported, they will automatically be removed before that plugin is called.
+step. Global overrides tell the CLI to override or add an argument at every step. In any
+instance an argument passed to a plugin is not supported, they will automatically be
+removed before that plugin is called.
 
 When these overrides are added, one or more arguments for each flag can be supplied. You
 do not need to respecify a flag before each individual override. Just group your
@@ -61,16 +60,14 @@ Below we'll demonstrate how to use overrides via the GeoIPS CLI.
 .. code-block:: bash
 
   geoips run order_based test_product $GEOIPS_TESTDATA_DIR/test_data_abi/data/goes16_20200918_1950/* \
-    -s abi:Infrared.spec.steps.algorithm.output_units=Kelvin \
+    -s abi:Infrared.algorithm.output_units=Kelvin \
     -s reader.area_def=null \
-    -k readers.satellite_zenith_angle_cutoff=80 \
     -g sector_list=global_cylindrical \
     -g logging_level=info
 
 The format of string-based overrides goes as follows:
 
 Step override: ``<step_id>.<optional_string1>.<optional_string2>...<argument>=<some_value>``
-Kind override: ``<kind>.<argument_name>=<some_value>``
 Global override: ``<global_variable_name>=<some_value>``
 
 .. note::
@@ -119,7 +116,7 @@ Global override: ``<global_variable_name>=<some_value>``
   Then, to override the ``output_units`` argument of the ``algorithm`` step, your
   override string would need to look like this:
 
-  ``-s abi:Infrared.spec.steps.algorithm.output_units=Kelvin``
+  ``-s abi:Infrared.algorithm.output_units=Kelvin``
 
 Dictionary-based Overrides
 --------------------------
@@ -127,17 +124,16 @@ Dictionary-based Overrides
 You can also override a workflow via dictionary-based overrides. This is how overrides
 occur in a workflow's ``test`` section, and the same logic can be applied via the
 command line. To specify dictionary-based overrides at the command line, we use
-uppercase ``-S``, ``-K``, and ``-G`` flags. These are flags accept singular instances
-of dictionaries that adhere to the format in which you can specify ``[S]tep``, ``[K]ind``,
-and ``[G]lobal`` overrides in a workflow's test section.
+uppercase ``-S`` and ``-G`` flags. These are flags accept singular instances
+of dictionaries that adhere to the format in which you can specify ``[S]tep`` and
+``[G]lobal`` overrides in a workflow's test section.
 
 Below we demonstrate how to specify dictionary-based overrides at the command line.
 
 .. code-block:: bash
 
   geoips run order_based test_product $GEOIPS_TESTDATA_DIR/test_data_abi/data/goes16_20200918_1950/* \
-      -S '{"reader": {"self_register": "LOW"}, "abi:Infrared": {"spec": {"steps": {"algorithm": {"output_units": "kelvin"}}}}}' \
-      -K '{"readers": {"satellite_zenith_angle_cutoff": 80}}' \
+      -S '{"reader": {"self_register": "LOW"}, "abi:Infrared": {"algorithm": {"output_units": "kelvin"}}}' \
       -G '{"sector_list": "global_cylindrical", "logging_level": "info"}'
 
 As you can see, these are not nearly as easy to specify at the command line, but we
@@ -171,18 +167,12 @@ Take for example the following workflow.
       abi:Infrared:
         full_test_policy: on_token_mismatch # | always | never
         compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Infrared.imagery_clean/20200918.195020.goes-16.abi.Infrared.test_goes16_eqc_3km_day_20200918T1950Z.100p00.noaa.3p0.png
-    steps:
-      reader:
-        area_def: null
-      abi:Infrared:
-        spec:
-          steps:
-            algorithm:
-              output_units: Kelvin
-    kinds:
-      readers:
-        satellite_zenith_angle_cutoff: 80
-    globals:
+  arguments:
+    reader:
+      area_def: null
+    abi:Infrared.algorithm:
+      output_units: Kelvin
+    global:
       sector_list: global_cylindrical
       logging_level: info
   spec:

--- a/docs/source/releases/latest/obp-argument-overrides-refactor.yaml
+++ b/docs/source/releases/latest/obp-argument-overrides-refactor.yaml
@@ -1,0 +1,94 @@
+enhancement:
+- title: OBP Argument Overrides Refactor
+  description: |
+    Refactors how argument overrides are applied in GeoIPS workflow plugins. A new
+    'arguments' field has been added as a new optional field to the top-level of a
+    workflow plugin as well as an optional field to its 'test' section. It follows the
+    same format regardless of which section it's specified in. It looks like the
+    following:
+
+    ```yaml
+    arguments:
+      global:
+        <global_argument>: <value>
+      <step_id>.<argument>: <value>
+      <step_id>.<nested_step_id>...<argument>: <value
+      <global>.<argument>: <value
+    ```
+
+    Again, these are optional fields and will only be applied if specified. The logic
+    of how these overrides are applied follow these rules:
+
+    - ``geoips run order_based`` (in order of precedence)
+      1. CLI string overrides (``-g`` and ``-s``)
+      2. CLI dict overrides (``-G`` and ``-S``)
+      3. Base overrides (e.g. ``arguments`` top level field)
+    - ``geoips test workflow`` (in order of precedence)
+      1. ``test['arguments']`` field
+      2. ``arguments`` top-level field
+
+    The argument logic can be applied in a step's arguments as well. For example, if a
+    nested workflow were to occur as a step, you could do:
+
+    ``<inner_step_id>.<argument>: <value>``
+
+    additionally, you can override the ``depends_on`` field of a nested step. Such as:
+
+    ``<inner_step_id>.depends_on: [<inner_step_idX>, ...]``
+
+    Finally, modified a large majority of the workflows found in
+    ``geoips/plugins/yaml/workflows/tests/`` to adhere to this new logic. All of the
+    workflows modified in this PR seem to be working now.
+  files:
+    modified:
+      - docs/dev/running_order_based_procflow.rst
+      - geoips/commandline/geoips_run.py
+      - geoips/interfaces/class_based_plugin.py
+      - geoips/interfaces/yaml_based/workflows.py
+      - geoips/plugins/classes/algorithms/absdiff_mst.py
+      - geoips/plugins/classes/algorithms/visir/nasa_dust_rgb.py
+      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_annotated_enhanced.yaml
+      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_netcdf_geoips.yaml
+      - geoips/plugins/yaml/workflows/tests/abi_static_nasa_dust_rgb_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/abi_static_test_visible_logarithmic_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/abi_static_visible_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/ami_static_infrared_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/ami_static_mst_absdiff_ir_bd_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/ami_static_visible_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/ewsg_static_infrared_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/fci_static_visible_imagery_annotated.yaml
+      - geoips/plugins/yaml/workflows/tests/gfs_static_waveheight_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/gfs_static_windspeed_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/mimic_coarse_static_tpw_cimss_imagery_annotated.yaml
+      - geoips/plugins/yaml/workflows/tests/mwr_tb165_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/mwr_tb180_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/mwr_tb325_15_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/mwr_tb50_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/mwr_tb89_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_airmass_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_convective_storms_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_day_microphys_summer_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_day_microphys_winter_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_day_solar_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_natural_color_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_night_microphys_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_volcanic_ash_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_wv_upper_no_self_register_unprojected_image.yaml
+      - geoips/plugins/yaml/workflows/tests/seviri_wv_upper_unprojected_image.yaml
+      - geoips/plugins/yaml/workflows/tests/sgli_static_ir_rgb_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/smap_awips_netcdf.yaml
+      - geoips/plugins/yaml/workflows/tests/smap_unsectored_text_winds.yaml
+      - geoips/plugins/yaml/workflows/tests/viirs_static_visible_imagery_clean.yaml
+      - geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_imagery_annotated.yaml
+      - geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_unprojected_image.yaml
+      - geoips/plugins/yaml/workflows/tests/viirsday_global_night_vis_ir_cogeotiff_rgba.yaml
+      - geoips/pydantic_models/v1/workflows.py
+      - tests/unit_tests/plugins/yaml/workflows/test_workflow_overrides.py
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null

--- a/geoips/commandline/geoips_run.py
+++ b/geoips/commandline/geoips_run.py
@@ -188,31 +188,6 @@ class GeoipsRunOrderBased(GeoipsWorkflowCommand):
             )
         return override
 
-    def kind_override_type(self, value: str):
-        """Ensure an override string fits the following format.
-
-        Expected Format
-        ---------------
-        '<kind>.<argument_name>=<some_value>'
-
-        Parameters
-        ----------
-        value: str
-            The full kind override string for a geoips run order_based command.
-
-        Returns
-        -------
-        override_dict: dict
-            The validated contents of an override string in a dictionary.
-        """
-        try:
-            override = workflows.kind_override_type(value)
-        except ValueError:
-            raise self.parser.error(
-                f"Invalid format '{value}'. Expected '<kind>.<argument_name>=<value>'"
-            )
-        return override
-
     def step_override_type(self, value: str):
         """Ensure an override string fits the following format.
 
@@ -269,17 +244,6 @@ class GeoipsRunOrderBased(GeoipsWorkflowCommand):
             ),
         )
         self.parser.add_argument(
-            "-K",
-            "--kind-override-dict",
-            default={},
-            type=self.dict_type,
-            help=(
-                "One or more kind overrides to apply to your workflow. In a dictionary "
-                "format. See geoips.pydantic_models.v1.workflows for more info on the "
-                "correct format."
-            ),
-        )
-        self.parser.add_argument(
             "-G",
             "--global-override-dict",
             default={},
@@ -301,18 +265,6 @@ class GeoipsRunOrderBased(GeoipsWorkflowCommand):
                 "Step override string to apply to your workflow. An "
                 "override string should take on the following format:\n "
                 "'<step_id>.<string1>.<optional_string2>...<argument>=<some_value>'"
-            ),
-        )
-        self.parser.add_argument(
-            "-k",
-            "--kind-override-strings",
-            default=[],
-            type=self.kind_override_type,
-            action="append",
-            help=(
-                "Kind override string to apply to your workflow. An "
-                "override string should take on the following format:\n "
-                "'<kind>.<argument_name>=<some_value>'"
             ),
         )
         self.parser.add_argument(
@@ -358,44 +310,29 @@ class GeoipsRunOrderBased(GeoipsWorkflowCommand):
             - The overridden workflow.
         """
         s_override_dict = args.step_override_dict
-        k_override_dict = args.kind_override_dict
         g_override_dict = args.global_override_dict
 
         s_override_strings = args.step_override_strings
-        k_override_strings = args.kind_override_strings
         g_override_strings = args.global_override_strings
 
+        # Even if no overrides have been applied at the commandline, make sure to apply
+        # the argument overrides in the workflow file if they exist.
+
         # apply dict-based overrides
-        if any(
-            [
-                s_override_dict,
-                k_override_dict,
-                g_override_dict,
-            ]
-        ):
-            workflow = workflows._override_workflow_dict_format(
-                workflow,
-                goverrides=g_override_dict,
-                koverrides=k_override_dict,
-                soverrides=s_override_dict,
-            )
-            WorkflowPluginModel(**workflow, is_registered=False)
+        workflow = workflows._override_workflow_dict_format(
+            workflow,
+            goverrides=g_override_dict,
+            soverrides=s_override_dict,
+        )
+        WorkflowPluginModel(**workflow, is_registered=False)
 
         # apply string-based overrides
-        if any(
-            [
-                s_override_strings,
-                k_override_strings,
-                g_override_strings,
-            ]
-        ):
-            workflow = workflows._override_workflow_string_format(
-                workflow,
-                goverrides=g_override_strings,
-                koverrides=k_override_strings,
-                soverrides=s_override_strings,
-            )
-            WorkflowPluginModel(**workflow, is_registered=False)
+        workflow = workflows._override_workflow_string_format(
+            workflow,
+            goverrides=g_override_strings,
+            soverrides=s_override_strings,
+        )
+        WorkflowPluginModel(**workflow, is_registered=False)
 
         return workflow
 

--- a/geoips/interfaces/class_based_plugin.py
+++ b/geoips/interfaces/class_based_plugin.py
@@ -346,8 +346,7 @@ class BaseClassPlugin(ABC):
                 f"Original error: {exc}"
             ) from exc
 
-    @staticmethod
-    def _extract_child_kwargs(data, kwargs):
+    def _extract_child_kwargs(self, data, kwargs):
         """Inject conduit-mapped keyword arguments from upstream DataTree children.
 
         Walks each child of *data* (a ``multi_input`` DataTree built by
@@ -400,7 +399,14 @@ class BaseClassPlugin(ABC):
             if val is not None:
                 kwargs[kwarg_name] = val
 
-        _apply_legacy_product_name_rename(kwargs)
+        # The following interfaces expect 'product_name' to be a variable in the
+        # xarray object they are provided.
+        if self.interface in [
+            "coverage_checkers",
+            "filename_formatters",
+            "output_formatters",
+        ]:
+            _apply_legacy_product_name_rename(kwargs)
 
         return kwargs
 

--- a/geoips/interfaces/yaml_based/workflows.py
+++ b/geoips/interfaces/yaml_based/workflows.py
@@ -38,12 +38,12 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        value: str
+        value : str
             The full global override string for a geoips run order_based command.
 
         Returns
         -------
-        override_dict: dict
+        override_dict : dict
             The validated contents of an override string in a dictionary.
         """
         try:
@@ -68,12 +68,12 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        value: str
+        value : str
             The full step override string for a geoips run order_based command.
 
         Returns
         -------
-        override_dict: dict
+        override_dict : dict
             The validated contents of an override string in a dictionary.
         """
         try:
@@ -107,18 +107,18 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        d: dict[dict]
+        d : dict[dict]
             The nested dictionary to set a key, value pair in.
-        keys: list[str]
+        keys : list[str]
             A list of keys to access the nested dictionaries.
-        argument: str
+        argument : str
             The final key to set value to.
-        value: Any
+        value : Any
             The value to assign to a key that's in a nested dictionary.
 
         Returns
         -------
-        d: dict[dict]
+        d : dict[dict]
             A nested dictionary.
         """
         if d.get("spec") and d.get("spec").get("steps"):
@@ -135,14 +135,14 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        steps: dict[dict]
+        steps : dict[dict]
             An ordered dictionary of steps to apply in a given workflow.
-        override: Any
+        override : Any
             The value of the override.
 
         Returns
         -------
-        steps: dict[dict]
+        steps : dict[dict]
             An overridden representation of 'steps'.
         """
         steps = self._set_nested(
@@ -159,14 +159,14 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        steps: dict[dict]
+        steps : dict[dict]
             An ordered dictionary of steps to apply in a given workflow.
-        override: Any
+        override : Any
             The value of the override.
 
         Returns
         -------
-        steps: dict[dict]
+        steps : dict[dict]
             An overridden representation of 'steps'.
         """
         for id, step in steps.items():
@@ -189,19 +189,19 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        workflow: dict
+        workflow : dict
             A dictionary representation of a workflow plugin.
-        goverrides: list[str], optional
+        goverrides : list[str], optional
             A list of string global overrides.
-        soverrides: list[str], optional
+        soverrides : list[str], optional
             A list of string step overrides.
-        grab_bases: bool, optional
+        grab_bases : bool, optional
             Whether or not to use the override arguments specified in a workflow's
             'arguments' section. Defaults to True.
 
         Returns
         -------
-        overridden: dict
+        overridden : dict
             The overridden representation of 'workflow'.
         """
         steps = workflow["spec"]["steps"]
@@ -403,28 +403,46 @@ class WorkflowsInterface(BaseYamlInterface):
 
         return steps
 
-    def _convert_override_dict_to_string_format(self, workflow, input_arguments=None):
+    def _convert_override_dict_to_string_format(
+        self,
+        workflow,
+        input_arguments=None,
+        use_test_arguments=False,
+    ):
         """
         Convert a workflow's test section overrides to string-based overrides.
 
         Parameters
         ----------
-        workflow: dict
+        workflow : dict
             A dictionary representation of a workflow plugin.
-        input_arguments: dict, optional
+        input_arguments : dict, optional
             A dictionary of input override arguments from the commandline. Defaults to
             None.
+        use_test_arguments : bool, optional
+            Whether or not to default to the arguments specified in a workflow's 'test'
+            section or to default to the arguments set in the top level of a workflow
+            plugin.
 
         Returns
         -------
-        goverrides: list[str]
+        goverrides : list[str]
             A list of global override strings.
-        soverrides: list[str]
+        soverrides : list[str]
             A list of step override strings.
         """
         goverrides = []
         soverrides = []
-        arguments = input_arguments if input_arguments else workflow.get("arguments")
+        if use_test_arguments:
+            arguments = (
+                input_arguments
+                if input_arguments
+                else workflow.get("test", {}).get("arguments", {})
+            )
+        else:
+            arguments = (
+                input_arguments if input_arguments else workflow.get("arguments", {})
+            )
 
         for override_key, overrides in arguments.items():
             if override_key.startswith("global"):
@@ -457,29 +475,38 @@ class WorkflowsInterface(BaseYamlInterface):
         goverrides={},
         soverrides={},
         oc_overrides={},
+        use_test_arguments=False,
     ):
         """Override a workflow plugin where applicable.
 
         Parameters
         ----------
-        workflow: dict
+        workflow : dict
             A dictionary representation of a workflow plugin.
-        goverrides: dict, optional
+        goverrides : dict, optional
             A dictionary of global overrides.
-        soverrides: dict, optional
+        soverrides : dict, optional
             A dictionary for step overrides.
-        oc_overrides: dict, optional
+        oc_overrides : dict, optional
             A dictionary for output_checker overrides.
+        use_test_arguments : bool, optional
+            Whether or not to default to the arguments specified in a workflow's 'test'
+            section or to default to the arguments set in the top level of a workflow
+            plugin.
 
         Returns
         -------
-        overridden: dict
+        overridden : dict
             The overridden representation of 'workflow'.
         """
         in_goverrides, in_soverrides = self._convert_override_dict_to_string_format(
-            workflow, input_arguments={"global": goverrides}.update(soverrides)
+            workflow,
+            input_arguments={"global": goverrides}.update(soverrides),
+            use_test_arguments=use_test_arguments,
         )
-        goverrides, soverrides = self._convert_override_dict_to_string_format(workflow)
+        goverrides, soverrides = self._convert_override_dict_to_string_format(
+            workflow,
+        )
 
         # Add CLI arguments at the end of the list, they will override if duplicates
         # occur
@@ -527,7 +554,7 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        expanded_workflow: WorkflowPlugin type
+        expanded_workflow : WorkflowPlugin type
             A dictionary representation of an expanded workflow plugin. Expanding means
             nested workflows and/or products have been fully generated and everything
             has been specified in a single workflow plugin.
@@ -538,7 +565,10 @@ class WorkflowsInterface(BaseYamlInterface):
                 "but the plugin is missing a top level 'test' section."
             )
 
-        expanded_workflow = self._override_workflow_dict_format(expanded_workflow)
+        expanded_workflow = self._override_workflow_dict_format(
+            expanded_workflow,
+            use_test_arguments=True,
+        )
 
         # Import buried in order to avoid circular import error
         from geoips.pydantic_models.v1.workflows import WorkflowPluginModel
@@ -567,9 +597,9 @@ class WorkflowsInterface(BaseYamlInterface):
 
         Parameters
         ----------
-        name: str
+        name : str
             The name of the workflow plugin.
-        rebuild_registries: bool (default=None)
+        rebuild_registries : bool (default=None)
             Whether or not to rebuild the registries if get_plugin fails. If set to
             None, default to what we have set in geoips.filenames.base_paths, which
             defaults to True. If specified, use the input value of rebuild_registries,
@@ -577,7 +607,7 @@ class WorkflowsInterface(BaseYamlInterface):
             get_plugin fails, rebuild the plugin registry, call then call
             get_plugin once more with rebuild_registries toggled off, so it only gets
             rebuilt once.
-        _expand: private bool (default=False)
+        _expand : private bool (default=False)
             If true, fully expand the workflow plugin in place. Otherwise, load as is
             done usually. This should only be used for the 'geoips expand <workflow>'
             command.

--- a/geoips/interfaces/yaml_based/workflows.py
+++ b/geoips/interfaces/yaml_based/workflows.py
@@ -3,13 +3,12 @@
 
 """Workflow interface module."""
 
-# cspell: ignore koverrides soverrides
+# cspell: ignore soverrides
 
 from collections.abc import Mapping
 from copy import deepcopy
 import logging
 
-from lexeme_type.lexeme import Lexeme
 import yaml
 
 from geoips.interfaces.base import BaseYamlInterface
@@ -56,48 +55,6 @@ class WorkflowsInterface(BaseYamlInterface):
 
         return {
             "argument": lhs,
-            # doing a yaml.safe_load attempts to cast the value into its correct type
-            "value": yaml.safe_load(rhs),
-        }
-
-    def kind_override_type(self, value: str):
-        """Ensure an override string fits the following format.
-
-        Expected Format
-        ---------------
-        '<kind>.<argument_name>=<some_value>'
-
-        Parameters
-        ----------
-        value: str
-            The full kind override string for a geoips run order_based command.
-
-        Returns
-        -------
-        override_dict: dict
-            The validated contents of an override string in a dictionary.
-        """
-        try:
-            lhs, rhs = value.split("=", 1)
-        except ValueError:
-            raise ValueError(
-                f"Invalid format '{value}'. Expected '<kind>.<argument_name>=<value>'"
-            )
-
-        parts = lhs.split(".")
-
-        if len(parts) != 2:
-            raise ValueError(
-                f"Invalid key '{lhs}'. Must be in the format of "
-                "'<kind>.<argument_name>'"
-            )
-
-        kind = parts[0]
-        argument = parts[1]
-
-        return {
-            "kind": kind,
-            "argument": argument,
             # doing a yaml.safe_load attempts to cast the value into its correct type
             "value": yaml.safe_load(rhs),
         }
@@ -164,6 +121,8 @@ class WorkflowsInterface(BaseYamlInterface):
         d: dict[dict]
             A nested dictionary.
         """
+        if d.get("spec") and d.get("spec").get("steps"):
+            keys = ["spec", "steps"] + keys
         current = d
         for key in [step_id] + keys:
             current = current.setdefault(key, {})
@@ -195,28 +154,6 @@ class WorkflowsInterface(BaseYamlInterface):
         )
         return steps
 
-    def _override_kind(self, steps, override):
-        """Override an argument of a given kind.
-
-        Parameters
-        ----------
-        steps: dict[dict]
-            An ordered dictionary of steps to apply in a given workflow.
-        override: Any
-            The value of the override.
-
-        Returns
-        -------
-        steps: dict[dict]
-            An overridden representation of 'steps'.
-        """
-        for id, step in steps.items():
-            if Lexeme(step["kind"]).singular == Lexeme(override["kind"]).singular:
-                if step.get("arguments"):
-                    steps[id]["arguments"][override["argument"]] = override["value"]
-
-        return steps
-
     def _override_global(self, steps, override):
         """Override an argument of a given global.
 
@@ -233,7 +170,11 @@ class WorkflowsInterface(BaseYamlInterface):
             An overridden representation of 'steps'.
         """
         for id, step in steps.items():
-            if step.get("arguments") and override["argument"] in step["arguments"]:
+            if step.get("kind") == "workflow" and step.get("spec", {}).get("steps"):
+                step["spec"]["steps"] = self._override_global(
+                    step["spec"]["steps"], override
+                )
+            else:
                 steps[id]["arguments"][override["argument"]] = override["value"]
         return steps
 
@@ -241,8 +182,8 @@ class WorkflowsInterface(BaseYamlInterface):
         self,
         workflow,
         goverrides=[],
-        koverrides=[],
         soverrides=[],
+        grab_bases=True,
     ):
         """Override a workflow plugin where applicable.
 
@@ -252,10 +193,11 @@ class WorkflowsInterface(BaseYamlInterface):
             A dictionary representation of a workflow plugin.
         goverrides: list[str], optional
             A list of string global overrides.
-        koverrides: list[str], optional
-            A list of string kind overrides.
         soverrides: list[str], optional
             A list of string step overrides.
+        grab_bases: bool, optional
+            Whether or not to use the override arguments specified in a workflow's
+            'arguments' section. Defaults to True.
 
         Returns
         -------
@@ -263,19 +205,29 @@ class WorkflowsInterface(BaseYamlInterface):
             The overridden representation of 'workflow'.
         """
         steps = workflow["spec"]["steps"]
+        if grab_bases:
+            base_goverrides, base_soverrides = (
+                self._convert_override_dict_to_string_format(workflow)
+            )
+            # Add CLI arguments at the end of the list, they will override if duplicates
+            # occur
+            goverrides = base_goverrides.extend(goverrides)
+            soverrides = base_soverrides.extend(soverrides)
 
-        wf_overrides = {"globals": goverrides, "kinds": koverrides, "steps": soverrides}
+        wf_overrides = {
+            "global": goverrides,
+            "step": soverrides,
+        }
 
         for override_type, overrides in wf_overrides.items():
-            type_singular = Lexeme(override_type).singular
             for override in overrides:
                 if isinstance(override, str):
-                    steps = getattr(self, f"_override_{type_singular}")(
+                    steps = getattr(self, f"_override_{override_type}")(
                         steps,
-                        getattr(self, f"{type_singular}_override_type")(override),
+                        getattr(self, f"{override_type}_override_type")(override),
                     )
                 else:
-                    steps = getattr(self, f"_override_{type_singular}")(steps, override)
+                    steps = getattr(self, f"_override_{override_type}")(steps, override)
 
         workflow["spec"]["steps"] = steps
 
@@ -451,7 +403,7 @@ class WorkflowsInterface(BaseYamlInterface):
 
         return steps
 
-    def _convert_override_dict_to_string_format(self, workflow):
+    def _convert_override_dict_to_string_format(self, workflow, input_arguments=None):
         """
         Convert a workflow's test section overrides to string-based overrides.
 
@@ -459,77 +411,42 @@ class WorkflowsInterface(BaseYamlInterface):
         ----------
         workflow: dict
             A dictionary representation of a workflow plugin.
+        input_arguments: dict, optional
+            A dictionary of input override arguments from the commandline. Defaults to
+            None.
 
         Returns
         -------
         goverrides: list[str]
             A list of global override strings.
-        koverrides: list[str]
-            A list of kind override strings.
         soverrides: list[str]
             A list of step override strings.
         """
-
-        def _iterate_over_nested(current):
-            """Iterate over the keys of a nested dictionary.
-
-            Expected format of the nested dictionary is a single key, value pair in
-            each nested dictionary.
-
-            Parameters
-            ----------
-            current: dict
-                The current instance of a dictionary in a nested dictionary.
-
-            Returns
-            -------
-            key: str
-                The key of the leaf nested dictionary. One the final iteration is hit,
-                balloon back up and return the name of the key in each parent
-                dictionary.
-            value: Any
-                The override value being applied.
-            """
-            key = list(current.keys())[0]
-            if not isinstance(current[key], Mapping):
-                return f"{key}={current[key]}"
-            else:
-                return f"{key}.{_iterate_over_nested(current[key])}"
-
-        override_types = ["globals", "kinds", "steps"]
         goverrides = []
-        koverrides = []
         soverrides = []
-        for override_type in override_types:
-            overrides = workflow.get("test", {}).get(override_type)
-            if overrides:
-                for override_key, override in overrides.items():
-                    if isinstance(override, Mapping) and not override.keys():
-                        continue
-                    elif isinstance(override, Mapping):
-                        str_override = (
-                            f"{override_key}.{_iterate_over_nested(override)}"
-                        )
-                    else:
-                        str_override = f"{override_key}={override}"
+        arguments = input_arguments if input_arguments else workflow.get("arguments")
 
-                    if override_type == "globals":
-                        goverrides.append(str_override)
-                    elif override_type == "kinds":
-                        koverrides.append(str_override)
-                    else:
-                        soverrides.append(str_override)
+        for override_key, overrides in arguments.items():
+            if override_key.startswith("global"):
+                override_type = "global"
+            else:
+                override_type = "step"
+            for argument, value in overrides.items():
+                if override_type == "global":
+                    str_override = f"{argument}={value}"
+                    goverrides.append(str_override)
+                else:
+                    str_override = f"{override_key}.{argument}={value}"
+                    soverrides.append(str_override)
 
-        return goverrides, koverrides, soverrides
+        return goverrides, soverrides
 
     def _override_workflow_dict_format(
         self,
         workflow,
-        goverrides=None,
-        koverrides=None,
-        soverrides=None,
-        oc_overrides=None,
-        use_test=False,
+        goverrides={},
+        soverrides={},
+        oc_overrides={},
     ):
         """Override a workflow plugin where applicable.
 
@@ -539,38 +456,30 @@ class WorkflowsInterface(BaseYamlInterface):
             A dictionary representation of a workflow plugin.
         goverrides: dict, optional
             A dictionary of global overrides.
-        koverrides: dict, optional
-            A dictionary of kind overrides.
         soverrides: dict, optional
             A dictionary for step overrides.
         oc_overrides: dict, optional
             A dictionary for output_checker overrides.
-        use_test: bool, optional
-            Whether or not to use the overrides specified in a workflow's 'test' section
-            or to use the overrides provided as arguments to this function.
 
         Returns
         -------
         overridden: dict
             The overridden representation of 'workflow'.
         """
-        if not use_test:
-            for override_type, overrides in {
-                "globals": goverrides,
-                "kinds": koverrides,
-                "steps": soverrides,
-            }.items():
-                if overrides:
-                    workflow["test"][override_type] = overrides
-                else:
-                    workflow["test"][override_type] = {}
-
-        goverrides, koverrides, soverrides = (
-            self._convert_override_dict_to_string_format(workflow)
+        in_goverrides, in_soverrides = self._convert_override_dict_to_string_format(
+            workflow, input_arguments={"global": goverrides}.update(soverrides)
         )
+        goverrides, soverrides = self._convert_override_dict_to_string_format(workflow)
+
+        # Add CLI arguments at the end of the list, they will override if duplicates
+        # occur
+        if in_goverrides and any(set(in_goverrides).difference(set(goverrides))):
+            goverrides.extend(in_goverrides)
+        if in_soverrides and any(set(in_soverrides).difference(set(soverrides))):
+            soverrides.extend(in_soverrides)
 
         workflow = self._override_workflow_string_format(
-            workflow, goverrides, koverrides, soverrides
+            workflow, goverrides, soverrides, grab_bases=False
         )
 
         steps = deepcopy(workflow["spec"]["steps"])
@@ -619,9 +528,7 @@ class WorkflowsInterface(BaseYamlInterface):
                 "but the plugin is missing a top level 'test' section."
             )
 
-        expanded_workflow = self._override_workflow_dict_format(
-            expanded_workflow, use_test=True
-        )
+        expanded_workflow = self._override_workflow_dict_format(expanded_workflow)
 
         # Import buried in order to avoid circular import error
         from geoips.pydantic_models.v1.workflows import WorkflowPluginModel

--- a/geoips/interfaces/yaml_based/workflows.py
+++ b/geoips/interfaces/yaml_based/workflows.py
@@ -431,12 +431,22 @@ class WorkflowsInterface(BaseYamlInterface):
                 override_type = "global"
             else:
                 override_type = "step"
-            for argument, value in overrides.items():
+            if isinstance(overrides, dict):
+                for argument, value in overrides.items():
+                    if override_type == "global":
+                        str_override = f"{argument}={value}"
+                        goverrides.append(str_override)
+                    else:
+                        str_override = f"{override_key}.{argument}={value}"
+                        soverrides.append(str_override)
+            else:
+                argument = override_key.split(".")[-1]
+                value = overrides
                 if override_type == "global":
                     str_override = f"{argument}={value}"
                     goverrides.append(str_override)
                 else:
-                    str_override = f"{override_key}.{argument}={value}"
+                    str_override = f"{override_key}={value}"
                     soverrides.append(str_override)
 
         return goverrides, soverrides

--- a/geoips/plugins/classes/algorithms/absdiff_mst.py
+++ b/geoips/plugins/classes/algorithms/absdiff_mst.py
@@ -50,7 +50,7 @@ class AbsdiffMstAlgorithmPlugin(BaseAlgorithmPlugin):
         """Apply data range and requested corrections to an absdiff product.
 
         Data manipulation steps for applying a data range and requested corrections
-        to a single channel productn absdiff product.
+        to a single channel product absdiff product.
 
         Parameters
         ----------

--- a/geoips/plugins/classes/algorithms/visir/nasa_dust_rgb.py
+++ b/geoips/plugins/classes/algorithms/visir/nasa_dust_rgb.py
@@ -7,6 +7,8 @@ Data manipulation steps for the "nasa_dust_rgb" product.
 This algorithm expects Brightness Temperatures in units of degrees Kelvin
 """
 
+import numpy as np
+
 from geoips.interfaces.class_based.algorithms import BaseAlgorithmPlugin
 
 import logging
@@ -93,7 +95,15 @@ class NasaDustRgbAlgorithmPlugin(BaseAlgorithmPlugin):
         )
 
         alp = alpha_from_masked_arrays([red, grn, blu])
-        rgba = rgba_from_arrays(red, grn, blu, alp)
+        try:
+            rgba = rgba_from_arrays(red, grn, blu, alp)
+        except AttributeError:
+            rgba = rgba_from_arrays(
+                np.ma.masked_array(red, fill_value=0),
+                np.ma.masked_array(grn, fill_value=0),
+                np.ma.masked_array(blu, fill_value=0),
+                alp,
+            )
         return rgba
 
 

--- a/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_annotated_enhanced.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_annotated_enhanced.yaml
@@ -22,17 +22,7 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Infrared.imagery_clean
       output_checker_name: image
-  # steps:
-  #   reader:
-  #     area_def: null
-  #   abi_Infrared:
-  #     spec:
-  #       steps:
-  #         algorithm:
-  #           output_units: Kelvin
-  # kinds:
-  #   readers:
-  #     satellite_zenith_angle_cutoff: 80
+arguments:
   globals:
     # will be uncommented after split operation is implemented
     # sector_list: test_goes16_eqc_3km_night_20200918T1950Z

--- a/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
@@ -21,12 +21,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV $GEOIPS_PACKAGES_DIR/geoips/tests/outputs/abi.static.<product>.imagery_clean
       output_checker_name: image
-spec:
-  globals:
+arguments:
+  global:
     product_name: Infrared
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_goes16_eqc_3km_day_20200918T1950Z"]
+spec:
   steps:
     sector:
       kind: sector
@@ -34,13 +35,15 @@ spec:
     reader:
       kind: reader
       name: abi_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
       depends_on: [sector]
     abi_Infrared:
       kind: product
       name: [abi, Infrared]
       depends_on: [reader, sector]
+      arguments:
+        coverage_checker.variable_name: Infrared
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -37,6 +37,7 @@ spec:
       name: abi_netcdf
       arguments:
         resampled_read: True
+        chans: [B14BT]
       depends_on: [sector]
     abi_Infrared:
       kind: product

--- a/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
@@ -19,7 +19,7 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV $GEOIPS_PACKAGES_DIR/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      compare_path: !ENV $GEOIPS_PACKAGES_DIR/geoips/tests/outputs/abi.static.Infrared.imagery_clean
       output_checker_name: image
 arguments:
   global:

--- a/geoips/plugins/yaml/workflows/tests/abi_static_infrared_netcdf_geoips.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_infrared_netcdf_geoips.yaml
@@ -21,14 +21,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.netcdf_geoips
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Infrared.netcdf_geoips
       output_checker_name: netcdf
-spec:
+arguments:
   globals:
     product_name: Infrared
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_goes16_eqc_10km_edge_night_20200918T1950Z"]
+spec:
   steps:
     sector:
       kind: sector
@@ -36,13 +37,16 @@ spec:
     reader:
       kind: reader
       name: abi_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
+        chans: [B14BT]
       depends_on: [sector]
     abi_Infrared:
       kind: product
       name: [abi, Infrared]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Infrared
     filename_formatter:
       kind: filename_formatter
       name: geoips_netcdf_fname

--- a/geoips/plugins/yaml/workflows/tests/abi_static_nasa_dust_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_nasa_dust_rgb_imagery_clean.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -20,14 +20,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.nasa_dust_rgb.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: nasa_dust_rgb
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_goes16_eqc_10km_edge_day_20200918T1950Z"]
+spec:
   steps:
     sector:
       kind: sector
@@ -35,13 +36,16 @@ spec:
     reader:
       kind: reader
       name: abi_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
+        chans: ["B11BT", "B13BT", "B14BT", "B15BT"]
       depends_on: [sector]
     abi_nasa_dust_rgb:
       kind: product
       name: [abi, nasa_dust_rgb]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: nasa_dust_rgb
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/abi_static_test_visible_logarithmic_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_test_visible_logarithmic_imagery_clean.yaml
@@ -21,14 +21,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Test-Visible-Logarithmic.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Test-Visible-Logarithmic
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_goes16_eqc_3km_terminator_20200918T1950Z"]
+spec:
   steps:
     sector:
       kind: sector
@@ -36,17 +37,20 @@ spec:
     reader:
       kind: reader
       name: abi_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
+        chans: ["B03Ref", "MED:solar_zenith_angle"]
       depends_on: [sector]
     abi_Test_Visible_Logarithmic:
       kind: product
       name: [abi, Test-Visible-Logarithmic]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Test-Visible-Logarithmic
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname
-      depends_on: 
+      depends_on:
         - abi_Test_Visible_Logarithmic.algorithm
         - abi_Test_Visible_Logarithmic.coverage_checker
         - sector

--- a/geoips/plugins/yaml/workflows/tests/abi_static_visible_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/abi_static_visible_imagery_clean.yaml
@@ -21,14 +21,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/abi.static.Visible.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Visible
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_goeseast_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -36,13 +37,16 @@ spec:
     reader:
       kind: reader
       name: abi_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
+        chans: ["B03Ref", "MED:solar_zenith_angle"]
       depends_on: [sector]
     abi_Visible:
       kind: product
       name: [abi, Visible]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Visible
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/ami_static_infrared_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/ami_static_infrared_imagery_clean.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -20,14 +20,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.Infrared.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Infrared
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["geokompsat"]
+spec:
   steps:
     sector:
       kind: sector
@@ -35,13 +36,16 @@ spec:
     reader:
       kind: reader
       name: ami_netcdf
-      arguments: 
+      arguments:
         resampled_read: True
+        chans: ["IR112BT"]
       depends_on: [sector]
     ami_Infrared:
       kind: product
       name: [ami, Infrared]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Infrared
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/ami_static_mst_absdiff_ir_bd_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/ami_static_mst_absdiff_ir_bd_imagery_clean.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -21,15 +21,16 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.mst.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.mst.absdiff-IR-BD.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: absdiff-IR-BD
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["geokompsat"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -38,13 +39,45 @@ spec:
       kind: reader
       name: ami_netcdf
       depends_on: []
-    ami_absdiff_IR_BD:
-      kind: product
-      name: [ami, absdiff-IR-BD]
-      depends_on: [sector, reader]
+    algorithm:
+      kind: algorithm
+      name: absdiff_mst
+      arguments:
+        variables: [IR112BT, IR112BT]
+        output_data_range: [0.0, 35.0]
+        input_units: Kelvin
+        output_units: celsius
+        min_outbounds: crop
+        max_outbounds: crop
+        norm: False
+        inverse: False
+    colormapper:
+      kind: colormapper
+      name: matplotlib_linear_norm
+      arguments:
+        cmap_name: turbo
+        cmap_source: matplotlib
+        data_range: [0.0, 35.0]
+        cbar_ticks: [0, 5, 10, 15, 20, 25, 30, 35]
+        cbar_label: 11µ BT (°C)
+    interpolator:
+      kind: interpolator
+      name: interp_nearest
+      depends_on: [sector, algorithm]
+    coverage_checker:
+      kind: coverage_checker
+      name: masked_arrays
+      arguments:
+        minimum_coverage: 10
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname
+      depends_on: [interpolator, sector, coverage_checker]
     output_formatter:
       kind: output_formatter
       name: imagery_clean
+      depends_on:
+        - sector
+        - colormapper
+        - algorithm
+        - filename_formatter

--- a/geoips/plugins/yaml/workflows/tests/ami_static_visible_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/ami_static_visible_imagery_clean.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -20,14 +20,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ami.static.Visible.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Visible
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["geokompsat"]
+spec:
   steps:
     sector:
       kind: sector
@@ -35,13 +36,16 @@ spec:
     reader:
       kind: reader
       name: ami_netcdf
-      arguments: 
-        resampled_read: True
       depends_on: [sector]
+      arguments:
+        resampled_read: True
+        chans: ["VI006Ref"]
     ami_Visible:
       kind: product
       name: [ami, Visible]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Visible
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/ewsg_static_infrared_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/ewsg_static_infrared_imagery_clean.yaml
@@ -21,14 +21,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ewsg.static.<product>.imagery_clean
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/ewsg.static.Infrared.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Infrared
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["ewsg"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: ewsg_netcdf
       depends_on: [sector]
+      arguments:
+        chans: ["gvar_ch4"]
     gvar_Infrared:
       kind: product
       name: [gvar, Infrared]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Infrared
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/fci_static_visible_imagery_annotated.yaml
+++ b/geoips/plugins/yaml/workflows/tests/fci_static_visible_imagery_annotated.yaml
@@ -2,7 +2,7 @@
 # # # https://github.com/NRLMMD-GEOIPS.
 
 # script migration = done
-# product testing = ongoing
+# product testing = done
 
 # Default values - if you do not have this exact test case available, call with available data files / sectors.
 # This exact test case required for valid comparisons - remove "compare_path" argument if running a different
@@ -21,14 +21,15 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/fci.static.<product>.imagery_annotated
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/fci.static.Visible.imagery_annotated
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Visible
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,15 @@ spec:
       kind: reader
       name: fci_netcdf
       depends_on: []
+      arguments:
+        chans: ["B03Ref", "MED:solar_zenith_angle", "MED:satellite_zenith_angle"]
     fci_Visible:
       kind: product
       name: [fci, Visible]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Visible
+        interpolator.varlist: [Visible]
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/gfs_static_waveheight_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/gfs_static_waveheight_imagery_clean.yaml
@@ -23,13 +23,14 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/gfs.static.waveheight.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Model-WaveHeight
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["conus"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -42,6 +43,8 @@ spec:
       kind: product
       name: [gfs, Model-WaveHeight]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: significant_height_of_combined_wind_waves_and_swell
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/gfs_static_windspeed_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/gfs_static_windspeed_imagery_clean.yaml
@@ -23,13 +23,14 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/gfs.static.windspeed.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Model-Windspeed
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["himawari"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -42,6 +43,8 @@ spec:
       kind: product
       name: [gfs, Model-Windspeed]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: windspeed_kts
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mimic_coarse_static_tpw_cimss_imagery_annotated.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mimic_coarse_static_tpw_cimss_imagery_annotated.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/mimic_coarse.static.TPW-CIMSS.imagery_annotated
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TPW-CIMSS
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -41,6 +42,8 @@ spec:
       kind: product
       name: [mimic, TPW-CIMSS]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: tpw
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mwr_tb165_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mwr_tb165_imagery_clean.yaml
@@ -22,12 +22,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/aws.orbital.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TB165
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -40,6 +41,8 @@ spec:
       kind: product
       name: [mwr, TB165]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: TB165
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mwr_tb180_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mwr_tb180_imagery_clean.yaml
@@ -22,12 +22,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/aws.orbital.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TB180
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -40,6 +41,8 @@ spec:
       kind: product
       name: [mwr, TB180]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: TB180
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mwr_tb325_15_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mwr_tb325_15_imagery_clean.yaml
@@ -22,12 +22,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/aws.orbital.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TB325_1
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -40,6 +41,8 @@ spec:
       kind: product
       name: [mwr, TB325-1]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: TB325_1
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mwr_tb50_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mwr_tb50_imagery_clean.yaml
@@ -22,12 +22,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/aws.orbital.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TB50
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -39,6 +40,8 @@ spec:
       kind: product
       name: [mwr, TB50]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: TB50
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/mwr_tb89_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/mwr_tb89_imagery_clean.yaml
@@ -22,12 +22,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/aws.orbital.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: TB89
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
+spec:
   steps:
     sector:
       kind: sector
@@ -40,6 +41,8 @@ spec:
       kind: product
       name: [mwr, TB89]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: TB89
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_airmass_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_airmass_imagery_clean.yaml
@@ -17,12 +17,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.airmass.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: airmass
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -31,10 +32,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B05BT", "B06BT", "B08BT", "B09BT"]
     seviri_airmass:
       kind: product
       name: [seviri, airmass]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: airmass
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname
@@ -42,7 +47,7 @@ spec:
     output_formatter:
       kind: output_formatter
       name: imagery_clean
-      depends_on: 
+      depends_on:
         - seviri_airmass.algorithm
         - seviri_airmass.colormapper
         - filename_formatter

--- a/geoips/plugins/yaml/workflows/tests/seviri_convective_storms_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_convective_storms_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Convective_Storms.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Convective_Storms
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B04BT", "B05BT", "B06BT", "B09BT", "B01Ref", "B03Ref"]
     seviri_Convective_Storms:
       kind: product
       name: [seviri, Convective_Storms]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Convective_Storms
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_day_microphys_summer_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_day_microphys_summer_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Day_Microphys_Summer.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Day_Microphys_Summer
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B02Ref", "B04BT", "B09BT"]
     seviri_Day_Microphys_Summer:
       kind: product
       name: [seviri, Day_Microphys_Summer]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Day_Microphys_Summer
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_day_microphys_winter_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_day_microphys_winter_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Day_Microphys_Winter.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Day_Microphys_Winter
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B02Ref", "B04BT", "B09BT"]
     seviri_Day_Microphys_Winter:
       kind: product
       name: [seviri, Day_Microphys_Winter]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Day_Microphys_Winter
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_day_solar_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_day_solar_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Day_Solar.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Day_Solar
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B02Ref", "B03Ref", "B04BT"]
     seviri_Day_Solar:
       kind: product
       name: [seviri, Day_Solar]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Day_Solar
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
@@ -21,12 +21,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Dust_RGB.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Dust_RGB
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -36,10 +37,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B07BT", "B09BT", "B10BT"]
     seviri_Dust_RGB:
       kind: product
       name: [seviri, Dust_RGB]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Dust_RGB
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_natural_color_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_natural_color_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Natural_Color.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Natural_Color
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B01Ref", "B02Ref", "B03Ref"]
     seviri_Natural_Color:
       kind: product
       name: [seviri, Natural_Color]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Natural_Color
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_night_microphys_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_night_microphys_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Night_Microphys.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Night_Microphys
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B04BT", "B09BT", "B10BT"]
     seviri_Night_Microphys:
       kind: product
       name: [seviri, Night_Microphys]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Night_Microphys
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_volcanic_ash_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_volcanic_ash_imagery_clean.yaml
@@ -23,12 +23,13 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.Volcanic_Ash.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Volcanic_Ash
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["test_meteoeu_eqc_3km_landocean"]
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: seviri_hrit
       depends_on: [sector]
+      arguments:
+        chans: ["B07BT", "B09BT", "B10BT"]
     seviri_Volcanic_Ash:
       kind: product
       name: [seviri, Volcanic_Ash]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Volcanic_Ash
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_wv_upper_no_self_register_unprojected_image.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_wv_upper_no_self_register_unprojected_image.yaml
@@ -24,18 +24,23 @@ test:
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.WV-Upper.no_self_register.unprojected_image
       # verify this
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: WV-Upper-No-SR
     reader_defined_area_def: False
+spec:
   steps:
     reader:
       kind: reader
       name: seviri_hrit
+      arguments:
+        chans: ["B05BT"]
     seviri_WV_Upper_No_SR:
       kind: product
       name: [seviri, WV-Upper-No-SR]
       depends_on: [reader]
+      arguments:
+        coverage_checker.variable_name: WV-Upper-No-SR
     filename_formatter:
       kind: filename_formatter
       name: basic_fname

--- a/geoips/plugins/yaml/workflows/tests/seviri_wv_upper_unprojected_image.yaml
+++ b/geoips/plugins/yaml/workflows/tests/seviri_wv_upper_unprojected_image.yaml
@@ -23,10 +23,11 @@ test:
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/seviri.WV-Upper.unprojected_image
       # verify this
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: WV-Upper
     reader_defined_area_def: False
+spec:
   steps:
     reader:
       kind: reader
@@ -34,10 +35,13 @@ spec:
       arguments:
         self_register_dataset: FULL_DISK
         self_register_source: seviri
+        chans: ["B05BT"]
     seviri_WV_Upper:
       kind: product
       name: [seviri, WV-Upper]
       depends_on: [reader]
+      arguments:
+        coverage_checker.variable_name: WV-Upper
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/sgli_static_ir_rgb_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/sgli_static_ir_rgb_imagery_clean.yaml
@@ -21,13 +21,14 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/sgli.static.<product>.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: IR-RGB
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["korea"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -36,10 +37,14 @@ spec:
       kind: reader
       name: sgli_l1b_hdf5
       depends_on: [sector]
+      arguments:
+        chans: ["SW03Ref","VN11Ref","VN08Ref","solar_zenith_angle"]
     sgli_IR_RGB:
       kind: product
       name: [sgli, IR-RGB]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: IR-RGB
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/smap_awips_netcdf.yaml
+++ b/geoips/plugins/yaml/workflows/tests/smap_awips_netcdf.yaml
@@ -16,10 +16,11 @@ docstring: SMAP unsectored wind speed data.
 package: geoips
 test:
   fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_awips_windspeed/RSS_smap_wind_daily_2024_02_20_NRT_v01.0.nc
-spec:
+arguments:
   globals:
     product_name: unsectored
     reader_defined_area_def: False
+spec:
   steps:
     reader:
       kind: reader

--- a/geoips/plugins/yaml/workflows/tests/smap_unsectored_text_winds.yaml
+++ b/geoips/plugins/yaml/workflows/tests/smap_unsectored_text_winds.yaml
@@ -22,10 +22,11 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/smap.unsectored.text_winds
       output_checker_name: text
-spec:
+arguments:
   globals:
     product_name: unsectored
     reader_defined_area_def: False
+spec:
   steps:
     reader:
       kind: reader

--- a/geoips/plugins/yaml/workflows/tests/viirs_static_visible_imagery_clean.yaml
+++ b/geoips/plugins/yaml/workflows/tests/viirs_static_visible_imagery_clean.yaml
@@ -22,13 +22,14 @@ test:
       full_test_policy: on_token_mismatch # always | never
       compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/viirs.static.visible.imagery_clean
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Visible
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["se_asia"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -37,10 +38,14 @@ spec:
       kind: reader
       name: viirs_sdr_hdf5
       depends_on: [sector]
+      arguments:
+        chans: ["M05Ref"]
     viirs_Visible:
       kind: product
       name: [viirs, Visible]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Visible
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_imagery_annotated.yaml
+++ b/geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_imagery_annotated.yaml
@@ -17,13 +17,14 @@ docstring: |
 package: geoips
 test:
   fnames: !ENV ${GEOIPS_TESTDATA_DIR}/test_data_viirs/data/npp/20240117/172400/VNP02DNB.A2024017.1724.002.2024018012054.nc
-spec:
+arguments:
   globals:
     product_name: Night-Vis-IR-GeoIPS1
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["north_pole"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -31,14 +32,17 @@ spec:
     reader:
       kind: reader
       name: viirs_netcdf
-      arguments: 
+      depends_on: [sector]
+      arguments:
         self_register_dataset: DNB
         self_register_source: viirs
-      depends_on: [sector]
+        chans: ["DNBRad", "DNB:solar_zenith_angle"]
     viirs_Night_Vis_IR_GeoIPS1:
       kind: product
       name: [viirs, Night-Vis-IR-GeoIPS1]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Night-Vis-IR-GeoIPS1
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_unprojected_image.yaml
+++ b/geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_unprojected_image.yaml
@@ -20,22 +20,26 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/viirsclearnight.<product>.unprojected_image
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/viirsclearnight.Night-Vis-IR-GeoIPS1.unprojected_image
       output_checker_name: image
-spec:
+arguments:
   globals:
     product_name: Night-Vis-IR-GeoIPS1
     reader_defined_area_def: False
+spec:
   steps:
     reader:
       kind: reader
       name: viirs_netcdf
-      arguments: 
+      arguments:
         self_register_dataset: DNB
         self_register_source: viirs
+        chans: ["DNBRad", "M16BT", "DNB:solar_zenith_angle"]
     viirs_Night_Vis_IR_GeoIPS1:
       kind: product
       name: [viirs, Night-Vis-IR-GeoIPS1]
+      arguments:
+        coverage_checker.variable_name: Night-Vis-IR-GeoIPS1
     filename_formatter:
       kind: filename_formatter
       name: geoips_fname

--- a/geoips/plugins/yaml/workflows/tests/viirsday_global_night_vis_ir_cogeotiff_rgba.yaml
+++ b/geoips/plugins/yaml/workflows/tests/viirsday_global_night_vis_ir_cogeotiff_rgba.yaml
@@ -19,15 +19,16 @@ test:
   outputs:
     output_formatter:
       full_test_policy: on_token_mismatch # always | never
-      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/viirsday.global.<product>.cogeotiff_rgba
+      compare_path: !ENV ${GEOIPS_PACKAGES_DIR}/geoips/tests/outputs/viirsday.global.Night-Vis-IR.cogeotiff_rgba
       output_checker_name: geotiff
-spec:
+arguments:
   globals:
     product_name: Night-Vis-IR
     reader_defined_area_def: False
     # will be uncommented after split operation is implemented
     # sector_list: ["global_cylindrical"]
-    minimum_coverage: 0 
+    minimum_coverage: 0
+spec:
   steps:
     sector:
       kind: sector
@@ -36,10 +37,14 @@ spec:
       kind: reader
       name: viirs_netcdf
       depends_on: [sector]
+      arguments:
+        chans: ["DNBRad", "M16BT"]
     viirs_Night_Vis_IR:
       kind: product
       name: [viirs, Night-Vis-IR]
       depends_on: [sector, reader]
+      arguments:
+        coverage_checker.variable_name: Night-Vis-IR
     filename_formatter:
       kind: filename_formatter
       name: geotiff_fname

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -1227,30 +1227,6 @@ class OutputCheckerOverrideModel(PermissiveFrozenModel):
     )
 
 
-class NestedSpecOverride(PermissiveFrozenModel):
-    """Spec definition allowing for recursive overrides."""
-
-    steps: Dict[str, StepOverrideType] = Field(default_factory=dict)
-
-
-class StepOverrideType(PermissiveFrozenModel):
-    """
-    A workflow step override.
-
-    Either:
-    - arbitrary arguments
-    OR
-    - a nested spec containing additional steps
-    """
-
-    spec: Optional[NestedSpecOverride] = None
-
-
-# Required for recursive references
-NestedSpecOverride.model_rebuild()
-StepOverrideType.model_rebuild()
-
-
 class WorkflowTestModel(FrozenModel):
     """Model for the test section of GeoIPS workflow plugins."""
 
@@ -1259,38 +1235,6 @@ class WorkflowTestModel(FrozenModel):
         ...,
         description="A list of one or more filepaths to the data used for this test.",
         validation_alias=AliasChoices("fnames", "filenames"),
-    )
-    #
-    # globals:
-    #   argument: value
-    #
-    globals: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Override dictionary for global arguments.",
-    )
-
-    #
-    # kinds:
-    #     readers:
-    #         argument: value
-    #
-    # Keys must match interfaces.__all__
-    #
-    kinds: Dict[str, Dict[str, Any]] = Field(
-        default_factory=dict,
-        description="Override dictionary for plugins matching a certain 'kind'.",
-    )
-
-    #
-    # steps:
-    #     step_id:
-    #         argument: value
-    #
-    # or recursive nested specs
-    #
-    steps: Dict[str, StepOverrideType] = Field(
-        default_factory=dict,
-        description="Override dictionary for individual steps.",
     )
 
     #
@@ -1310,20 +1254,6 @@ class WorkflowTestModel(FrozenModel):
             " an output checker."
         ),
     )
-
-    @model_validator(mode="after")
-    def validate_kind_keys(self) -> WorkflowTestModel:
-        """Ensure kinds keys are valid GeoIPS interfaces."""
-        # Make sure any element of kinds are a valid interface
-        invalid = set(self.kinds) - set(interfaces.__all__)
-
-        if invalid:
-            raise ValueError(
-                f"Invalid kinds keys: {sorted(invalid)}. "
-                f"Valid interfaces are: {sorted(interfaces.__all__)}"
-            )
-
-        return self
 
     @field_validator("filenames", mode="before")
     @classmethod
@@ -1355,6 +1285,7 @@ class WorkflowPluginModel(PluginModel):
     """A plugin that produces a workflow."""
 
     model_config = ConfigDict(extra="allow")
+
     test: WorkflowTestModel = Field(
         None,
         description=(
@@ -1370,6 +1301,11 @@ class WorkflowPluginModel(PluginModel):
             },
         ],
     )
+
+    arguments: Optional[Dict[str, Any]] | None = Field(
+        None, description="Argument overrides to apply to your workflow."
+    )
+
     spec: WorkflowSpecModel = Field(..., description="The workflow specification")
 
     @model_validator(mode="before")

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -916,7 +916,10 @@ class WorkflowSpecModel(FrozenModel):
                 # I.e. arguments:
                 #        step_id.argument_name: value
                 step_id, argument_name = key.split(".")
-                steps[step_id]["arguments"][argument_name] = value
+                if argument_name == "depends_on":
+                    steps[step_id]["depends_on"] = value
+                else:
+                    steps[step_id]["arguments"][argument_name] = value
 
         if _inputs and kind == "workflow":
             for step_id, step in steps.items():

--- a/geoips/pydantic_models/v1/workflows.py
+++ b/geoips/pydantic_models/v1/workflows.py
@@ -1240,6 +1240,14 @@ class WorkflowTestModel(FrozenModel):
         validation_alias=AliasChoices("fnames", "filenames"),
     )
 
+    # arguments:
+    #     globals:
+    #         minimum_coverage: <float>
+    #         product_name: <some_value>
+    arguments: Optional[Dict[str, Any]] | None = Field(
+        None, description="Argument overrides to apply to your workflow."
+    )
+
     #
     # outputs:
     #     step_id:

--- a/tests/unit_tests/plugins/yaml/workflows/test_workflow_overrides.py
+++ b/tests/unit_tests/plugins/yaml/workflows/test_workflow_overrides.py
@@ -1,6 +1,6 @@
 """Unit test module for testing workflow overrides."""
 
-# cspell: ignore koverrides, soverrides
+# cspell: ignore soverrides
 
 from collections import OrderedDict
 from copy import deepcopy
@@ -52,20 +52,12 @@ def sample_workflow():
                 },
             }
         },
-        "test": {
-            "globals": {
+        "arguments": {
+            "global": {
                 "logging_level": "INFO",
+                "satellite_zenith_angle_cutoff": 90,
             },
-            "kinds": {
-                "algorithms": {
-                    "output_units": "kelvin",
-                }
-            },
-            "steps": {
-                "reader": {
-                    "self_register": "LOW",
-                }
-            },
+            "reader.self_register": "LOW",
         },
     }
 
@@ -102,42 +94,17 @@ def test_global_override_type_yaml_casting():
     }
 
 
-def test_kind_override_type():
-    """Test parsing a valid kind override string.
-
-    Ensures the kind name, argument name, and value are extracted
-    correctly from a valid override specification.
-    """
-    result = workflows.kind_override_type("algorithm.output_units=kelvin")
-
-    assert result == {
-        "kind": "algorithm",
-        "argument": "output_units",
-        "value": "kelvin",
-    }
-
-
-def test_kind_override_type_invalid_key_format():
-    """Test failure when a kind override key is improperly formatted.
-
-    A valid kind override must contain exactly one period separating
-    the kind name and argument name.
-    """
-    with pytest.raises(ValueError, match="Must be in the format"):
-        workflows.kind_override_type("algorithm.output.units=kelvin")
-
-
 def test_step_override_type():
     """Test parsing a step override containing nested keys.
 
     Verifies that the step identifier, intermediate keys, argument,
     and value are extracted correctly from a nested override path.
     """
-    result = workflows.step_override_type("reader.spec.arguments.self_register=LOW")
+    result = workflows.step_override_type("reader.self_register=LOW")
 
     assert result == {
         "step_id": "reader",
-        "keys": ["spec", "arguments"],
+        "keys": [],
         "argument": "self_register",
         "value": "LOW",
     }
@@ -219,27 +186,6 @@ def test_override_step(sample_workflow):
     assert result["reader"]["arguments"]["self_register"] == "LOW"
 
 
-def test_override_kind(sample_workflow):
-    """Test overriding all steps of a given kind.
-
-    Parameters
-    ----------
-    sample_workflow: pytest.fixture[dict]
-        A dummy workflow to perform unit tests on.
-    """
-    override = {
-        "kind": "algorithm",
-        "argument": "output_units",
-        "value": "kelvin",
-    }
-
-    steps = deepcopy(sample_workflow["spec"]["steps"])
-
-    result = workflows._override_kind(steps, override)
-
-    assert result["algorithm"]["arguments"]["output_units"] == "kelvin"
-
-
 def test_override_global(sample_workflow):
     """Test overriding all matching global arguments.
 
@@ -277,28 +223,26 @@ def test_override_workflow_string_format_from_dict(sample_workflow):
         }
     ]
 
-    koverrides = [
-        {
-            "kind": "algorithms",
-            "argument": "output_units",
-            "value": "kelvin",
-        }
-    ]
-
     soverrides = [
         {
             "step_id": "reader",
             "keys": [],
             "argument": "self_register",
             "value": "LOW",
-        }
+        },
+        {
+            "step_id": "algorithm",
+            "keys": [],
+            "argument": "output_units",
+            "value": "kelvin",
+        },
     ]
 
     result = workflows._override_workflow_string_format(
         workflow,
         goverrides=goverrides,
-        koverrides=koverrides,
         soverrides=soverrides,
+        grab_bases=False,
     )
 
     steps = result["spec"]["steps"]
@@ -320,22 +264,19 @@ def test_override_workflow_string_format_from_string(sample_workflow):
 
     goverrides = ["satellite_zenith_angle_cutoff=85"]
 
-    koverrides = ["algorithms.output_units=kelvin"]
-
     soverrides = ["reader.self_register=LOW"]
 
     result = workflows._override_workflow_string_format(
         workflow,
         goverrides=goverrides,
-        koverrides=koverrides,
         soverrides=soverrides,
+        grab_bases=False,
     )
 
     steps = result["spec"]["steps"]
 
     assert steps["reader"]["arguments"]["self_register"] == "LOW"
     assert steps["reader"]["arguments"]["satellite_zenith_angle_cutoff"] == 85
-    assert steps["algorithm"]["arguments"]["output_units"] == "kelvin"
 
 
 ##########################################
@@ -359,12 +300,6 @@ def test_override_workflow_dict_format(sample_workflow):
         "satellite_zenith_angle_cutoff": 90,
     }
 
-    koverrides = {
-        "algorithms": {
-            "output_units": "kelvin",
-        }
-    }
-
     soverrides = {
         "reader": {
             "self_register": "LOW",
@@ -374,15 +309,12 @@ def test_override_workflow_dict_format(sample_workflow):
     result = workflows._override_workflow_dict_format(
         workflow,
         goverrides=goverrides,
-        koverrides=koverrides,
         soverrides=soverrides,
     )
 
     steps = result["spec"]["steps"]
 
     assert steps["reader"]["arguments"]["satellite_zenith_angle_cutoff"] == 90
-
-    assert steps["algorithm"]["arguments"]["output_units"] == "kelvin"
 
     assert steps["reader"]["arguments"]["self_register"] == "LOW"
 
@@ -575,16 +507,13 @@ def test_convert_override_dict_to_string_format(sample_workflow):
     Ensures that global, kind, and step overrides are converted into
     the string representation accepted by the CLI.
     """
-    goverrides, koverrides, soverrides = (
-        workflows._convert_override_dict_to_string_format(sample_workflow)
+    goverrides, soverrides = workflows._convert_override_dict_to_string_format(
+        sample_workflow
     )
 
     assert goverrides == [
         "logging_level=INFO",
-    ]
-
-    assert koverrides == [
-        "algorithms.output_units=kelvin",
+        "satellite_zenith_angle_cutoff=90",
     ]
 
     assert soverrides == [
@@ -599,44 +528,11 @@ def test_convert_override_dict_to_string_format_nested():
     into the expected dot-delimited string representation.
     """
     workflow = {
-        "test": {
-            "steps": {
-                "abi:Infrared": {
-                    "spec": {
-                        "steps": {
-                            "algorithm": {
-                                "output_units": "kelvin",
-                            },
-                        }
-                    }
-                }
-            }
-        }
+        "arguments": {
+            "abi:Infrared.algorithm.output_units": "kelvin",
+        },
     }
 
-    _, _, soverrides = workflows._convert_override_dict_to_string_format(workflow)
+    goverrides, soverrides = workflows._convert_override_dict_to_string_format(workflow)
 
-    assert soverrides == ["abi:Infrared.spec.steps.algorithm.output_units=kelvin"]
-
-
-def test_convert_override_dict_to_string_format_empty_mapping():
-    """Test that empty override mappings are ignored.
-
-    Verifies that empty dictionaries within the workflow test section
-    do not generate override strings.
-    """
-    workflow = {
-        "test": {
-            "globals": {
-                "logging_level": {},
-            }
-        }
-    }
-
-    goverrides, koverrides, soverrides = (
-        workflows._convert_override_dict_to_string_format(workflow)
-    )
-
-    assert goverrides == []
-    assert koverrides == []
-    assert soverrides == []
+    assert soverrides == ["abi:Infrared.algorithm.output_units=kelvin"]


### PR DESCRIPTION
## ✨ Summary

Refactors how argument overrides are applied in GeoIPS workflow plugins. A new
'arguments' field has been added as a new optional field to the top-level of a
workflow plugin as well as an optional field to its 'test' section. It follows the
same format regardless of which section it's specified in. It looks like the
following:

```yaml
arguments:
  global:
    <global_argument>: <value>
  <step_id>.<argument>: <value>
  <step_id>.<nested_step_id>...<argument>: <value
  <global>.<argument>: <value
```

Again, these are optional fields and will only be applied if specified. The logic
of how these overrides are applied follow these rules:

- ``geoips run order_based`` (in order of precedence)
  1. CLI string overrides (``-g`` and ``-s``)
  2. CLI dict overrides (``-G`` and ``-S``)
  3. Base overrides (e.g. ``arguments`` top level field)
- ``geoips test workflow`` (in order of precedence)
  1. ``test['arguments']`` field
  2. ``arguments`` top-level field

The argument logic can be applied in a step's arguments as well. For example, if a
nested workflow were to occur as a step, you could do:

``<inner_step_id>.<argument>: <value>``

additionally, you can override the ``depends_on`` field of a nested step. Such as:

``<inner_step_id>.depends_on: [<inner_step_idX>, ...]``

Finally, modified a large majority of the workflows found in
``geoips/plugins/yaml/workflows/tests/`` to adhere to this new logic. All of the
workflows modified in this PR seem to be working now.

```
  files:
    modified:
      - docs/dev/running_order_based_procflow.rst
      - geoips/commandline/geoips_run.py
      - geoips/interfaces/class_based_plugin.py
      - geoips/interfaces/yaml_based/workflows.py
      - geoips/plugins/classes/algorithms/absdiff_mst.py
      - geoips/plugins/classes/algorithms/visir/nasa_dust_rgb.py
      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_annotated_enhanced.yaml
      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/abi_static_infrared_netcdf_geoips.yaml
      - geoips/plugins/yaml/workflows/tests/abi_static_nasa_dust_rgb_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/abi_static_test_visible_logarithmic_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/abi_static_visible_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/ami_static_infrared_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/ami_static_mst_absdiff_ir_bd_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/ami_static_visible_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/ewsg_static_infrared_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/fci_static_visible_imagery_annotated.yaml
      - geoips/plugins/yaml/workflows/tests/gfs_static_waveheight_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/gfs_static_windspeed_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/mimic_coarse_static_tpw_cimss_imagery_annotated.yaml
      - geoips/plugins/yaml/workflows/tests/mwr_tb165_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/mwr_tb180_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/mwr_tb325_15_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/mwr_tb50_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/mwr_tb89_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_airmass_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_convective_storms_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_day_microphys_summer_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_day_microphys_winter_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_day_solar_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_dust_rgb_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_natural_color_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_night_microphys_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_volcanic_ash_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_wv_upper_no_self_register_unprojected_image.yaml
      - geoips/plugins/yaml/workflows/tests/seviri_wv_upper_unprojected_image.yaml
      - geoips/plugins/yaml/workflows/tests/sgli_static_ir_rgb_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/smap_awips_netcdf.yaml
      - geoips/plugins/yaml/workflows/tests/smap_unsectored_text_winds.yaml
      - geoips/plugins/yaml/workflows/tests/viirs_static_visible_imagery_clean.yaml
      - geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_imagery_annotated.yaml
      - geoips/plugins/yaml/workflows/tests/viirsclearnight_night_vis_ir_geoips1_unprojected_image.yaml
      - geoips/plugins/yaml/workflows/tests/viirsday_global_night_vis_ir_cogeotiff_rgba.yaml
      - geoips/pydantic_models/v1/workflows.py
      - tests/unit_tests/plugins/yaml/workflows/test_workflow_overrides.py
```
---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [ ] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [ ] **Full test**: Yes, full test *is passing*.
- [ ] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [ ] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

---
## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

## 🧪 Testing Instructions

Let us know how to test/verify your changes if you need anything *beyond* running the integration and unit tests.

Keep it simple and clear—like an empty sky! ☀️
